### PR TITLE
Exclude moment locale info

### DIFF
--- a/public/build_config/webpack.prod.conf.js
+++ b/public/build_config/webpack.prod.conf.js
@@ -23,6 +23,7 @@ module.exports = {
         'NODE_ENV': '"production"'
       }
     }),
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
One line change that cuts 125KB minified from production build. We're not using moment's locale information so it can be excluded.