### PR TITLE
Made iTunes URL Optional

### DIFF
--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -7,7 +7,7 @@ import com.gu.tagmanagement.{PodcastMetadata => ThriftPodcastMetadata}
 case class PodcastMetadata( linkUrl: String,
                             copyrightText: Option[String],
                             authorText: Option[String],
-                            iTunesUrl: String,
+                            iTunesUrl: Option[String],
                             iTunesBlock: Boolean,
                             clean: Boolean,
                             explicit: Boolean,
@@ -32,7 +32,7 @@ object PodcastMetadata {
       (JsPath \ "linkUrl").format[String] and
         (JsPath \ "copyrightText").formatNullable[String] and
         (JsPath \ "authorText").formatNullable[String] and
-        (JsPath \ "iTunesUrl").format[String] and
+        (JsPath \ "iTunesUrl").formatNullable[String] and
         (JsPath \ "iTunesBlock").format[Boolean] and
         (JsPath \ "clean").format[Boolean] and
         (JsPath \ "explicit").format[Boolean] and

--- a/thrift/tag.thrift
+++ b/thrift/tag.thrift
@@ -27,7 +27,7 @@ struct PodcastMetadata {
     3: optional string authorText;
 
     /** The iTunes url for the podcast **/
-    4: required string iTunesUrl;
+    4: optional string iTunesUrl;
 
     /** Should the podcast appear in iTunes **/
     5: required bool iTunesBlock;


### PR DESCRIPTION
Not every imported podcast has an iTunes URL, so made the field optional