### PR TITLE
Adds "Category" to Topic Tags

### DIFF
--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -18,7 +18,7 @@ case class Tag(
   hidden: Boolean = false,
   legallySensitive: Boolean = false,
   comparableValue: String,
-  category: Option[String],
+  categories: Set[String] = Set(),
   section: Option[Long],
   description: Option[String] = None,
   parents: Set[Long] = Set(),
@@ -41,7 +41,7 @@ object Tag {
       (JsPath \ "hidden").format[Boolean] and
       (JsPath \ "legallySensitive").format[Boolean] and
       (JsPath \ "comparableValue").format[String] and
-      (JsPath \ "category").formatNullable[String] and
+      (JsPath \ "categories").formatNullable[Set[String]].inmap[Set[String]](_.getOrElse(Set()), Some(_)) and
       (JsPath \ "section").formatNullable[Long] and
       (JsPath \ "description").formatNullable[String] and
       (JsPath \ "parents").formatNullable[Set[Long]].inmap[Set[Long]](_.getOrElse(Set()), Some(_)) and

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -18,6 +18,7 @@ case class Tag(
   hidden: Boolean = false,
   legallySensitive: Boolean = false,
   comparableValue: String,
+  category: Option[String],
   section: Option[Long],
   description: Option[String] = None,
   parents: Set[Long] = Set(),
@@ -40,6 +41,7 @@ object Tag {
       (JsPath \ "hidden").format[Boolean] and
       (JsPath \ "legallySensitive").format[Boolean] and
       (JsPath \ "comparableValue").format[String] and
+      (JsPath \ "category").formatNullable[String] and
       (JsPath \ "section").formatNullable[Long] and
       (JsPath \ "description").formatNullable[String] and
       (JsPath \ "parents").formatNullable[Set[Long]].inmap[Set[Long]](_.getOrElse(Set()), Some(_)) and
@@ -53,8 +55,7 @@ object Tag {
       Logger.error(s"failed to load tag ${item.toJSON}", e)
     }; throw e
   }
-  
+
   def fromJson(json: JsValue) = json.as[Tag]
 
 }
-

--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -15,7 +15,7 @@ case class CreateTagCommand(
                       hidden: Boolean = false,
                       legallySensitive: Boolean = false,
                       comparableValue: String,
-                      category: Option[String] = None,
+                      categories: Set[String] = Set(),
                       section: Option[Long],
                       description: Option[String] = None,
                       parents: Set[Long] = Set(),
@@ -40,7 +40,7 @@ case class CreateTagCommand(
       legallySensitive = legallySensitive,
       comparableValue = comparableValue,
       section = section,
-      category = category,
+      categories = categories,
       description = description,
       parents = parents,
       references = references
@@ -73,7 +73,7 @@ object CreateTagCommand {
       (JsPath \ "hidden").format[Boolean] and
       (JsPath \ "legallySensitive").format[Boolean] and
       (JsPath \ "comparableValue").format[String] and
-      (JsPath \ "category").formatNullable[String] and
+      (JsPath \ "categories").formatNullable[Set[String]].inmap[Set[String]](_.getOrElse(Set()), Some(_)) and
       (JsPath \ "section").formatNullable[Long] and
       (JsPath \ "description").formatNullable[String] and
       (JsPath \ "parents").formatNullable[Set[Long]].inmap[Set[Long]](_.getOrElse(Set()), Some(_)) and

--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -15,6 +15,7 @@ case class CreateTagCommand(
                       hidden: Boolean = false,
                       legallySensitive: Boolean = false,
                       comparableValue: String,
+                      category: Option[String] = None,
                       section: Option[Long],
                       description: Option[String] = None,
                       parents: Set[Long] = Set(),
@@ -39,6 +40,7 @@ case class CreateTagCommand(
       legallySensitive = legallySensitive,
       comparableValue = comparableValue,
       section = section,
+      category = category,
       description = description,
       parents = parents,
       references = references
@@ -71,6 +73,7 @@ object CreateTagCommand {
       (JsPath \ "hidden").format[Boolean] and
       (JsPath \ "legallySensitive").format[Boolean] and
       (JsPath \ "comparableValue").format[String] and
+      (JsPath \ "category").formatNullable[String] and
       (JsPath \ "section").formatNullable[Long] and
       (JsPath \ "description").formatNullable[String] and
       (JsPath \ "parents").formatNullable[Set[Long]].inmap[Set[Long]](_.getOrElse(Set()), Some(_)) and

--- a/public/components/TagEdit/TagEdit.react.js
+++ b/public/components/TagEdit/TagEdit.react.js
@@ -23,9 +23,9 @@ export default class TagEdit extends React.Component {
       }));
     }
 
-    onUpdateCategory(e) {
+    onUpdateCategory(selectedCategories) {
       this.props.updateTag(Object.assign({}, this.props.tag, {
-        category: e.target.value
+        categories: selectedCategories
       }));
     }
 
@@ -44,7 +44,7 @@ export default class TagEdit extends React.Component {
           </div>),
           (<div className="tag-edit__input-group" key="keyword-category">
             <label className="tag-edit__input-group__header">Category</label>
-              <TopicCategories selectedCategory={this.props.tag.category} onChange={this.onUpdateCategory.bind(this)}/>
+              <TopicCategories selectedCategories={this.props.tag.categories} onChange={this.onUpdateCategory.bind(this)}/>
           </div>)
         ];
       }

--- a/public/components/TagEdit/TagEdit.react.js
+++ b/public/components/TagEdit/TagEdit.react.js
@@ -5,6 +5,8 @@ import TagDescriptionEdit from './formComponents/TagDescription.react';
 import TagVisibility from './formComponents/TagVisibility.react';
 import SectionSelect from '../utils/SectionSelect.react';
 
+import TopicCategories from './formComponents/topic/TopicCategories.js';
+
 import * as tagTypes from '../../constants/tagTypes';
 
 export default class TagEdit extends React.Component {
@@ -21,6 +23,12 @@ export default class TagEdit extends React.Component {
       }));
     }
 
+    onUpdateCategory(e) {
+      this.props.updateTag(Object.assign({}, this.props.tag, {
+        category: e.target.value
+      }));
+    }
+
     //This will contain the logic for different tag forms (keyword vs contributor etc...)
     renderTagTypeSpecificFields() {
 
@@ -29,10 +37,16 @@ export default class TagEdit extends React.Component {
       }
 
       if (this.props.tag.type === tagTypes.topic) {
-        return (<div className="tag-edit__input-group">
-          <label className="tag-edit__input-group__header">Section</label>
-          <SectionSelect selectedId={this.props.tag.section} sections={this.props.sections} onChange={this.onUpdateSection.bind(this)}/>
-        </div>);
+        return [
+          (<div className="tag-edit__input-group" key="keyword-section">
+            <label className="tag-edit__input-group__header">Section</label>
+              <SectionSelect selectedId={this.props.tag.section} sections={this.props.sections} onChange={this.onUpdateSection.bind(this)}/>
+          </div>),
+          (<div className="tag-edit__input-group" key="keyword-category">
+            <label className="tag-edit__input-group__header">Category</label>
+              <TopicCategories selectedCategory={this.props.tag.category} onChange={this.onUpdateCategory.bind(this)}/>
+          </div>)
+        ];
       }
     }
 

--- a/public/components/TagEdit/formComponents/topic/TopicCategories.js
+++ b/public/components/TagEdit/formComponents/topic/TopicCategories.js
@@ -5,19 +5,51 @@ export default class TopicCategories extends React.Component {
 
   constructor(props) {
     super(props);
+
+    this.isSelected = this.isSelected.bind(this);
+    this.addCategory = this.addCategory.bind(this);
+    this.removeCategory = this.removeCategory.bind(this);
+  }
+
+  removeCategory(category) {
+    this.props.onChange(this.props.selectedCategories.filter(selectedCat => {
+      return selectedCat !== category;
+    }));
+  }
+
+  addCategory(category) {
+    if (this.props.selectedCategories) {
+      this.props.onChange(this.props.selectedCategories.concat([category]));
+    } else {
+      this.props.onChange([category]);
+    }
+  }
+
+  onChecked(category) {
+    if (this.isSelected(category)) {
+      this.removeCategory(category);
+    } else {
+      this.addCategory(category);
+    }
+  }
+
+  isSelected(category) {
+    return !!this.props.selectedCategories && this.props.selectedCategories.indexOf(category) !== -1;
   }
 
   render () {
 
     return (
-      <select value={this.props.selectedCategory} onChange={this.props.onChange} disabled={!!this.props.forceDisabled}>
-        {!this.props.selectedCategory ? <option></option> : false}
-        {topicCategories.sort((a, b) => {return a > b ? 1 : -1;}).map(function(type) {
+      <div>
+        {topicCategories.map(category => {
           return (
-            <option value={type} key={type}>{type}</option>
+            <span key={category}>
+              <input type="checkbox" checked={this.isSelected(category)} onChange={this.onChecked.bind(this, category)}/>
+              {category}
+            </span>
           );
         })}
-      </select>
+      </div>
     );
   }
 }

--- a/public/components/TagEdit/formComponents/topic/TopicCategories.js
+++ b/public/components/TagEdit/formComponents/topic/TopicCategories.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import {topicCategories} from '../../../../constants/topicCategories';
+
+export default class TopicCategories extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render () {
+
+    return (
+      <select value={this.props.selectedCategory} onChange={this.props.onChange} disabled={!!this.props.forceDisabled}>
+        {!this.props.selectedCategory ? <option></option> : false}
+        {topicCategories.sort((a, b) => {return a > b ? 1 : -1;}).map(function(type) {
+          return (
+            <option value={type} key={type}>{type}</option>
+          );
+        })}
+      </select>
+    );
+  }
+}

--- a/public/constants/topicCategories.js
+++ b/public/constants/topicCategories.js
@@ -1,0 +1,10 @@
+export const topicCategories = [
+  'People',
+  'Places',
+  'Organisations',
+  'Works',
+  'Events',
+  'Objects',
+  'Activities',
+  'Abstract concepts'
+];

--- a/public/util/validateTag.js
+++ b/public/util/validateTag.js
@@ -37,7 +37,7 @@ export function validateTag(tag) {
   let booleanFields = ['hidden', 'legallySensitive'];
 
   if (tag.type === tagTypes.topic) {
-    mandatoryFields = mandatoryFields.concat(['section']);
+    mandatoryFields = mandatoryFields.concat(['section', 'category']);
   }
 
   return []

--- a/public/util/validateTag.js
+++ b/public/util/validateTag.js
@@ -37,7 +37,7 @@ export function validateTag(tag) {
   let booleanFields = ['hidden', 'legallySensitive'];
 
   if (tag.type === tagTypes.topic) {
-    mandatoryFields = mandatoryFields.concat(['section', 'category']);
+    mandatoryFields = mandatoryFields.concat(['section']);
   }
 
   return []


### PR DESCRIPTION
As discussed in the meeting this adds the ability to select a category for a topic tag. 

The category is optional in the Tag model (as existing tags don't have it) but is a mandatory field in the interface.

