### PR TITLE
Podcast Images (and Image Metadata)

### DIFF
--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -1,0 +1,22 @@
+package controllers
+
+import play.api.libs.json.Json
+import play.api.mvc.{Action, Controller}
+import play.api.Logger
+import services.ImageMetadataService
+
+object Support extends Controller with PanDomainAuthActions {
+
+  def imageMetadata(imageUrl: String = "") = AuthAction {
+
+    val imageMetadata = ImageMetadataService.fetch(imageUrl)
+    Ok(Json.toJson(imageMetadata))
+
+    ImageMetadataService.fetch(imageUrl).map { imageMetadata =>
+      Ok(Json.toJson(imageMetadata))
+    }.getOrElse(NotFound)
+
+  }
+
+
+}

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -2,21 +2,13 @@ package controllers
 
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
-import play.api.Logger
 import services.ImageMetadataService
 
 object Support extends Controller with PanDomainAuthActions {
 
-  def imageMetadata(imageUrl: String = "") = AuthAction {
-
-    val imageMetadata = ImageMetadataService.fetch(imageUrl)
-    Ok(Json.toJson(imageMetadata))
-
+  def imageMetadata(imageUrl: String = "") = APIAuthAction {
     ImageMetadataService.fetch(imageUrl).map { imageMetadata =>
       Ok(Json.toJson(imageMetadata))
     }.getOrElse(NotFound)
-
   }
-
-
 }

--- a/app/services/ImageMetadata.scala
+++ b/app/services/ImageMetadata.scala
@@ -1,0 +1,67 @@
+package services
+
+import java.io.ByteArrayInputStream
+import javax.imageio.ImageIO
+
+import java.security.MessageDigest
+import javax.imageio.stream.ImageInputStream
+import play.api.Logger
+
+import com.squareup.okhttp.Request.Builder
+import com.squareup.okhttp.{OkHttpClient, Request}
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Format}
+
+import scala.util.control.NonFatal
+
+case class ImageMetadataFetchFail(m: String) extends RuntimeException(m)
+
+case class ImageMetadata(width: Int, height: Int, size: Int, mediaId: String, mimeType: String)
+
+object ImageMetadata {
+  implicit val imageMetadataFormat: Format[ImageMetadata] = (
+    (JsPath \ "width").format[Int] and
+      (JsPath \ "height").format[Int] and
+      (JsPath \ "size").format[Int] and
+      (JsPath \ "id").format[String] and
+      (JsPath \ "mimeType").format[String]
+    )(ImageMetadata.apply, unlift(ImageMetadata.unapply))
+}
+
+
+object ImageMetadataService {
+
+  val httpClient = new OkHttpClient()
+
+  def calculateMediaId(imageBytes: Array[Byte]): String = {
+    // Replicated from Media Service logic at
+    // https://github.com/guardian/media-service/blob/master/image-loader/app/lib/play/BodyParsers.scala#L16
+    val digest = MessageDigest.getInstance("SHA-1").digest(imageBytes)
+    digest.map("%02x".format(_)).mkString
+  }
+
+
+  def fetch(uri: String): Option[ImageMetadata] = try {
+
+    val imageRequest = new Builder().url(uri).build()
+    val response = httpClient.newCall(imageRequest).execute()
+
+    response.code match {
+      case 200 => {
+
+        val mimeType = response.header("content-type")
+        val bytes = response.body().bytes()
+        val mediaId = calculateMediaId(bytes)
+        val image = ImageIO.read(new ByteArrayInputStream(bytes))
+
+        Some(ImageMetadata(image.getWidth, image.getHeight, bytes.size, mediaId, mimeType))
+      }
+      case c => {
+        Logger.warn(s"failed to get image metadata for $uri. response code $c, message ${response.body}")
+        throw ImageMetadataFetchFail(s"failed to get image metadata for $uri. response code $c, message ${response.body}")
+      }
+    }
+  } catch {
+    case NonFatal(e) => None
+  }
+}

--- a/app/services/ImageMetadata.scala
+++ b/app/services/ImageMetadata.scala
@@ -41,7 +41,7 @@ object ImageMetadataService {
   }
 
 
-  def fetch(uri: String): Option[ImageMetadata] = try {
+  def fetch(uri: String): Option[ImageMetadata] = {
 
     val imageRequest = new Builder().url(uri).build()
     val response = httpClient.newCall(imageRequest).execute()
@@ -61,7 +61,5 @@ object ImageMetadataService {
         throw ImageMetadataFetchFail(s"failed to get image metadata for $uri. response code $c, message ${response.body}")
       }
     }
-  } catch {
-    case NonFatal(e) => None
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -33,3 +33,6 @@ GET        /management/healthcheck        controllers.Management.healthCheck
 
 # Map static resources from the /public folder to the /assets URL path
 GET        /assets/*file                  controllers.Assets.versioned(path="/public", file: Asset)
+
+# Support routes
+GET        /support/image-metadata        controllers.Support.imageMetadata(imageUrl: String)

--- a/public/components/TagEdit/formComponents/TagImageEdit.react.js
+++ b/public/components/TagEdit/formComponents/TagImageEdit.react.js
@@ -38,13 +38,15 @@ export default class TagImageEdit extends React.Component {
   }
 
   updateInputUrl(e) {
+    const url = e.target.value.replace('http://static.guim.co.uk', 'https://static.guim.co.uk')
+
     this.setState({
-      inputUrl: e.target.value,
+      inputUrl: url,
       currentMetadata: false,
       metadataFetchStatus: FETCH_STATES.fetching
     });
 
-    this.fetchMetadata(e.target.value);
+    this.fetchMetadata(url);
   }
 
   addImage() {
@@ -100,7 +102,12 @@ export default class TagImageEdit extends React.Component {
     }
 
     if (this.state.metadataFetchStatus === FETCH_STATES.error) {
-      return (<div className="tag-edit__image__add--error"><i className="i-cross-red" />Url Not Valid</div>);
+      return (
+        <div className="tag-edit__image__add--error">
+          <i className="i-cross-red" />
+          Url Not Valid. The image should be located on https://static.guim.co.uk
+        </div>
+      );
     }
 
     if (this.state.metadataFetchStatus === FETCH_STATES.success) {

--- a/public/components/TagEdit/formComponents/TagImageEdit.react.js
+++ b/public/components/TagEdit/formComponents/TagImageEdit.react.js
@@ -1,0 +1,152 @@
+import React from 'react';
+import {validateImageUrl} from '../../../util/validateImage';
+import {getImageMetadata} from '../../../util/supportApi.js';
+
+const FETCH_STATES = {
+  error: 'FETCH_STATE_ERROR',
+  fetching: 'FETCH_STATE_FETCHING',
+  success: 'FETCH_STATE_SUCCESS'
+};
+
+export default class TagImageEdit extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      inputUrl: ''
+    };
+
+    this.fetchMetadata = this.fetchMetadata.bind(this);
+  }
+
+  onImageUpdate() {
+    this.props.onChange();
+  }
+
+  getMainAsset() {
+
+    if (!this.props.tagImage.assets) {
+      return false;
+    }
+
+    return this.props.tagImage.assets.sort((a, b) => a.width < b.width)[0];
+  }
+
+  removeImage() {
+    this.props.onChange({});
+  }
+
+  updateInputUrl(e) {
+    this.setState({
+      inputUrl: e.target.value,
+      currentMetadata: false,
+      metadataFetchStatus: FETCH_STATES.fetching
+    });
+
+    this.fetchMetadata(e.target.value);
+  }
+
+  addImage() {
+    this.props.onChange({
+      imageId: this.state.currentMetadata.id,
+      assets: [
+        {
+          height: this.state.currentMetadata.height,
+          imageUrl: this.state.inputUrl,
+          mimeType: this.state.currentMetadata.mimeType,
+          width: this.state.currentMetadata.width
+        }
+      ]
+    });
+
+    this.setState({
+      inputUrl: undefined,
+      currentMetadata: undefined,
+      metadataFetchStatus: undefined
+    });
+  }
+
+  fetchMetadata(imageUrl) {
+
+    //Validate before any requests happen
+    if (!validateImageUrl(imageUrl)) {
+      this.setState({
+        currentMetadata: false,
+        metadataFetchStatus: FETCH_STATES.error
+      });
+
+      return false;
+    }
+
+    getImageMetadata(imageUrl).then(metadata => {
+      if (this.state.inputUrl === imageUrl) { // Check it's still the current url
+        this.setState({
+          currentMetadata: metadata,
+          metadataFetchStatus: FETCH_STATES.success
+        });
+      }
+    }).fail(e => {
+      this.setState({
+        currentMetadata: false,
+        metadataFetchStatus: FETCH_STATES.error
+      });
+    });
+  }
+
+  renderAddButton() {
+    if (this.state.metadataFetchStatus === FETCH_STATES.fetching) {
+      return (<div className="tag-edit__image__add">Checking Url...</div>);
+    }
+
+    if (this.state.metadataFetchStatus === FETCH_STATES.error) {
+      return (<div className="tag-edit__image__add--error"><i className="i-cross-red" />Url Not Valid</div>);
+    }
+
+    if (this.state.metadataFetchStatus === FETCH_STATES.success) {
+      return (<div className="tag-edit__image__add--success" onClick={this.addImage.bind(this)}><i className="i-tick-green" />Add Image</div>);
+    }
+
+    return false;
+  }
+
+  renderImage() {
+
+    const imageAsset = this.getMainAsset();
+
+    if (!validateImageUrl(imageAsset.imageUrl)) {
+      return (
+        <div>
+          <input type="text" className="tag-edit__input" value={this.state.inputUrl} onChange={this.updateInputUrl.bind(this)}/>
+          {this.renderAddButton()}
+        </div>
+      );
+    }
+
+    return (
+      <div className="tag-edit__field">
+        <a href={imageAsset.imageUrl} target="_blank">
+          <img src={imageAsset.imageUrl} className="tag-edit__field__image"/>
+        </a>
+        <div className="tag-edit__image__info">
+          <div>Width: {imageAsset.width}px</div>
+          <div>Height: {imageAsset.height}px</div>
+          <div className="tag-edit__image__remove" onClick={this.removeImage.bind(this)}>
+            <i className="i-cross-red" />Remove image
+          </div>
+        </div>
+      </div>
+    );
+
+  }
+
+  render () {
+
+    return (
+        <div className="tag-edit__field">
+          <label className="tag-edit__label">{this.props.label}</label>
+          {this.renderImage()}
+        </div>
+    );
+  }
+}

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import R from 'ramda';
 
+import TagImageEdit from '../TagImageEdit.react';
+
 export default class PodcastMetadata extends React.Component {
 
   constructor(props) {
@@ -59,6 +61,12 @@ export default class PodcastMetadata extends React.Component {
     }));
   }
 
+  updateImage(image) {
+    this.props.updateTag(R.merge(this.props.tag, {
+      podcastMetadata: R.merge(this.props.tag.podcastMetadata, {image: image})
+    }));
+  }
+
   renderMetadataForm() {
     if (!this.tagHasPodcast()) {
       return false;
@@ -94,6 +102,7 @@ export default class PodcastMetadata extends React.Component {
           <input type="checkbox" onChange={this.updateExplicit.bind(this)} checked={this.props.tag.podcastMetadata.explicit || false}/>
           <label className="tag-edit__label"> Explicit</label>
         </div>
+        <TagImageEdit tagImage={this.props.tag.podcastMetadata.image} label="Podcast Image" onChange={this.updateImage.bind(this)}/>
       </div>
     );
   }

--- a/public/style/components/tag-edit/_index.scss
+++ b/public/style/components/tag-edit/_index.scss
@@ -37,6 +37,10 @@ $tag-edit-padding: $standard-padding/2;
 
 }
 
+
+
+
+
 .tag-edit__visibility {
   columns: 2;
   -webkit-columns: 2;
@@ -44,7 +48,55 @@ $tag-edit-padding: $standard-padding/2;
 }
 
 .tag-edit__field {
+  position: relative;
   margin: $standard-padding/2 0;
+}
+
+.tag-edit__field__image {
+  display: inline-block;
+  width: 100px;
+}
+
+.tag-edit__image__info {
+  @extend %f-header;
+  @extend %fs-data-3;
+
+
+  display: inline-block;
+  vertical-align: top;
+
+  margin-left: $standard-padding;
+}
+
+.tag-edit__image__remove {
+  position: absolute;
+  color: $c-red;
+  bottom: 0;
+  cursor: pointer;
+
+}
+
+%tag-edit__image__add {
+  @extend %f-header;
+  @extend %fs-data-3;
+
+  text-align: right;
+
+  padding: 10px;
+}
+
+.tag-edit__image__add {
+  @extend %tag-edit__image__add;
+}
+
+.tag-edit__image__add--error {
+  @extend %tag-edit__image__add;
+  color: $c-red;
+}
+
+.tag-edit__image__add--success {
+  @extend %tag-edit__image__add;
+  color: $c-green;
 }
 
 .tag-edit__label {

--- a/public/style/components/tag-edit/_index.scss
+++ b/public/style/components/tag-edit/_index.scss
@@ -97,6 +97,8 @@ $tag-edit-padding: $standard-padding/2;
 .tag-edit__image__add--success {
   @extend %tag-edit__image__add;
   color: $c-green;
+
+  cursor: pointer;
 }
 
 .tag-edit__label {

--- a/public/util/supportApi.js
+++ b/public/util/supportApi.js
@@ -1,0 +1,9 @@
+import Reqwest from 'reqwest';
+
+export function getImageMetadata(imageUrl) {
+      return Reqwest({
+          url: '/support/image-metadata?imageUrl=' + imageUrl,
+          contentType: 'application/json',
+          method: 'get'
+      });
+}

--- a/public/util/validateImage.js
+++ b/public/util/validateImage.js
@@ -1,0 +1,5 @@
+const URL_REGEX = /^https:\/\/static.guim.co.uk\/sys-images\/Guardian\/.*\.(png|jpg)$/;
+
+export function validateImageUrl(url) {
+  return !!url && !!url.match(URL_REGEX);
+}


### PR DESCRIPTION
This adds the non-GRID image add/removal functionality for Podcast Image (in the form of a general component for use everywhere)

On inputting of a recognised url (jpg or png on https://static.guim.co.uk) the component will query the `/support/image-metadata` to recieve:

``` JSON

{
   "width": 720,
   "height": 600,
   "size": 121116,
   "id": "23ea8766375c48498c1fabc1ee448af1a2f9cb69",
   "mimeType": "image/png"
}
```

This can then be used to update the podcast metadata