### PR TITLE
Section Editing And Editions

### DIFF
--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import model.command.CommandError._
-import model.command.{BatchTagCommand, PathUsageCheck, CreateTagCommand, UpdateTagCommand}
+import model.command._
 import model.jobs.{BatchTagAddCompleteCheck, Job}
 import org.joda.time.DateTime
 import permissions.Permissions
@@ -86,10 +86,11 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   def updateSection(id: Long) = APIAuthAction { req =>
 
     req.body.asJson.map { json =>
-      SectionRepository.updateSection(json).map{ section =>
-        Ok(Json.toJson(section))
-      }.getOrElse(BadRequest("Could not update section"))
-
+      try {
+        UpdateSectionCommand(json.as[Section]).process.map{ t => Ok(Json.toJson(t)) } getOrElse NotFound
+      } catch {
+        commandErrorAsResult
+      }
     }.getOrElse {
       BadRequest("Expecting Json data")
     }

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -96,6 +96,28 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     }
   }
 
+  def addEditionToSection(id: Long) = APIAuthAction { req =>
+    req.body.asJson.map { json =>
+      val editionName = (json \ "editionName").as[String]
+
+      try {
+        AddEditionToSectionCommand(id, editionName.toUpperCase).process.map{ t => Ok(Json.toJson(t)) } getOrElse NotFound
+      } catch {
+        commandErrorAsResult
+      }
+    }.getOrElse {
+      BadRequest("Expecting Json data")
+    }
+  }
+
+  def removeEditionFromSection(id: Long, editionName: String) = APIAuthAction { req =>
+    try {
+      RemoveEditionFromSectionCommand(id, editionName.toUpperCase).process.map{ t => Ok(Json.toJson(t)) } getOrElse NotFound
+    } catch {
+      commandErrorAsResult
+    }
+  }
+
   def listSections() = APIAuthAction {
     Ok(Json.toJson(SectionRepository.loadAllSections))
   }

--- a/app/model/Section.scala
+++ b/app/model/Section.scala
@@ -18,6 +18,8 @@ case class Section(
                     editions: Map[String, EditionalisedPage] = Map()
                     ) {
 
+  def toItem = Item.fromJSON(Json.toJson(this).toString())
+
   def asThrift = ThriftSection(
     id            = id,
     sectionTagId  = sectionTagId,

--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -50,6 +50,14 @@ object SectionAudit {
     SectionAudit(section.id, "updated", new DateTime(), user.map(_.email).getOrElse("default user"), s"section '${section.name}' updated", SectionSummary(section))
   }
 
+  def addedEdition(section: Section, editionName: String)(implicit user: Option[User] = None): SectionAudit = {
+    SectionAudit(section.id, "added edition", new DateTime(), user.map(_.email).getOrElse("default user"), s"added ${editionName} edition to section '${section.name}", SectionSummary(section))
+  }
+
+  def removedEdition(section: Section, editionName: String)(implicit user: Option[User] = None): SectionAudit = {
+    SectionAudit(section.id, "removed edition", new DateTime(), user.map(_.email).getOrElse("default user"), s"removed ${editionName} edition from section '${section.name}", SectionSummary(section))
+  }
+
 }
 
 case class SectionSummary(

--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -1,0 +1,81 @@
+package model
+
+import com.amazonaws.services.dynamodbv2.document.Item
+import com.gu.pandomainauth.model.User
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Json, JsPath, Format}
+import repositories.SectionRepository
+
+import scala.util.control.NonFatal
+
+
+case class SectionAudit(
+                     sectionId: Long,
+                     operation: String,
+                     date: DateTime,
+                     user: String,
+                     description: String,
+                     sectionSummary: SectionSummary
+                   ) {
+  def toItem = Item.fromJSON(Json.toJson(this).toString())
+}
+
+object SectionAudit {
+
+  implicit val sectionAuditFormat: Format[SectionAudit] = (
+    (JsPath \ "sectionId").format[Long] and
+      (JsPath \ "operation").format[String] and
+      (JsPath \ "date").format[DateTime] and
+      (JsPath \ "user").format[String] and
+      (JsPath \ "description").format[String] and
+      (JsPath \ "sectionSummary").format[SectionSummary]
+    )(SectionAudit.apply, unlift(SectionAudit.unapply))
+
+  def fromItem(item: Item) = try {
+    Json.parse(item.toJSON).as[SectionAudit]
+  } catch {
+    case NonFatal(e) => {
+      Logger.error(s"failed to load section Audit ${item.toJSON}", e)
+      throw e
+    }
+  }
+
+  def created(section: Section)(implicit user: Option[User] = None): SectionAudit = {
+    SectionAudit(section.id, "created", new DateTime(), user.map(_.email).getOrElse("default user"), s"section '${section.name}' created", SectionSummary(section))
+  }
+
+  def updated(section: Section)(implicit user: Option[User] = None): SectionAudit = {
+    SectionAudit(section.id, "updated", new DateTime(), user.map(_.email).getOrElse("default user"), s"section '${section.name}' updated", SectionSummary(section))
+  }
+
+}
+
+case class SectionSummary(
+                       sectionId: Long,
+                       name: String,
+                       path: String,
+                       editions: String
+                     )
+
+object SectionSummary {
+
+  implicit val tagAuditFormat: Format[SectionSummary] = (
+    (JsPath \ "sectionId").format[Long] and
+      (JsPath \ "name").format[String] and
+      (JsPath \ "path").format[String] and
+      (JsPath \ "editions").format[String]
+    )(SectionSummary.apply, unlift(SectionSummary.unapply))
+
+  def apply(section: Section): SectionSummary =
+    new SectionSummary(
+      sectionId = section.id,
+      name = section.name,
+      path = section.path,
+      editions = section.editions.keys.mkString(" ") match {
+        case "" => "No Editions"
+        case e => e
+      }
+    )
+}

--- a/app/model/command/AddEditionToSectionCommand.scala
+++ b/app/model/command/AddEditionToSectionCommand.scala
@@ -1,0 +1,38 @@
+package model.command
+
+import com.gu.pandomainauth.model.User
+import com.gu.tagmanagement.{EventType, SectionEvent}
+import model.command.CommandError._
+import model.command.logic.SectionEditionPathCalculator
+import model.{Section, SectionAudit, EditionalisedPage}
+import play.api.Logger
+import repositories.{PathRegistrationFailed, PathManager, SectionAuditRepository, SectionRepository}
+import services.KinesisStreams
+
+
+case class AddEditionToSectionCommand(sectionId: Long, editionName: String) extends Command {
+
+  type T = Section
+
+  override def process()(implicit user: Option[User] = None): Option[Section] = {
+    Logger.info(s"add ${editionName} to section ${sectionId}")
+
+    val section = SectionRepository.getSection(sectionId).getOrElse(SectionNotFound)
+
+    val calculatedPath = SectionEditionPathCalculator.calculatePath(section, editionName)
+
+    val pageId = try { PathManager.registerPathAndGetPageId(calculatedPath) } catch { case p: PathRegistrationFailed => PathInUse}
+
+    val updatedSection = section.copy(
+      editions = section.editions ++ Map(editionName -> EditionalisedPage(calculatedPath, pageId))
+    )
+
+    val result = SectionRepository.updateSection(updatedSection)
+
+    KinesisStreams.sectionUpdateStream.publishUpdate(updatedSection.id.toString, SectionEvent(EventType.Update, updatedSection.id, Some(updatedSection.asThrift)))
+
+    SectionAuditRepository.upsertSectionAudit(SectionAudit.addedEdition(updatedSection, editionName))
+
+    result
+  }
+}

--- a/app/model/command/CommandErrors.scala
+++ b/app/model/command/CommandErrors.scala
@@ -8,8 +8,12 @@ case class CommandError(message: String, responseCode: Int) extends RuntimeExcep
 object CommandError extends Results {
 
   def SectionNotFound = throw new CommandError("section not found", 400)
+  def EditionNotFound = throw new CommandError("edition not found", 400)
   def TagNotFound = throw new CommandError("tag not found", 400)
   def PathInUse = throw new CommandError("path in use", 400)
+  def PathNotFound = throw new CommandError("could not remove path from pathmanager", 400)
+
+  def InvalidSectionEditionRegion = throw new CommandError("Invalid region supplied", 400)
 
   def commandErrorAsResult: PartialFunction[Throwable, Result] = {
     case CommandError(msg, 400) => BadRequest(msg)

--- a/app/model/command/RemoveEditionFromSectionCommand.scala
+++ b/app/model/command/RemoveEditionFromSectionCommand.scala
@@ -1,0 +1,38 @@
+package model.command
+
+import com.gu.pandomainauth.model.User
+import com.gu.tagmanagement.{EventType, SectionEvent}
+import model.command.CommandError._
+import model.command.logic.SectionEditionPathCalculator
+import model.{EditionalisedPage, Section, SectionAudit}
+import play.api.Logger
+import repositories.{PathManager, PathRegistrationFailed, PathRemoveFailed, SectionAuditRepository, SectionRepository}
+import services.KinesisStreams
+
+
+case class RemoveEditionFromSectionCommand(sectionId: Long, editionName: String) extends Command {
+
+  type T = Section
+
+  override def process()(implicit user: Option[User] = None): Option[Section] = {
+    Logger.info(s"removing ${editionName} from section ${sectionId}")
+
+    val section = SectionRepository.getSection(sectionId).getOrElse(SectionNotFound)
+
+    val editionInfo = section.editions.get(editionName.toUpperCase).getOrElse(EditionNotFound)
+
+    val pageId = try { PathManager.removePathForId(editionInfo.pageId) } catch { case p: PathRemoveFailed => PathNotFound}
+
+    val updatedSection = section.copy(
+      editions = section.editions.filterKeys(_.toUpperCase != editionName.toUpperCase)
+    )
+
+    val result = SectionRepository.updateSection(updatedSection)
+
+    KinesisStreams.sectionUpdateStream.publishUpdate(updatedSection.id.toString, SectionEvent(EventType.Update, updatedSection.id, Some(updatedSection.asThrift)))
+
+    SectionAuditRepository.upsertSectionAudit(SectionAudit.removedEdition(updatedSection, editionName))
+
+    result
+  }
+}

--- a/app/model/command/UpdateSectionCommand.scala
+++ b/app/model/command/UpdateSectionCommand.scala
@@ -1,0 +1,26 @@
+package model.command
+
+import com.gu.pandomainauth.model.User
+import com.gu.tagmanagement.{EventType, SectionEvent}
+import model.{Section, SectionAudit}
+import play.api.Logger
+import repositories.{SectionAuditRepository, SectionRepository}
+import services.KinesisStreams
+
+
+case class UpdateSectionCommand(section: Section) extends Command {
+
+  type T = Section
+
+  override def process()(implicit user: Option[User] = None): Option[Section] = {
+    Logger.info(s"updating section ${section.id}")
+
+    val result = SectionRepository.updateSection(section)
+
+    KinesisStreams.sectionUpdateStream.publishUpdate(section.id.toString, SectionEvent(EventType.Update, section.id, Some(section.asThrift)))
+
+    SectionAuditRepository.upsertSectionAudit(SectionAudit.updated(section))
+
+    result
+  }
+}

--- a/app/model/command/logic/SectionEditionPathCalculator.scala
+++ b/app/model/command/logic/SectionEditionPathCalculator.scala
@@ -1,0 +1,18 @@
+package model.command.logic
+
+import model.command.CommandError._
+import model.Section
+
+object SectionEditionPathCalculator {
+
+  def calculatePath(section: Section, editionRegion: String) = {
+
+    editionRegion match {
+      case "US" => s"us/${section.wordsForUrl}"
+      case "UK" => s"uk/${section.wordsForUrl}"
+      case "AU" => s"au/${section.wordsForUrl}"
+      case _ => throw InvalidSectionEditionRegion
+    }
+  }
+
+}

--- a/app/repositories/SectionAuditRepository.scala
+++ b/app/repositories/SectionAuditRepository.scala
@@ -1,0 +1,33 @@
+package repositories
+
+import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition
+import model.SectionAudit
+import org.joda.time.{DateTime, Duration, ReadableDuration}
+import services.Dynamo
+
+import scala.collection.JavaConversions._
+
+
+object SectionAuditRepository {
+
+  def upsertSectionAudit(sectionAudit: SectionAudit) = {
+    try {
+      Dynamo.sectionAuditTable.putItem(sectionAudit.toItem)
+      Some(sectionAudit)
+    } catch {
+      case e: Error => None
+    }
+  }
+
+  def getAuditTrailForSection(sectionId: Long): List[SectionAudit] = {
+    Dynamo.sectionAuditTable.query("sectionId", sectionId).map(SectionAudit.fromItem).toList
+  }
+
+  def getRecentAuditOfOperation(operation: String, timePeriod: ReadableDuration = Duration.standardDays(7)): List[SectionAudit] = {
+    val from = new DateTime().minus(timePeriod).getMillis
+    Dynamo.tagAuditTable.getIndex("operation-date-index")
+      .query("operation", operation, new RangeKeyCondition("date").ge(from))
+      .map(SectionAudit.fromItem).toList
+  }
+
+}

--- a/app/repositories/SectionRepository.scala
+++ b/app/repositories/SectionRepository.scala
@@ -12,10 +12,9 @@ object SectionRepository {
     Option(Dynamo.sectionTable.getItem("id", id)).map(Section.fromItem)
   }
 
-  def updateSection(sectionJson: JsValue) = {
+  def updateSection(section: Section) = {
     try {
-      val section = Section.fromJson(sectionJson) // parsing input json here provides bugjet validation
-      Dynamo.sectionTable.putItem(Item.fromJSON(sectionJson.toString()))
+      Dynamo.sectionTable.putItem(section.toItem)
       Some(section)
     } catch {
       case e: Error => None

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -52,6 +52,8 @@ object Dynamo {
   lazy val sequenceTable = dynamoDb.getTable(Config().sequenceTableName)
   lazy val jobTable = dynamoDb.getTable(Config().jobTableName)
   lazy val tagAuditTable = dynamoDb.getTable(Config().tagAuditTableName)
+  lazy val sectionAuditTable = dynamoDb.getTable(Config().sectionAuditTableName)
+
   lazy val clusterStatusTable = dynamoDb.getTable(Config().clusterStatusTableName)
   lazy val referencesTypeTable = dynamoDb.getTable(Config().referencesTypeTableName)
 }
@@ -83,5 +85,6 @@ class KinesisStreamProducer(streamName: String) {
 
 object KinesisStreams {
   lazy val tagUpdateStream = new KinesisStreamProducer(Config().tagUpdateStreamName)
+  lazy val sectionUpdateStream = new KinesisStreamProducer(Config().sectionUpdateStreamName)
   lazy val taggingOperationsStream = new KinesisStreamProducer(Config().taggingOperationsStreamName)
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -73,11 +73,13 @@ sealed trait Config {
   def sequenceTableName: String
   def jobTableName: String
   def tagAuditTableName: String
+  def sectionAuditTableName: String
   def clusterStatusTableName: String
 
   def referencesTypeTableName: String
 
   def tagUpdateStreamName: String
+  def sectionUpdateStreamName: String
   def taggingOperationsStreamName: String
 
   def jobQueueName: String
@@ -99,9 +101,11 @@ class DevConfig extends Config {
 
   override def jobTableName: String = "tag-manager-jobs-dev"
   override def tagAuditTableName: String = "tag-manager-tag-audit-dev"
+  override def sectionAuditTableName: String = "tag-manager-section-audit-dev"
   override def clusterStatusTableName: String = "tag-manager-cluster-status-dev"
 
   override def tagUpdateStreamName: String = "tag-update-stream-dev"
+  override def sectionUpdateStreamName: String = "section-update-stream-dev"
   override def taggingOperationsStreamName: String = "tagging-operations-stream-dev"
 
   override def jobQueueName: String = "tag-manager-job-queue-dev"
@@ -124,9 +128,12 @@ class CodeConfig extends Config {
 
   override def jobTableName: String = "tag-manager-jobs-dev"
   override def tagAuditTableName: String = "tag-manager-tag-audit-dev"
+  override def sectionAuditTableName: String = "tag-manager-section-audit-dev"
   override def clusterStatusTableName: String = "tag-manager-cluster-status-dev"
 
   override def tagUpdateStreamName: String = "tag-update-stream-dev"
+  override def sectionUpdateStreamName: String = "section-update-stream-dev"
+
   override def taggingOperationsStreamName: String = "tagging-operations-stream-dev"
 
   override def jobQueueName: String = "tag-manager-job-queue-dev"
@@ -148,9 +155,11 @@ class ProdConfig extends Config {
 
   override def jobTableName: String = "tag-manager-jobs-PROD"
   override def tagAuditTableName: String = "tag-manager-tag-audit-PROD"
+  override def sectionAuditTableName: String = "tag-manager-section-audit-PROD"
   override def clusterStatusTableName: String = "tag-manager-cluster-status-PROD"
 
   override def tagUpdateStreamName: String = "tag-update-stream-PROD"
+  override def sectionUpdateStreamName: String = "section-update-stream-PROD"
   override def taggingOperationsStreamName: String = "tagging-operations-stream-PROD"
 
   override def jobQueueName: String = "tag-manager-job-queue-PROD"

--- a/conf/routes
+++ b/conf/routes
@@ -21,6 +21,9 @@ PUT        /api/tag/:id                   controllers.TagManagementApi.updateTag
 GET        /api/sections                  controllers.TagManagementApi.listSections
 GET        /api/section/:id               controllers.TagManagementApi.getSection(id: Long)
 PUT        /api/section/:id               controllers.TagManagementApi.updateSection(id: Long)
+POST       /api/section/:id/edition       controllers.TagManagementApi.addEditionToSection(id: Long)
+DELETE     /api/section/:id/edition/:editionName       controllers.TagManagementApi.removeEditionFromSection(id: Long, editionName: String)
+
 
 GET        /api/referenceTypes            controllers.TagManagementApi.listReferenceTypes
 

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,9 @@ GET        /merge                         controllers.App.index(id = "")
 GET        /status                        controllers.App.index(id = "")
 GET        /unauthorised                  controllers.App.index(id = "")
 GET        /mapping                       controllers.App.index(id = "")
+GET        /section                       controllers.App.index(id = "")
+GET        /section/:id                   controllers.App.index(id)
+
 
 # API
 GET        /api/tags                      controllers.TagManagementApi.searchTags

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "webpack": "^1.12.2"
   },
   "devDependencies": {
-    "eslint": "^1.7.3",
-    "eslint-plugin-react": "^3.6.3",
+    "eslint": "^1.10.3",
+    "eslint-plugin-react": "^3.13.1",
     "react-hot-loader": "^1.3.0",
     "webpack-dev-server": "^1.12.1"
   }

--- a/public/actions/SectionsActions/getSection.js
+++ b/public/actions/SectionsActions/getSection.js
@@ -1,0 +1,38 @@
+import tagManagerApi from '../../util/tagManagerApi';
+
+export const SECTION_GET_REQUEST = 'SECTION_GET_REQUEST';
+export const SECTION_GET_RECEIVE = 'SECTION_GET_RECEIVE';
+export const SECTION_GET_ERROR = 'SECTION_GET_ERROR';
+
+function requestSectionGet() {
+    return {
+        type:       SECTION_GET_REQUEST,
+        receivedAt: Date.now()
+    };
+}
+
+function receiveSectionGet(section) {
+    return {
+        type:       SECTION_GET_RECEIVE,
+        section:    section,
+        receivedAt: Date.now()
+    };
+}
+
+function errorSectionGet(error) {
+    return {
+        type:       SECTION_GET_ERROR,
+        message:    'Could not get section',
+        error:      error,
+        receivedAt: Date.now()
+    };
+}
+
+export function getSection(id) {
+    return dispatch => {
+        dispatch(requestSectionGet());
+        return tagManagerApi.getSection(id)
+            .then(res => dispatch(receiveSectionGet(res)))
+            .fail(error => dispatch(errorSectionGet(error)));
+    };
+}

--- a/public/actions/SectionsActions/saveSection.js
+++ b/public/actions/SectionsActions/saveSection.js
@@ -1,0 +1,38 @@
+import tagManagerApi from '../../util/tagManagerApi';
+
+export const SECTION_SAVE_REQUEST = 'SECTION_SAVE_REQUEST';
+export const SECTION_SAVE_RECEIVE = 'SECTION_SAVE_RECEIVE';
+export const SECTION_SAVE_ERROR = 'SECTION_SAVE_ERROR';
+
+function requestSectionSave() {
+    return {
+        type:       SECTION_SAVE_REQUEST,
+        receivedAt: Date.now()
+    };
+}
+
+function recieveSectionSave(section) {
+    return {
+        type:       SECTION_SAVE_RECEIVE,
+        section:    section,
+        receivedAt: Date.now()
+    };
+}
+
+function errorSectionSave(error) {
+    return {
+        type:       SECTION_SAVE_ERROR,
+        message:    'Could not save section',
+        error:      error,
+        receivedAt: Date.now()
+    };
+}
+
+export function saveSection(section) {
+    return dispatch => {
+        dispatch(requestSectionSave());
+        return tagManagerApi.saveSection(section.id, section)
+            .then(res => dispatch(recieveSectionSave(res)))
+            .fail(error => dispatch(errorSectionSave(error)));
+    };
+}

--- a/public/actions/SectionsActions/updateSection.js
+++ b/public/actions/SectionsActions/updateSection.js
@@ -1,0 +1,11 @@
+//NOTE: THIS DOESN'T SAVE THE SECTION, ONLY UPDATE THE CLIENT STATE. USE saveSection TO SAVE
+
+export const SECTION_UPDATE = 'SECTION_UPDATE';
+
+export function updateSection(section) {
+    return {
+        type:       SECTION_UPDATE,
+        section:    section,
+        receivedAt: Date.now()
+    };
+}

--- a/public/components/Header.react.js
+++ b/public/components/Header.react.js
@@ -29,6 +29,9 @@ export default class Header extends React.Component {
                 <div className="header__children">
                     <ul className="links">
                         <li className="links__item top-toolbar__item--highlight">
+                            <Link to="/section">Section Editor</Link>
+                        </li>
+                        <li className="links__item top-toolbar__item--highlight">
                             <Link to="/mapping">Mapping Manager</Link>
                         </li>
                         <li className="links__item top-toolbar__item--highlight">

--- a/public/components/MappingTable/MappingTable.react.js
+++ b/public/components/MappingTable/MappingTable.react.js
@@ -75,7 +75,7 @@ export default class MappingTable extends React.Component {
             </tr>
           </thead>
           <tbody>
-            {mappings.sort((a, b) => a.tagInternalName.toLowerCase > b.tagInternalName.toLowerCase).map((mapping) => {
+            {mappings.sort((a, b) => a.tagInternalName > b.tagInternalName ? 1 : -1).map((mapping) => {
               return (
                 <MappingTableRow
                   tagId={mapping.tagId}

--- a/public/components/SectionEdit/SectionAddEdition.react.js
+++ b/public/components/SectionEdit/SectionAddEdition.react.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import {allowedEditions} from '../../constants/allowedEditions';
+import tagManagerApi from '../../util/tagManagerApi';
+
+export default class SectionAddEdition extends React.Component {
+
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        adding: false
+      }
+    }
+
+    getNonSelectedEditions() {
+      return allowedEditions.filter(edition => this.props.section.editions[edition] === undefined);
+    }
+
+    addEdition(editionRegion) {
+      tagManagerApi.addEditionToSection(this.props.section.id, editionRegion).then((resp) => {
+        this.props.refreshSection();
+      });
+    }
+
+    render() {
+
+      if (this.props.disabled) {
+        return (
+          <div>
+            Save (or Reset) section updates before adding a region.
+          </div>
+        )
+      }
+
+      if (!this.getNonSelectedEditions().length) {
+        return false;
+      }
+
+      return (
+        <div className="section-edit__edition__add">
+          {this.getNonSelectedEditions().map((edition) => {
+            return (
+              <button onClick={this.addEdition.bind(this, edition)} key={edition}>Add a {edition} edition</button>
+            );
+          }, this)}
+        </div>
+      );
+    }
+}

--- a/public/components/SectionEdit/SectionEdit.react.js
+++ b/public/components/SectionEdit/SectionEdit.react.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import SectionName from './SectionName.react';
+import SectionEdition from './SectionEditions.react';
 import SaveButton from '../utils/SaveButton.react';
 
 class SectionEdit extends React.Component {
@@ -26,7 +27,12 @@ class SectionEdit extends React.Component {
 
     saveSection() {
       this.props.sectionActions.saveSection(this.props.section);
+    }
 
+    updateEditions(editions) {
+      this.props.sectionActions.updateSection(Object.assign({}, this.props.section, {
+        editions: editions
+      }));
     }
 
     render () {
@@ -43,12 +49,10 @@ class SectionEdit extends React.Component {
             <SectionName section={this.props.section} updateSection={this.props.sectionActions.updateSection} />
           </div>
           <div className="section-edit__column">
+            <SectionEdition editions={this.props.section.editions} updateEditions={this.updateEditions.bind(this)}/>
           </div>
-          <div className="section-edit__column">
-          </div>
-
+          <div className="section-edit__column"></div>
           <SaveButton isHidden={!this.isSectionDirty()} onSaveClick={this.saveSection.bind(this)} onResetClick={this.resetSection.bind(this)}/>
-
         </div>
       );
     }

--- a/public/components/SectionEdit/SectionEdit.react.js
+++ b/public/components/SectionEdit/SectionEdit.react.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import SectionName from './SectionName.react';
+import SaveButton from '../utils/SaveButton.react';
+
+class SectionEdit extends React.Component {
+
+    constructor(props) {
+      super(props);
+
+      this.isSectionDirty = this.isSectionDirty.bind(this);
+    }
+
+    componentDidMount() {
+      if (!this.props.section || this.props.section.id !== parseInt(this.props.routeParams.sectionId, 10)) {
+        this.props.sectionActions.getSection(this.props.routeParams.sectionId);
+      }
+    }
+
+    isSectionDirty() {
+      return this.props.saveState === 'SAVE_STATE_DIRTY';
+    }
+
+    resetSection() {
+      this.props.sectionActions.getSection(this.props.routeParams.sectionId);
+    }
+
+    saveSection() {
+      this.props.sectionActions.saveSection(this.props.section);
+
+    }
+
+    render () {
+
+      if (!this.props.section || this.props.section.id !== parseInt(this.props.routeParams.sectionId, 10)) {
+        return (
+          <div>Fetching section...</div>
+        );
+      }
+
+      return (
+        <div className="section-edit">
+          <div className="section-edit__column--sidebar">
+            <SectionName section={this.props.section} updateSection={this.props.sectionActions.updateSection} />
+          </div>
+          <div className="section-edit__column">
+          </div>
+          <div className="section-edit__column">
+          </div>
+
+          <SaveButton isHidden={!this.isSectionDirty()} onSaveClick={this.saveSection.bind(this)} onResetClick={this.resetSection.bind(this)}/>
+
+        </div>
+      );
+    }
+}
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as getSection from '../../actions/SectionsActions/getSection';
+import * as updateSection from '../../actions/SectionsActions/updateSection';
+import * as saveSection from '../../actions/SectionsActions/saveSection';
+
+function mapStateToProps(state) {
+  return {
+    section: state.section,
+    config: state.config,
+    saveState: state.saveState
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    sectionActions: bindActionCreators(Object.assign({}, getSection, updateSection, saveSection), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SectionEdit);

--- a/public/components/SectionEdit/SectionEdit.react.js
+++ b/public/components/SectionEdit/SectionEdit.react.js
@@ -49,7 +49,7 @@ class SectionEdit extends React.Component {
             <SectionName section={this.props.section} updateSection={this.props.sectionActions.updateSection} />
           </div>
           <div className="section-edit__column">
-            <SectionEdition editions={this.props.section.editions} updateEditions={this.updateEditions.bind(this)}/>
+            <SectionEdition section={this.props.section} updateEditions={this.updateEditions.bind(this)} saveState={this.props.saveState} refreshSection={this.resetSection.bind(this)}/>
           </div>
           <div className="section-edit__column"></div>
           <SaveButton isHidden={!this.isSectionDirty()} onSaveClick={this.saveSection.bind(this)} onResetClick={this.resetSection.bind(this)}/>

--- a/public/components/SectionEdit/SectionEditions.react.js
+++ b/public/components/SectionEdit/SectionEditions.react.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import R from 'ramda';
 
+import {allowedEditions} from '../../constants/allowedEditions';
+
 export default class SectionEdit extends React.Component {
 
     constructor(props) {
@@ -9,6 +11,20 @@ export default class SectionEdit extends React.Component {
 
     removeEdition(editionRegion) {
       this.props.updateEditions(R.omit([editionRegion], this.props.editions));
+    }
+
+    renderAddEdition() {
+      const nonSelectedEditions = allowedEditions.filter(edition => this.props.editions[edition] === undefined);
+
+      if (!nonSelectedEditions.length) {
+        return false;
+      }
+
+      return (
+        <div>
+          Possible to Add... {nonSelectedEditions.join(' ')}
+        </div>
+      );
     }
 
     renderEdition(editionRegion) {
@@ -26,11 +42,15 @@ export default class SectionEdit extends React.Component {
       );
     }
 
-    render () {
+    renderEditions() {
+
+      if (!Object.keys(this.props.editions).length) {
+        return false;
+      }
 
       return (
-        <table className="section-edit__editions">
-          <thead className="section-edit__editions__header">
+        <table>
+          <thead>
             <tr>
               <th>
                 Edition
@@ -41,10 +61,25 @@ export default class SectionEdit extends React.Component {
               <th></th>
             </tr>
           </thead>
-          <tbody className="section-edit__editions__body">
+          <tbody>
             {Object.keys(this.props.editions).map(this.renderEdition, this)}
           </tbody>
         </table>
+      );
+    }
+
+    render () {
+
+      return (
+        <div className="section-edit__editions">
+          <div className="section-edit__header">
+            International Editions
+          </div>
+          {this.renderEditions()}
+          <div className="section-edit__edition__add">
+            {this.renderAddEdition()}
+          </div>
+        </div>
       );
     }
 }

--- a/public/components/SectionEdit/SectionEditions.react.js
+++ b/public/components/SectionEdit/SectionEditions.react.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import R from 'ramda';
+
+export default class SectionEdit extends React.Component {
+
+    constructor(props) {
+      super(props);
+    }
+
+    removeEdition(editionRegion) {
+      this.props.updateEditions(R.omit([editionRegion], this.props.editions));
+    }
+
+    renderEdition(editionRegion) {
+
+      const edition = this.props.editions[editionRegion];
+
+      return (
+        <tr className="section-edit__editions__item" key={edition.path}>
+          <td>{editionRegion}</td>
+          <td>{edition.path}</td>
+          <td>
+            <i className="i-delete" onClick={this.removeEdition.bind(this, editionRegion)} />
+          </td>
+        </tr>
+      );
+    }
+
+    render () {
+
+      return (
+        <table className="section-edit__editions">
+          <thead className="section-edit__editions__header">
+            <tr>
+              <th>
+                Edition
+              </th>
+              <th>
+                Path
+              </th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody className="section-edit__editions__body">
+            {Object.keys(this.props.editions).map(this.renderEdition, this)}
+          </tbody>
+        </table>
+      );
+    }
+}

--- a/public/components/SectionEdit/SectionEditions.react.js
+++ b/public/components/SectionEdit/SectionEditions.react.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import R from 'ramda';
-
-import {allowedEditions} from '../../constants/allowedEditions';
+import SectionAddEdition from './SectionAddEdition.react';
+import tagManagerApi from '../../util/tagManagerApi';
 
 export default class SectionEdit extends React.Component {
 
@@ -10,26 +10,14 @@ export default class SectionEdit extends React.Component {
     }
 
     removeEdition(editionRegion) {
-      this.props.updateEditions(R.omit([editionRegion], this.props.editions));
-    }
-
-    renderAddEdition() {
-      const nonSelectedEditions = allowedEditions.filter(edition => this.props.editions[edition] === undefined);
-
-      if (!nonSelectedEditions.length) {
-        return false;
-      }
-
-      return (
-        <div>
-          Possible to Add... {nonSelectedEditions.join(' ')}
-        </div>
-      );
+      tagManagerApi.removeEditionFromSection(this.props.section.id, editionRegion).then((resp) => {
+        this.props.refreshSection();
+      });
     }
 
     renderEdition(editionRegion) {
 
-      const edition = this.props.editions[editionRegion];
+      const edition = this.props.section.editions[editionRegion];
 
       return (
         <tr className="section-edit__editions__item" key={edition.path}>
@@ -44,7 +32,7 @@ export default class SectionEdit extends React.Component {
 
     renderEditions() {
 
-      if (!Object.keys(this.props.editions).length) {
+      if (!Object.keys(this.props.section.editions).length) {
         return false;
       }
 
@@ -62,7 +50,7 @@ export default class SectionEdit extends React.Component {
             </tr>
           </thead>
           <tbody>
-            {Object.keys(this.props.editions).map(this.renderEdition, this)}
+            {Object.keys(this.props.section.editions).map(this.renderEdition, this)}
           </tbody>
         </table>
       );
@@ -76,9 +64,7 @@ export default class SectionEdit extends React.Component {
             International Editions
           </div>
           {this.renderEditions()}
-          <div className="section-edit__edition__add">
-            {this.renderAddEdition()}
-          </div>
+          <SectionAddEdition section={this.props.section} disabled={this.props.saveState === "SAVE_STATE_DIRTY"} refreshSection={this.props.refreshSection}/>
         </div>
       );
     }

--- a/public/components/SectionEdit/SectionName.react.js
+++ b/public/components/SectionEdit/SectionName.react.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+function slugify(text) {
+  return text ? text.toLowerCase().replace(/[^a-z0-9-]/g, '-') : '';
+}
+
+export default class SectionName extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  onUpdateName(e) {
+    this.props.updateSection(Object.assign({}, this.props.section, {
+      name: e.target.value
+    }));
+  }
+
+  render () {
+    if (!this.props.section) {
+      console.log('SectionEdit loaded without section provided');
+      return false;
+    }
+
+    return (
+      <div className="tag-edit__input-group">
+        <div className="tag-edit__name">
+          <label className="tag-edit__input-group__header">Name</label>
+          <input className="tag-edit__input" type="text" value={this.props.section.name} onChange={this.onUpdateName.bind(this)}/>
+          <div className="tag-edit__linked-field">
+            <div className={"tag-edit__linked-field__link--junction"}></div>
+            <div className={"tag-edit__linked-field__lock"}></div>
+            <label>Path</label>
+            <div className="tag-edit__linked-field__input-container">
+              <input type="text" value={this.props.section.path} disabled="true" />
+            </div>
+          </div>
+          <div className="tag-edit__linked-field">
+            <div className={"tag-edit__linked-field__link--corner"}></div>
+            <div className={"tag-edit__linked-field__lock"}></div>
+            <label>Slug</label>
+            <div className="tag-edit__linked-field__input-container">
+              <input type="text" value={this.props.section.wordsForUrl} disabled="true"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/public/components/SectionList/SectionList.react.js
+++ b/public/components/SectionList/SectionList.react.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import history from '../../routes/history';
+
+class SectionList extends React.Component {
+
+    constructor(props) {
+        super(props);
+    }
+
+    onSectionClick(section) {
+      history.replaceState(null, '/section/' + section.id);
+    }
+
+    componentDidMount() {
+
+      if (!this.props.sections || !this.props.sections.length) {
+        this.props.sectionActions.getSections();
+      }
+    }
+
+    renderListItem(section) {
+      return (
+        <tr key={section.id} className="taglist__results-item" onClick={this.onSectionClick.bind(this, section)}>
+          <td>{section.name}</td>
+          <td>{section.path}</td>
+          <td>{Object.keys(section.editions).length + ' editions'}</td>
+        </tr>
+      );
+    }
+
+    render () {
+
+      if (!this.props.sections || !this.props.sections.length) {
+        return (
+          <div>Fetching sections...</div>
+        );
+      }
+
+      return (
+        <table className="sectionlist">
+          <thead className="sectionlist__header">
+            <tr>
+              <th>Name</th>
+              <th>Path</th>
+              <th>Editionalised</th>
+            </tr>
+          </thead>
+          <tbody className="sectionlist__results">
+            {this.props.sections.sort((a, b) => a.name > b.name ? 1 : -1).map(this.renderListItem, this)}
+          </tbody>
+        </table>
+      );
+    }
+}
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as getSections from '../../actions/SectionsActions/getSections';
+
+function mapStateToProps(state) {
+  return {
+    sections: state.sections,
+    config: state.config
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    sectionActions: bindActionCreators(Object.assign({}, getSections), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SectionList);

--- a/public/components/TagContext/TagReferences/TagReferences.react.js
+++ b/public/components/TagContext/TagReferences/TagReferences.react.js
@@ -60,7 +60,7 @@ export default class TagReferences extends React.Component {
               </tr>
             </thead>
             <tbody className="tag-references__references">
-              {this.props.tag.externalReferences.sort((a, b) => a.type > b.type).map(this.renderReference, this)}
+              {this.props.tag.externalReferences.sort((a, b) => a.type > b.type ? 1 : -1).map(this.renderReference, this)}
               <tr>
                 <td colSpan="3" className="tag-references__addrow">
                   <AddReference onAddReference={this.addReference.bind(this)} referenceTypes={this.props.referenceTypes} />

--- a/public/constants/allowedEditions.js
+++ b/public/constants/allowedEditions.js
@@ -1,0 +1,5 @@
+export const allowedEditions = [
+  'UK',
+  'US',
+  'AU'
+];

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -2,6 +2,9 @@ import {TAG_GET_REQUEST, TAG_GET_RECEIVE, TAG_GET_ERROR} from '../actions/TagAct
 import {TAG_UPDATE} from '../actions/TagActions/updateTag';
 import {TAG_SAVE_REQUEST, TAG_SAVE_RECEIVE, TAG_SAVE_ERROR} from '../actions/TagActions/saveTag';
 import {SECTIONS_GET_REQUEST, SECTIONS_GET_RECEIVE, SECTIONS_GET_ERROR} from '../actions/SectionsActions/getSections';
+import {SECTION_GET_REQUEST, SECTION_GET_RECEIVE, SECTION_GET_ERROR} from '../actions/SectionsActions/getSection';
+import {SECTION_UPDATE} from '../actions/SectionsActions/updateSection';
+import {SECTION_SAVE_REQUEST, SECTION_SAVE_RECEIVE, SECTION_SAVE_ERROR} from '../actions/SectionsActions/saveSection';
 import {REFERENCE_TYPES_GET_REQUEST, REFERENCE_TYPES_GET_RECEIVE, REFERENCE_TYPES_GET_ERROR} from '../actions/ReferenceTypeActions/getReferenceTypes';
 import {TAG_POPULATE_BLANK} from '../actions/TagActions/createTag';
 import {CAPI_SEARCH_RECEIVE, CAPI_SEARCH_REQUEST, CAPI_FILTERS_UPDATE} from '../actions/CapiActions/searchCapi';
@@ -93,6 +96,48 @@ export default function tag(state = {
       sections: action.sections
     });
   case SECTIONS_GET_ERROR:
+    return Object.assign({}, state, {
+      error: action.message
+    });
+
+// SECTION GET
+
+  case SECTION_GET_REQUEST:
+    return Object.assign({}, state, {
+      section: false,
+      saveState: undefined
+    });
+  case SECTION_GET_RECEIVE:
+    return Object.assign({}, state, {
+      section: action.section,
+      saveState: saveState.clean
+    });
+  case SECTION_GET_ERROR:
+    return Object.assign({}, state, {
+      error: action.message,
+      saveState: undefined
+    });
+
+// SECTION UPDATE
+
+  case SECTION_UPDATE:
+    return Object.assign({}, state, {
+      section: action.section,
+      saveState: saveState.dirty
+    });
+
+// SECTION SAVE
+
+  case SECTION_SAVE_REQUEST:
+    return Object.assign({}, state, {
+      saveState: saveState.inprogress
+    });
+  case SECTION_SAVE_RECEIVE:
+    return Object.assign({}, state, {
+      section: action.section,
+      saveState: saveState.clean
+    });
+  case SECTION_SAVE_ERROR:
     return Object.assign({}, state, {
       error: action.message
     });

--- a/public/routes/routes.js
+++ b/public/routes/routes.js
@@ -11,6 +11,9 @@ import Status       from '../components/Status.react';
 import TagSearch    from '../components/TagSearch.react';
 import Unauthorised from '../components/Unauthorised.react';
 
+import SectionList from '../components/SectionList/SectionList.react';
+import SectionEdit from '../components/SectionEdit/SectionEdit.react';
+
 import {getStore}   from '../util/storeAccessor';
 
 function requirePermission(permissionName, nextState, replaceState) {
@@ -28,6 +31,9 @@ export default [
         <Route name="mapping" path="/mapping" component={MappingManager} />
         <Route name="merge" path="/merge" component={MergeTag} />
         <Route name="status" path="/status" component={Status} />
+        <Route name="sectionList" path="/section" component={SectionList} />
+        <Route name="sectionEdit" path="/section/:sectionId" component={SectionEdit} />
+
         <Route name="unauthorised" path="/unauthorised" component={Unauthorised} />
         <IndexRoute component={TagSearch}/>
     </Route>

--- a/public/style/components/section-edit/_index.scss
+++ b/public/style/components/section-edit/_index.scss
@@ -49,3 +49,16 @@
   border: 1px solid $c-grey-300;
 
 }
+
+.section-edit__header {
+  @extend %f-header;
+  @extend %fs-data-4;
+
+  font-weight: bold;
+
+  margin-bottom: $standard-padding;
+}
+
+.section-edit__editions {
+  padding: 10px;
+}

--- a/public/style/components/section-edit/_index.scss
+++ b/public/style/components/section-edit/_index.scss
@@ -1,0 +1,51 @@
+.section-edit {
+  display: flex;
+
+  height: calc(100vh - #{$size-header-height});
+}
+
+.section-edit__column {
+  @extend %tag__column;
+}
+
+.section-edit__column--sidebar {
+  @extend %tag__column;
+  background-color: $c-grey-200;
+
+  flex: 1 0 370px;
+
+}
+
+.section-edit__input-group {
+  padding: $standard-padding * 1.5;
+  border-bottom: 1px solid $c-grey-300;
+
+  select {
+    margin-top: $tag-edit-padding;
+    width: 100%;
+  }
+
+  textarea {
+    width: 100%;
+    min-height: 50px;
+  }
+}
+
+.section-edit__input-group__header {
+  @extend %f-header;
+  @extend %fs-data-4;
+
+  font-weight: bold;
+
+  display: block;
+
+}
+
+.section-edit__input {
+  width: 100%;
+  display: block;
+  background-color: $c-white;
+  padding: $standard-padding;
+  border: 1px solid $c-grey-300;
+
+}

--- a/public/style/components/section-list/_index.scss
+++ b/public/style/components/section-list/_index.scss
@@ -1,0 +1,9 @@
+.sectionlist {
+  max-width: 800px;
+  margin: 0 auto;
+  margin-top: 80px;
+  padding: $standard-padding;
+
+  border-top: 1px solid $c-grey-300;
+
+}

--- a/public/style/main.scss
+++ b/public/style/main.scss
@@ -27,3 +27,5 @@
 @import "components/job-status/index";
 @import "components/mapping/index";
 @import "components/tag-audit/index";
+@import "components/section-list/index";
+@import "components/section-edit/index";

--- a/public/util/tagManagerApi.js
+++ b/public/util/tagManagerApi.js
@@ -36,6 +36,23 @@ export default {
     });
   },
 
+  getSection: (id) => {
+    return Reqwest({
+      url: '/api/section/' + id,
+      method: 'get',
+      type: 'json'
+    });
+  },
+
+  saveSection: (id, section) => {
+    return Reqwest({
+        url: '/api/section/' + id,
+        data: JSON.stringify(section),
+        contentType: 'application/json',
+        method: 'put'
+    });
+  },
+
   getReferenceTypes: () => {
     return Reqwest({
       url: '/api/referenceTypes',

--- a/public/util/tagManagerApi.js
+++ b/public/util/tagManagerApi.js
@@ -53,6 +53,23 @@ export default {
     });
   },
 
+  addEditionToSection: (sectionId, editionName) => {
+    return Reqwest({
+        url: '/api/section/' + sectionId + '/edition',
+        data: JSON.stringify({editionName: editionName}),
+        contentType: 'application/json',
+        method: 'post'
+    });
+  },
+
+  removeEditionFromSection: (sectionId, editionName) => {
+    return Reqwest({
+        url: '/api/section/' + sectionId + '/edition/' + editionName,
+        contentType: 'application/json',
+        method: 'delete'
+    });
+  },
+
   getReferenceTypes: () => {
     return Reqwest({
       url: '/api/referenceTypes',

--- a/thrift/sectionEvent.thrift
+++ b/thrift/sectionEvent.thrift
@@ -1,0 +1,19 @@
+include "section.thrift"
+
+namespace scala com.gu.tagmanagement
+
+enum EventType {
+    UPDATE = 0,
+    DELETE = 1
+}
+
+struct SectionEvent {
+    /** the type of this event */
+    1: required EventType eventType;
+
+    /** the tag's id */
+    2: required i64 sectionId;
+
+    /** the full representation of the section's state */
+    3: optional section.Section section;
+}


### PR DESCRIPTION
This adds sections editing and editions to the tagmanager.

Sections can be viewed at https://tagmanager.local.dev-gutools.co.uk/section and can be edited at https://tagmanager.local.dev-gutools.co.uk/section/<section id> 

Currently only the section name can be edited. This like the tags can then be saved or reset, and have full tag-like auditing.

![screen shot 2016-01-05 at 15 34 12](https://cloud.githubusercontent.com/assets/551573/12119134/cd9e8886-b3c1-11e5-8eae-449f2d2c1bc9.png)

Any international editions are shown along with paths, these can be delete or added to, each of these operations contacting a new endpoint directly, so pathmanager updates can be handled (without diff-ing editions on each update)

![screen shot 2016-01-05 at 15 33 56](https://cloud.githubusercontent.com/assets/551573/12119128/c25858d0-b3c1-11e5-8d10-8def06e42847.png)
