### PR TITLE
Client side CAPI Stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expose-loader": "^0.7.0",
     "extract-text-webpack-plugin": "^0.9.1",
     "history": "^1.13.0",
+    "moment": "^2.10.6",
     "node-sass": "^3.3.3",
     "react": "^0.14.1",
     "react-addons-css-transition-group": "^0.14.2",

--- a/public/components/CapiStats/CapiStats.react.js
+++ b/public/components/CapiStats/CapiStats.react.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import moment from 'moment';
+import capiApi from '../../util/capi.js';
+
+export default class SaveButton extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+          dayUses: undefined,
+          prevDayUses: undefined,
+          weekUses: undefined,
+          prevWeekUses: undefined,
+          totalUses: undefined
+        };
+
+        this.fetchUseStats = this.fetchUseStats.bind(this);
+    }
+
+    componentDidMount() {
+      this.fetchUseStats();
+    }
+
+    fetchUseStats() {
+
+      const CAPI_DATE_FORMAT = 'YYYY-MM-DDTHH:MM:SS';
+      const today = moment().subtract(1, 'days').format(CAPI_DATE_FORMAT);
+      const yesterday = moment().subtract(2, 'days').format(CAPI_DATE_FORMAT);
+      const thisweek = moment().subtract(7, 'days').format(CAPI_DATE_FORMAT);
+      const lastweek = moment().subtract(14, 'days').format(CAPI_DATE_FORMAT);
+
+      capiApi.getByTag(this.props.tag, today)
+        .then(res => {
+          this.setState({
+            dayUses: res.response.total
+          });
+        });
+
+      capiApi.getByTag(this.props.tag, thisweek)
+        .then(res => {
+          this.setState({
+            weekUses: res.response.total
+          });
+        });
+      capiApi.getByTag(this.props.tag, yesterday, today)
+        .then(res => {
+          this.setState({
+            prevDayUses: res.response.total
+          });
+        });
+
+      capiApi.getByTag(this.props.tag, lastweek, thisweek)
+        .then(res => {
+          this.setState({
+            prevWeekUses: res.response.total
+          });
+        });
+
+      capiApi.getByTag(this.props.tag)
+        .then(res => {
+          this.setState({
+            totalUses: res.response.total
+          });
+        });
+    }
+
+    render () {
+      return (
+        <div className="capi-stats">
+          <div className="capi-stats__header">CAPI Stats</div>
+          <div className="capi-stats__stat">
+            <div className="capi-stats__stat__header">Today</div>
+            <div className="capi-stats__stat__value">{this.state.dayUses !== undefined ? this.state.dayUses : '...'}</div>
+            <div className="capi-stats__stat__prev">(Yesterday {this.state.prevDayUses !== undefined ? this.state.prevDayUses : '...'}) </div>
+          </div>
+          <div className="capi-stats__stat">
+            <div className="capi-stats__stat__header">This week</div>
+            <div className="capi-stats__stat__value">{this.state.weekUses !== undefined ? this.state.weekUses : '...'}</div>
+            <div className="capi-stats__stat__prev">(Last week {this.state.prevWeekUses !== undefined ? this.state.prevWeekUses : '...'}) </div>
+          </div>
+          <div className="capi-stats__stat">
+            <div className="capi-stats__stat__header">Total</div>
+            <div className="capi-stats__stat__value">{this.state.totalUses !== undefined ? this.state.totalUses : '...'}</div>
+          </div>
+        </div>
+      );
+    }
+}

--- a/public/components/CapiStats/CapiStats.react.js
+++ b/public/components/CapiStats/CapiStats.react.js
@@ -24,7 +24,7 @@ export default class SaveButton extends React.Component {
 
     fetchUseStats() {
 
-      const CAPI_DATE_FORMAT = 'YYYY-MM-DDTHH:MM:SS';
+      const CAPI_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
       const today = moment().subtract(1, 'days').format(CAPI_DATE_FORMAT);
       const yesterday = moment().subtract(2, 'days').format(CAPI_DATE_FORMAT);
       const thisweek = moment().subtract(7, 'days').format(CAPI_DATE_FORMAT);
@@ -66,21 +66,41 @@ export default class SaveButton extends React.Component {
     }
 
     render () {
+
+      var dayclass = 'capi-stats__stat__arrow';
+      if (this.state.dayUses > this.state.prevDayUses) {
+        dayclass += '--increase';
+      } else if (this.state.dayUses < this.state.prevDayUses) {
+        dayclass += '--decrease';
+      }
+
+      var weekclass = 'capi-stats__stat__arrow';
+      if (this.state.weekUses > this.state.prevWeekUses) {
+        weekclass += '--increase';
+      } else if (this.state.weekUses < this.state.prevWeekUses) {
+        weekclass += '--decrease';
+      }
+
       return (
         <div className="capi-stats">
           <div className="capi-stats__header">CAPI Stats</div>
           <div className="capi-stats__stat">
-            <div className="capi-stats__stat__header">Today</div>
-            <div className="capi-stats__stat__value">{this.state.dayUses !== undefined ? this.state.dayUses : '...'}</div>
-            <div className="capi-stats__stat__prev">(Yesterday {this.state.prevDayUses !== undefined ? this.state.prevDayUses : '...'}) </div>
+            <div className="capi-stats__stat__header">Last 24 Hours</div>
+            <div className="capi-stats__stat__value">
+              {this.state.dayUses !== undefined ? this.state.dayUses : '...'}
+              <span className={dayclass} title={'Previous 24hrs: ' + this.state.prevDayUses}></span>
+            </div>
           </div>
           <div className="capi-stats__stat">
             <div className="capi-stats__stat__header">This week</div>
-            <div className="capi-stats__stat__value">{this.state.weekUses !== undefined ? this.state.weekUses : '...'}</div>
-            <div className="capi-stats__stat__prev">(Last week {this.state.prevWeekUses !== undefined ? this.state.prevWeekUses : '...'}) </div>
+            <div className="capi-stats__stat__value">
+              {this.state.weekUses !== undefined ? this.state.weekUses : '...'}
+              <span className={weekclass} title={'Previous Week: ' + this.state.prevWeekUses}></span>
+
+            </div>
           </div>
           <div className="capi-stats__stat">
-            <div className="capi-stats__stat__header">Total</div>
+            <div className="capi-stats__stat__header">Total uses</div>
             <div className="capi-stats__stat__value">{this.state.totalUses !== undefined ? this.state.totalUses : '...'}</div>
           </div>
         </div>

--- a/public/components/Tag/Display.react.js
+++ b/public/components/Tag/Display.react.js
@@ -4,6 +4,7 @@ import TypeSelect from '../utils/TypeSelect.react';
 import SaveButton from '../utils/SaveButton.react';
 import TagValidationErrors from './TagValidation.react';
 import {validateTag} from '../../util/validateTag';
+import CapiStats from '../CapiStats/CapiStats.react';
 
 class TagDisplay extends React.Component {
 
@@ -68,7 +69,7 @@ class TagDisplay extends React.Component {
               Column 2
             </div>
             <div className="tag__column">
-              Column 3
+              <CapiStats tag={this.props.tag} />
             </div>
           </div>
           <SaveButton isHidden={!this.isTagDirty() || !this.isTagValid()} onSaveClick={this.saveTag.bind(this)} onResetClick={this.resetTag.bind(this)}/>

--- a/public/style/components/capi-stats/_index.scss
+++ b/public/style/components/capi-stats/_index.scss
@@ -41,3 +41,22 @@
   @extend %f-header;
   @extend %fs-data-1;
 }
+
+%capi-stats__stat__arrow {
+  display: inline-block;
+
+}
+
+.capi-stats__stat__arrow--increase::before {
+  @extend %capi-stats__stat__arrow;
+  
+  content: "▲";
+  color: $c-green;
+}
+
+.capi-stats__stat__arrow--decrease::before {
+  @extend %capi-stats__stat__arrow;
+
+  content: "▼";
+  color: $c-red;
+}

--- a/public/style/components/capi-stats/_index.scss
+++ b/public/style/components/capi-stats/_index.scss
@@ -1,0 +1,43 @@
+.capi-stats {
+  margin: $standard-padding / 2;
+  padding: $standard-padding;
+
+  background-color: $c-grey-100;
+  border: 1px solid $c-grey-200;
+}
+
+.capi-stats__header {
+  @extend %f-header;
+  @extend %fs-data-4;
+
+  font-weight: bold;
+
+  margin-bottom: $standard-padding/2;
+
+}
+
+.capi-stats__stat {
+  display: inline-block;
+  width: 33%;
+
+  vertical-align: top;
+
+  text-align: center;
+
+  margin-bottom: $standard-padding/2;
+}
+
+.capi-stats__stat__header {
+  @extend %f-header;
+  @extend %fs-data-3;
+}
+
+.capi-stats__stat__value {
+  @extend %f-header;
+  @extend %fs-data-6;
+}
+
+.capi-stats__stat__prev {
+  @extend %f-header;
+  @extend %fs-data-1;
+}

--- a/public/style/main.scss
+++ b/public/style/main.scss
@@ -11,3 +11,4 @@
 @import "components/tag/index";
 @import "components/tag-edit/index";
 @import "components/save/index";
+@import "components/capi-stats/index";

--- a/public/util/capi.js
+++ b/public/util/capi.js
@@ -1,0 +1,16 @@
+import Reqwest from 'reqwest';
+
+const CAPI_BASE = 'https://internal.content.guardianapis.com';
+
+export default {
+  getByTag: (tag, fromDate, toDate) => {
+    const fromQuery = fromDate ? '&from-date=' + fromDate : '';
+    const toQuery = toDate ? '&to-date=' + toDate : '';
+
+    return Reqwest({
+      url: CAPI_BASE + '/search?tag=' + tag.path + fromQuery + toQuery,
+      contentType: 'application/json',
+      method: 'get'
+    });
+  }
+};


### PR DESCRIPTION
![screen shot 2015-11-10 at 12 58 54](https://cloud.githubusercontent.com/assets/551573/11062912/d84fad3e-87aa-11e5-9aa6-46156fe0e739.png)

Component that takes a tag and collects CAPI usage stats.

This contains a constant with the CAPI URL, my next PR will extract that into a configuration object in state.