### PR TITLE
Remove images fully so can be validated as mandatory

### DIFF
--- a/public/components/TagEdit/TagEdit.react.js
+++ b/public/components/TagEdit/TagEdit.react.js
@@ -46,10 +46,18 @@ export default class TagEdit extends React.Component {
           (<div className="tag-edit__input-group" key="keyword-category">
             <label className="tag-edit__input-group__header">Category</label>
               <TopicCategories selectedCategories={this.props.tag.categories} onChange={this.onUpdateCategory.bind(this)}/>
-          </div>)
+          </div>
+        )
         ];
       } else if (this.props.tag.type === tagTypes.series) {
-        return <PodcastMetadata tag={this.props.tag} updateTag={this.props.updateTag}/>;
+        return [
+            (<PodcastMetadata tag={this.props.tag} updateTag={this.props.updateTag} key="series-podcast"/>),
+            (<div className="tag-edit__input-group" key="series-section">
+              <label className="tag-edit__input-group__header">Category</label>
+                <SectionSelect selectedId={this.props.tag.section} sections={this.props.sections} onChange={this.onUpdateSection.bind(this)}/>
+            </div>
+          )
+        ];
       }
     }
 

--- a/public/components/TagEdit/formComponents/TagImageEdit.react.js
+++ b/public/components/TagEdit/formComponents/TagImageEdit.react.js
@@ -26,7 +26,7 @@ export default class TagImageEdit extends React.Component {
 
   getMainAsset() {
 
-    if (!this.props.tagImage.assets) {
+    if (!this.props.tagImage || !this.props.tagImage.assets) {
       return false;
     }
 
@@ -34,7 +34,7 @@ export default class TagImageEdit extends React.Component {
   }
 
   removeImage() {
-    this.props.onChange({});
+    this.props.onChange(undefined);
   }
 
   updateInputUrl(e) {

--- a/public/util/validateTag.js
+++ b/public/util/validateTag.js
@@ -37,7 +37,7 @@ function validatePodcast(tag) {
     return []; //No podcast metadata
   }
 
-  const mandatoryPodcastFields = ['linkUrl'];
+  const mandatoryPodcastFields = ['linkUrl', 'image'];
 
   return validateMandatoryFields(mandatoryPodcastFields, tag.podcastMetadata);
 }


### PR DESCRIPTION
Makes sure to actually remove the image, then can be validated as a mandatory field using existing logic. TagImageEdit can also now cope with being passed undefined as an image.