### PR TITLE
Add a wrapper around Scribe for use with React

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
   java:
     version: oraclejdk8
   node:
-    version: 5.1.0
+    version: 5.2.0
   environment:
     NODE_ENV: production
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "redux-thunk": "^1.0.0",
     "reqwest": "^2.0.5",
     "sass-loader": "^3.1.1",
+    "scribe-editor": "^2.1.1",
+    "scribe-plugin-keyboard-shortcuts": "^0.1.1",
+    "scribe-plugin-link-prompt-command": "^0.4.0",
+    "scribe-plugin-toolbar": "^0.2.2",
     "style-loader": "^0.13.0",
     "svg-sprite": "^1.2.12",
     "webpack": "^1.12.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "css-loader": "^0.22.0",
     "expose-loader": "^0.7.0",
     "extract-text-webpack-plugin": "^0.9.1",
-    "history": "^1.13.0",
+    "history": "1.13.1",
     "lodash.debounce": "^3.1.1",
     "moment": "^2.10.6",
     "node-sass": "^3.3.3",

--- a/public/components/TagEdit/formComponents/TagDescription.react.js
+++ b/public/components/TagEdit/formComponents/TagDescription.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactScribe from '../../utils/ReactScribe.react';
 
 export default class TagVisibilityEdit extends React.Component {
 
@@ -6,9 +7,9 @@ export default class TagVisibilityEdit extends React.Component {
     super(props);
   }
 
-  updateDescription(e) {
+  updateDescription(html) {
     this.props.updateTag(Object.assign({}, this.props.tag, {
-      description: e.target.value
+      description: html
     }));
   }
 
@@ -19,9 +20,16 @@ export default class TagVisibilityEdit extends React.Component {
 
     return (
       <div className="tag-edit__input-group">
-        <label className="tag-edit__input-group__header">Description</label>
+        <label className="tag-edit__input-group__header">Description/Profile</label>
         <div>
-          <textarea onChange={this.updateDescription.bind(this)} value={this.props.tag.description || ''}/>
+          <ReactScribe
+            onChange={this.updateDescription.bind(this)}
+            value={this.props.tag.description || ''}
+            className="tag-edit__richtext"
+            toolbarClassName="tag-edit__richtext__toolbar"
+            toolbarItemClassName="tag-edit__richtext__toolbar__item"
+            editorClassName="tag-edit__richtext__editor"
+          />
         </div>
       </div>
     );

--- a/public/components/utils/ReactScribe.react.js
+++ b/public/components/utils/ReactScribe.react.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import Scribe from 'scribe-editor';
+import scribeKeyboardShortcutsPlugin from 'scribe-plugin-keyboard-shortcuts';
+import scribePluginToolbar from 'scribe-plugin-toolbar';
+import scribePluginLinkPromptCommand from 'scribe-plugin-link-prompt-command';
+
+export default class ReactScribe extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.onContentChange = this.onContentChange.bind(this);
+  }
+
+  componentDidMount() {
+    this.scribe = new Scribe(this.refs.editor);
+
+    this.configureScribe();
+
+    this.scribe.on('content-changed', this.onContentChange);
+  }
+
+  componentWillUnmount() {
+    this.scribe.off('content-changed', this.onContentChange);
+  }
+
+  configureScribe() {
+
+    this.scribe.use(scribePluginLinkPromptCommand());
+    this.scribe.use(scribeKeyboardShortcutsPlugin({
+      bold: function (event) { return event.metaKey && event.keyCode === 66; }, // b
+      italic: function (event) { return event.metaKey && event.keyCode === 73; }, // i
+      linkPrompt: function (event) { return event.metaKey && !event.shiftKey && event.keyCode === 75; }, // k
+      unlink: function (event) { return event.metaKey && event.shiftKey && event.keyCode === 75; } // shft + k
+    }));
+
+    this.scribe.use(scribePluginToolbar(this.refs.toolbar));
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return nextProps.value !== this.refs.editor.innerHTML;
+  }
+
+  onContentChange() {
+    const newContent = this.refs.editor.innerHTML;
+
+    if (newContent !== this.props.value) {
+      this.props.onChange(newContent);
+    }
+  }
+
+  render () {
+    return (
+      <div className={this.props.className}>
+        <div ref="toolbar" className={this.props.toolbarClassName}>
+          <div data-command-name="bold" className={this.props.toolbarItemClassName}>Bold</div>
+          <div data-command-name="italic" className={this.props.toolbarItemClassName}>Italic</div>
+          <div data-command-name="linkPrompt" className={this.props.toolbarItemClassName}>Link</div>
+          <div data-command-name="unlink" className={this.props.toolbarItemClassName}>Unlink</div>
+        </div>
+        <div className={this.props.editorClassName} dangerouslySetInnerHTML={{__html: this.props.value}} ref="editor"></div>
+      </div>
+    );
+  }
+}

--- a/public/style/components/tag-edit/_index.scss
+++ b/public/style/components/tag-edit/_index.scss
@@ -211,3 +211,54 @@ $tag-edit-padding: $standard-padding/2;
 
   }
 }
+
+
+.tag-edit__richtext {
+
+  @extend %f-header;
+  @extend %fs-data-3;
+
+  margin-top: $standard-padding/2;
+
+  background-color: white;
+  border: 1px solid $c-grey-300;
+}
+
+.tag-edit__richtext__toolbar {
+  position: relative;
+
+  background-color: $c-grey-100;
+  border-bottom: 1px solid $c-grey-300;
+
+}
+
+.tag-edit__richtext__toolbar__item {
+  display: inline-block;
+
+  cursor: pointer;
+  padding: $standard-padding/2 $standard-padding;
+
+  border-right: 1px solid $c-grey-300;
+}
+
+.tag-edit__richtext__editor {
+  padding: $standard-padding;
+
+  b {
+    font-weight: bold;
+  }
+
+  i {
+    font-style: italic;
+  }
+
+  a {
+    color: $c-blue-link;
+    text-decoration: underline;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+}


### PR DESCRIPTION
This adds ReactScribe, a wrapper around a scribe instance, turning into a React Component. Surfacing the regular `value` and `onChange` that you would expect with any other input.

![screen shot 2015-12-10 at 15 01 42](https://cloud.githubusercontent.com/assets/551573/11718649/f386a0ba-9f4e-11e5-8c7a-15993ce497df.png)

