### PR TITLE
XML Dump of all tags for inCopy to use

### DIFF
--- a/app/controllers/ReadOnly.scala
+++ b/app/controllers/ReadOnly.scala
@@ -6,7 +6,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 import repositories._
 
-object ReadOnly extends Controller {
+object ReadOnlyApi extends Controller {
   def getTagsAsXml() = Action.async {
     Future(TagLookupCache.allTags.get.map(_.asXml)) map { tags =>
       Ok(<tags>

--- a/app/controllers/ReadOnly.scala
+++ b/app/controllers/ReadOnly.scala
@@ -1,0 +1,17 @@
+package controllers
+
+import play.api.mvc.{Action, Controller}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import repositories._
+
+object ReadOnly extends Controller {
+  def getTagsAsXml() = Action.async {
+    Future(TagLookupCache.allTags.get.map(_.asXml)) map { tags =>
+      Ok(<tags>
+        {tags.seq.map { x => x }}
+        </tags>)
+    }
+  }
+}

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -1,5 +1,4 @@
 package controllers
-
 import model.command.CommandError._
 import model.command.{BatchTagCommand, PathUsageCheck, CreateTagCommand, UpdateTagCommand}
 import model.jobs.{BatchTagAddCompleteCheck, Job}
@@ -142,7 +141,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def getTagsAsXml() = APIAuthAction.async {
-    Future(TagRepository.loadAllTags.seq.map(_.asXml)) map { tags =>
+    Future(TagLookupCache.allTags.get.map(_.asXml)) map { tags =>
       Ok(<tags>
         {tags.seq.map { x => x }}
         </tags>)

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -131,8 +131,8 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   def getAuditForOperation(op: String) = APIAuthAction { req =>
     Ok(Json.toJson(TagAuditRepository.getRecentAuditOfOperation(op)))
   }
-  
-  def getJobs(tagIdParam: Option[Long]) = APIAuthAction { 
+
+  def getJobs(tagIdParam: Option[Long]) = APIAuthAction {
     val jobs = tagIdParam match {
       case Some(tagId) => JobRepository.findJobsForTag(tagId)
       case None => JobRepository.loadAllJobs
@@ -140,4 +140,10 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     Ok(Json.toJson(jobs))
   }
 
+  def getTagsAsXml() = APIAuthAction {
+    val tagsAsXml = TagRepository.loadAllTags.seq.map(_.asXml)
+    Ok(<tags>
+      {tagsAsXml.seq.map { x => x }}
+      </tags>)
+  }
 }

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -11,8 +11,6 @@ import play.api.libs.json._
 import play.api.mvc.{Action, Controller}
 import repositories._
 import permissions.BatchTagPermissionsCheck
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object TagManagementApi extends Controller with PanDomainAuthActions {
 
@@ -140,11 +138,4 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     Ok(Json.toJson(jobs))
   }
 
-  def getTagsAsXml() = APIAuthAction.async {
-    Future(TagLookupCache.allTags.get.map(_.asXml)) map { tags =>
-      Ok(<tags>
-        {tags.seq.map { x => x }}
-        </tags>)
-    }
-  }
 }

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -12,7 +12,8 @@ import play.api.libs.json._
 import play.api.mvc.{Action, Controller}
 import repositories._
 import permissions.BatchTagPermissionsCheck
-
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object TagManagementApi extends Controller with PanDomainAuthActions {
 
@@ -140,10 +141,11 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     Ok(Json.toJson(jobs))
   }
 
-  def getTagsAsXml() = APIAuthAction {
-    val tagsAsXml = TagRepository.loadAllTags.seq.map(_.asXml)
-    Ok(<tags>
-      {tagsAsXml.seq.map { x => x }}
-      </tags>)
+  def getTagsAsXml() = APIAuthAction.async {
+    Future(TagRepository.loadAllTags.seq.map(_.asXml)) map { tags =>
+      Ok(<tags>
+        {tags.seq.map { x => x }}
+        </tags>)
+    }
   }
 }

--- a/app/model/ContributorInformation.scala
+++ b/app/model/ContributorInformation.scala
@@ -19,6 +19,13 @@ case class ContributorInformation(
     twitterHandle =     twitterHandle,
     contactEmail =      contactEmail
   )
+  def asXml = {
+    <rcsId>{this.rcsId.getOrElse("")}</rcsId>
+    <bylineImage>{this.bylineImage.map(_.asXml).getOrElse("")}</bylineImage>
+    <largeBylineImage>{this.largeBylineImage.map(_.asXml).getOrElse("")}</largeBylineImage>
+    <twitterHandle>{this.twitterHandle.getOrElse("")}</twitterHandle>
+    <contactEmail>{this.contactEmail.getOrElse("")}</contactEmail>
+  }
 }
 
 object ContributorInformation {
@@ -40,4 +47,3 @@ object ContributorInformation {
       contactEmail =      thriftContributorInformation.contactEmail
     )
 }
-

--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -24,6 +24,17 @@ case class PodcastMetadata( linkUrl: String,
     explicit =          explicit,
     image =             image.map(_.asThrift)
   )
+
+  def asXml = {
+    <linkUrl>{this.linkUrl}</linkUrl>
+    <copyrightText>{this.copyrightText.getOrElse("")}</copyrightText>
+    <authorText>{this.authorText.getOrElse("")}</authorText>
+    <iTunesUrl>{this.iTunesUrl.getOrElse("")}</iTunesUrl>
+    <iTunesBlock>{this.iTunesBlock}</iTunesBlock>
+    <clean>{this.clean}</clean>
+    <explicit>{this.explicit}</explicit>
+    <image>{this.image.map(x => x.asXml).getOrElse("")}</image>
+  }
 }
 
 object PodcastMetadata {
@@ -51,4 +62,3 @@ object PodcastMetadata {
       image =             thriftPodcastMetadata.image.map(Image(_))
     )
 }
-

--- a/app/model/Reference.scala
+++ b/app/model/Reference.scala
@@ -7,6 +7,10 @@ import com.gu.tagmanagement.{Reference => ThriftReference}
 
 case class Reference(`type`: String, value: String) {
   def asThrift = ThriftReference(`type`, value)
+  def asXml = {<reference>
+               <type>{this.`type`}</type>
+               <value>{this.value}</value>
+               </reference>}
 }
 
 object Reference {

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -48,6 +48,28 @@ case class Tag(
     podcastMetadata   = podcastMetadata.map(_.asThrift),
     contributorInformation = contributorInformation.map(_.asThrift)
   )
+
+  def asXml = {
+      <tag>
+      <id>{this.id}</id>
+      <path>{this.path}</path>
+      <pageId>{this.pageId}</pageId>
+      <type>{this.`type`}</type>
+      <internalName>{this.internalName}</internalName>
+      <externalName>{this.externalName}</externalName>
+      <slug>{this.slug}</slug>
+      <hidden>{this.hidden}</hidden>
+      <legallySensitive>{this.legallySensitive}</legallySensitive>
+      <comparableValue>{this.comparableValue}</comparableValue>
+      <section>{this.section.getOrElse("")}</section>
+      <description>{this.description.getOrElse("")}</description>
+      <parents>{this.parents}</parents>
+      <references>{this.references.map(_.asXml)}</references>
+      <podcastMetadata>{this.podcastMetadata.map(_.asXml).getOrElse("")}</podcastMetadata>
+    <contributorInformation>{this.contributorInformation.getOrElse("")}</contributorInformation>
+      </tag>
+  }
+
 }
 
 object Tag {

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -66,7 +66,7 @@ case class Tag(
       <parents>{this.parents}</parents>
       <references>{this.references.map(_.asXml)}</references>
       <podcastMetadata>{this.podcastMetadata.map(_.asXml).getOrElse("")}</podcastMetadata>
-    <contributorInformation>{this.contributorInformation.getOrElse("")}</contributorInformation>
+    <contributorInformation>{this.contributorInformation.map(_.asXml).getOrElse("")}</contributorInformation>
       </tag>
   }
 

--- a/app/model/image.scala
+++ b/app/model/image.scala
@@ -10,6 +10,10 @@ case class Image(imageId: String, assets: List[ImageAsset]) {
     imageId = imageId,
     assets = assets.map(_.asThrift)
   )
+  def asXml = {
+    <imageId>{this.imageId}</imageId>
+    <assets>{this.assets.map(_.asXml)}</assets>
+  }
 }
 
 object Image {
@@ -29,6 +33,12 @@ object Image {
 
 case class ImageAsset(imageUrl: String, width: Long, height: Long, mimeType: String) {
   def asThrift = ThriftImageAsset(imageUrl, width, height, mimeType)
+  def asXml = {<imageAsset>
+    <imageUrl>{this.imageUrl}</imageUrl>
+    <width>{this.width}</width>
+    <height>{this.height}</height>
+    <mimeType>{this.mimeType}</mimeType>
+    </imageAsset>}
 }
 
 object ImageAsset {

--- a/conf/routes
+++ b/conf/routes
@@ -29,7 +29,7 @@ GET        /api/audit/operation/:op       controllers.TagManagementApi.getAuditF
 
 GET        /api/jobs                      controllers.TagManagementApi.getJobs(tagId: Option[Long])
 
-GET        /api/xml                       controllers.ReadOnly.getTagsAsXml
+GET        /api/xml                       controllers.ReadOnlyApi.getTagsAsXml
 
 GET        /hello                         controllers.App.hello
 GET        /testScan                      controllers.App.testScan

--- a/conf/routes
+++ b/conf/routes
@@ -29,7 +29,7 @@ GET        /api/audit/operation/:op       controllers.TagManagementApi.getAuditF
 
 GET        /api/jobs                      controllers.TagManagementApi.getJobs(tagId: Option[Long])
 
-
+GET        /api/xml                       controllers.TagManagementApi.getTagsAsXml
 
 GET        /hello                         controllers.App.hello
 GET        /testScan                      controllers.App.testScan

--- a/conf/routes
+++ b/conf/routes
@@ -29,7 +29,7 @@ GET        /api/audit/operation/:op       controllers.TagManagementApi.getAuditF
 
 GET        /api/jobs                      controllers.TagManagementApi.getJobs(tagId: Option[Long])
 
-GET        /api/xml                       controllers.TagManagementApi.getTagsAsXml
+GET        /api/xml                       controllers.ReadOnly.getTagsAsXml
 
 GET        /hello                         controllers.App.hello
 GET        /testScan                      controllers.App.testScan


### PR DESCRIPTION
This adds a route that adds a dump of all the tags in XML format. I haven't done the from time method yet as that will require a bit more work and we wanted to find out how much it was used (\cc @blishen)

