### PR TITLE
Sw merge tag

### DIFF
--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import model.command.CommandError._
-import model.command.{BatchTagCommand, PathUsageCheck, CreateTagCommand, UpdateTagCommand}
+import model.command._
 import model.jobs.{BatchTagAddCompleteCheck, Job}
 import org.joda.time.DateTime
 import play.api.Logger
@@ -111,6 +111,32 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     req.body.asJson.map { json =>
       try {
         json.as[BatchTagCommand].process.map{t => NoContent } getOrElse NotFound
+      } catch {
+        commandErrorAsResult
+      }
+    }.getOrElse {
+      BadRequest("Expecting Json data")
+    }
+  }
+
+  def mergeTag = APIAuthAction { req =>
+    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    req.body.asJson.map { json =>
+      try {
+        json.as[MergeTagCommand].process.map{t => NoContent } getOrElse NotFound
+      } catch {
+        commandErrorAsResult
+      }
+    }.getOrElse {
+      BadRequest("Expecting Json data")
+    }
+  }
+
+  def deleteTag(id: Long)= APIAuthAction { req =>
+    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    req.body.asJson.map { json =>
+      try {
+        (new DeleteTagCommand(id)).process.map{t => NoContent } getOrElse NotFound
       } catch {
         commandErrorAsResult
       }

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -21,7 +21,8 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def updateTag(id: Long) = APIAuthAction { req =>
-    implicit val user = Option(req.user)
+    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+
     req.body.asJson.map { json =>
       try {
         UpdateTagCommand(json.as[Tag]).process.map{t => Ok(Json.toJson(t)) } getOrElse NotFound
@@ -34,7 +35,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def createTag() = APIAuthAction { req =>
-    implicit val user = Option(req.user)
+    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
     req.body.asJson.map { json =>
       try {
         json.as[CreateTagCommand].process.map{t => Ok(Json.toJson(t)) } getOrElse NotFound
@@ -106,7 +107,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def batchTag = APIAuthAction { req =>
-    implicit val user = Option(req.user)
+    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
     req.body.asJson.map { json =>
       try {
         json.as[BatchTagCommand].process.map{t => NoContent } getOrElse NotFound

--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -52,6 +52,10 @@ object TagAudit {
     TagAudit(tag.id, "updated", new DateTime(), user.map(_.email).getOrElse("default user"), s"tag '${tag.internalName}' updated", TagSummary(tag), None)
   }
 
+  def deleted(tag: Tag, user: Option[User] = None): TagAudit = {
+    TagAudit(tag.id, "deleted", new DateTime(), user.map(_.email).getOrElse("default user"), s"tag '${tag.internalName}' deleted", TagSummary(tag), None)
+  }
+
   def batchTag(tag: Tag, operation: String, contentCount: Int)(implicit user: Option[User] = None): TagAudit = {
     val message = operation match {
       case "remove" => s"tag '${tag.internalName}' removed from $contentCount items(s)"

--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -44,16 +44,16 @@ object TagAudit {
     }
   }
 
-  def created(tag: Tag)(implicit user: Option[User] = None): TagAudit = {
-    TagAudit(tag.id, "created", new DateTime(), user.map(_.email).getOrElse("default user"), s"tag '${tag.internalName}' created", TagSummary(tag), None)
+  def created(tag: Tag)(implicit username: Option[String] = None): TagAudit = {
+    TagAudit(tag.id, "created", new DateTime(), username.getOrElse("default user"), s"tag '${tag.internalName}' created", TagSummary(tag), None)
   }
 
-  def updated(tag: Tag)(implicit user: Option[User] = None): TagAudit = {
-    TagAudit(tag.id, "updated", new DateTime(), user.map(_.email).getOrElse("default user"), s"tag '${tag.internalName}' updated", TagSummary(tag), None)
+  def updated(tag: Tag)(implicit username: Option[String] = None): TagAudit = {
+    TagAudit(tag.id, "updated", new DateTime(), username.getOrElse("default user"), s"tag '${tag.internalName}' updated", TagSummary(tag), None)
   }
 
-  def deleted(tag: Tag, user: Option[User] = None): TagAudit = {
-    TagAudit(tag.id, "deleted", new DateTime(), user.map(_.email).getOrElse("default user"), s"tag '${tag.internalName}' deleted", TagSummary(tag), None)
+  def deleted(tag: Tag, username: Option[String] = None): TagAudit = {
+    TagAudit(tag.id, "deleted", new DateTime(), username.getOrElse("default user"), s"tag '${tag.internalName}' deleted", TagSummary(tag), None)
   }
 
   def batchTag(tag: Tag, operation: String, contentCount: Int)(implicit user: Option[User] = None): TagAudit = {

--- a/app/model/command/BatchTagCommand.scala
+++ b/app/model/command/BatchTagCommand.scala
@@ -1,6 +1,5 @@
 package model.command
 
-import com.gu.pandomainauth.model.User
 import com.gu.tagmanagement.{TagWithSection, OperationType, TaggingOperation}
 import model.TagAudit
 import model.jobs.{BatchTagAddCompleteCheck, BatchTagRemoveCompleteCheck, Job}

--- a/app/model/command/BatchTagCommand.scala
+++ b/app/model/command/BatchTagCommand.scala
@@ -15,7 +15,7 @@ import services.{SQS, KinesisStreams}
 case class BatchTagCommand(contentIds: List[String], tagId: Long, operation: String) extends Command {
   type T = Long
 
-  override def process()(implicit user: Option[User] = None): Option[Long] = {
+  override def process()(implicit username: Option[String] = None): Option[Long] = {
     val tag = TagRepository.getTag(tagId) getOrElse(TagNotFound)
     val section = tag.section.flatMap( SectionRepository.getSection(_) )
 
@@ -33,7 +33,7 @@ case class BatchTagCommand(contentIds: List[String], tagId: Long, operation: Str
       id = Sequences.jobId.getNextId,
       `type` = "Batch tag",
       started = new DateTime,
-      startedBy = user.map(_.email),
+      startedBy = username,
       tagIds = List(tagId),
       command = this,
       steps = operation match {

--- a/app/model/command/Command.scala
+++ b/app/model/command/Command.scala
@@ -17,6 +17,7 @@ object Command {
   val commandWrites = new Writes[Command] {
     override def writes(c: Command): JsValue = c match {
       case b: BatchTagCommand => BatchTagCommand.batchTagCommandFormat.writes(b).asInstanceOf[JsObject] + ("type", JsString("BatchTagCommand"))
+      case m: MergeTagCommand => MergeTagCommand.mergeTagCommandFormat.writes(m).asInstanceOf[JsObject] + ("type", JsString("MergeTagCommand"))
       case other => {
         Logger.warn(s"unable to serialise command of type ${other.getClass}")
         throw new UnsupportedOperationException(s"unable to serialise command of type ${other.getClass}")
@@ -28,6 +29,7 @@ object Command {
     override def reads(json: JsValue): JsResult[Command] = {
       (json \ "type").get match {
         case JsString("BatchTagCommand") => BatchTagCommand.batchTagCommandFormat.reads(json)
+        case JsString("MergeTagCommand") => MergeTagCommand.mergeTagCommandFormat.reads(json)
         case JsString(other) => JsError(s"unsupported command type $other}")
         case _ => JsError(s"unexpected command type value")
       }

--- a/app/model/command/Command.scala
+++ b/app/model/command/Command.scala
@@ -1,6 +1,5 @@
 package model.command
 
-import com.gu.pandomainauth.model.User
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.functional.syntax._

--- a/app/model/command/Command.scala
+++ b/app/model/command/Command.scala
@@ -8,7 +8,7 @@ import play.api.libs.functional.syntax._
 trait Command {
   type T
 
-  def process()(implicit user: Option[User] = None): Option[T]
+  def process()(implicit username: Option[String] = None): Option[T]
 
 }
 

--- a/app/model/command/Command.scala
+++ b/app/model/command/Command.scala
@@ -18,6 +18,7 @@ object Command {
     override def writes(c: Command): JsValue = c match {
       case b: BatchTagCommand => BatchTagCommand.batchTagCommandFormat.writes(b).asInstanceOf[JsObject] + ("type", JsString("BatchTagCommand"))
       case m: MergeTagCommand => MergeTagCommand.mergeTagCommandFormat.writes(m).asInstanceOf[JsObject] + ("type", JsString("MergeTagCommand"))
+      case d: DeleteTagCommand => JsObject(Map("type" -> JsString("DeleteTagCommand"), "removingTagId" -> JsNumber(d.removingTagId)))
       case other => {
         Logger.warn(s"unable to serialise command of type ${other.getClass}")
         throw new UnsupportedOperationException(s"unable to serialise command of type ${other.getClass}")
@@ -30,6 +31,7 @@ object Command {
       (json \ "type").get match {
         case JsString("BatchTagCommand") => BatchTagCommand.batchTagCommandFormat.reads(json)
         case JsString("MergeTagCommand") => MergeTagCommand.mergeTagCommandFormat.reads(json)
+        case JsString("DeleteTagCommand") => (json \ "removingTagId").validate[Long].map(DeleteTagCommand)
         case JsString(other) => JsError(s"unsupported command type $other}")
         case _ => JsError(s"unexpected command type value")
       }

--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -30,7 +30,7 @@ case class CreateTagCommand(
 
   type T = Tag
 
-  def process()(implicit user: Option[User] = None): Option[Tag] = {
+  def process()(implicit username: Option[String] = None): Option[Tag] = {
 
     val calculatedPath = TagPathCalculator.calculatePath(`type`, slug, section)
 

--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -1,6 +1,5 @@
 package model.command
 
-import com.gu.pandomainauth.model.User
 import com.gu.tagmanagement.{EventType, TagEvent}
 import model.command.logic.TagPathCalculator
 import model.{TagAudit, PodcastMetadata, Tag, Reference}

--- a/app/model/command/DeleteTagCommand.scala
+++ b/app/model/command/DeleteTagCommand.scala
@@ -1,0 +1,64 @@
+package model.command
+
+import com.gu.tagmanagement.{TagWithSection, OperationType, TaggingOperation}
+import model.command.CommandError._
+import model.jobs.{TagRemovedCheck, RemoveTagStep, AllUsagesOfTagRemovedCheck, Job}
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Format}
+import repositories._
+import services.{SQS, KinesisStreams}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+case class DeleteTagCommand(removingTagId: Long) extends Command {
+  override type T = Long
+
+  override def process()(implicit username: Option[String] = None): Option[T] = {
+    val removingTag = TagRepository.getTag(removingTagId) getOrElse(TagNotFound)
+    val removingTagSection = removingTag.section.flatMap( SectionRepository.getSection(_) )
+
+    val jobId = Sequences.jobId.getNextId
+
+    Future {
+
+      val contentIds = ContentAPI.getContentIdsForTag(removingTag.path)
+
+      val deleteTagJob = Job(
+        id = jobId,
+        `type` = "Delete tag",
+        started = new DateTime,
+        startedBy = username,
+        tagIds = List(removingTagId),
+        command = this,
+        steps = List(
+          AllUsagesOfTagRemovedCheck(removingTag.path, contentIds.length),
+          RemoveTagStep(removingTagId, username),
+          TagRemovedCheck(removingTag.path)
+        )
+      )
+
+      Logger.info(s"raising job to check deleting ${removingTag.path}  completes")
+      JobRepository.upsertJob(deleteTagJob)
+      SQS.jobQueue.postMessage(deleteTagJob.id.toString, delaySeconds = 15)
+
+
+      contentIds foreach { contentPath =>
+        val taggingOperation = TaggingOperation(
+          operation = OperationType.Remove,
+          contentPath = contentPath,
+          tag = Some(TagWithSection(removingTag.asThrift, removingTagSection.map(_.asThrift)))
+        )
+        Logger.info(s"raising delete tag ${removingTag.path} for content $contentPath")
+        KinesisStreams.taggingOperationsStream.publishUpdate(contentPath.take(200), taggingOperation)
+      }
+    }
+
+    Some(jobId)
+
+  }
+}
+

--- a/app/model/command/MergeTagCommand.scala
+++ b/app/model/command/MergeTagCommand.scala
@@ -1,0 +1,74 @@
+package model.command
+
+import com.gu.tagmanagement.{TagWithSection, OperationType, TaggingOperation}
+import model.command.CommandError._
+import model.jobs.{TagRemovedCheck, RemoveTagStep, AllUsagesOfTagRemovedCheck, Job}
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Format}
+import repositories._
+import services.{SQS, KinesisStreams}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+case class MergeTagCommand(removingTagId: Long, replacementTagId: Long) extends Command {
+  override type T = Long
+
+  override def process()(implicit username: Option[String] = None): Option[T] = {
+    val removingTag = TagRepository.getTag(removingTagId) getOrElse(TagNotFound)
+    val removingTagSection = removingTag.section.flatMap( SectionRepository.getSection(_) )
+
+    val replacementTag = TagRepository.getTag(replacementTagId) getOrElse(TagNotFound)
+    val replacementTagSection = replacementTag.section.flatMap( SectionRepository.getSection(_) )
+
+    val jobId = Sequences.jobId.getNextId
+
+    Future {
+
+      val contentIds = ContentAPI.getContentIdsForTag(removingTag.path)
+
+      val mergeTagJob = Job(
+        id = jobId,
+        `type` = "Merge tag",
+        started = new DateTime,
+        startedBy = username,
+        tagIds = List(removingTagId, replacementTagId),
+        command = this,
+        steps = List(
+          AllUsagesOfTagRemovedCheck(removingTag.path, contentIds.length),
+          RemoveTagStep(removingTagId, username),
+          TagRemovedCheck(removingTag.path)
+        )
+      )
+
+      Logger.info(s"raising job to check merging ${removingTag.path} into ${replacementTag.path} completes")
+      JobRepository.upsertJob(mergeTagJob)
+      SQS.jobQueue.postMessage(mergeTagJob.id.toString, delaySeconds = 15)
+
+
+      contentIds foreach { contentPath =>
+        val taggingOperation = TaggingOperation(
+          operation = OperationType.Merge,
+          contentPath = contentPath,
+          tag = Some(TagWithSection(removingTag.asThrift, removingTagSection.map(_.asThrift))),
+          destinationTag = Some(TagWithSection(replacementTag.asThrift, replacementTagSection.map(_.asThrift)))
+        )
+        Logger.info(s"raising merge tag ${removingTag.path} -> ${replacementTag.path} for content $contentPath")
+        KinesisStreams.taggingOperationsStream.publishUpdate(contentPath.take(200), taggingOperation)
+      }
+    }
+
+    Some(jobId)
+
+  }
+}
+
+object MergeTagCommand {
+  implicit val mergeTagCommandFormat: Format[MergeTagCommand] = (
+      (JsPath \ "removingTagId").format[Long] and
+      (JsPath \ "replacementTagId").format[Long]
+    )(MergeTagCommand.apply, unlift(MergeTagCommand.unapply))
+}

--- a/app/model/command/PathUsageCheck.scala
+++ b/app/model/command/PathUsageCheck.scala
@@ -1,6 +1,5 @@
 package model.command
 
-import com.gu.pandomainauth.model.User
 import model.command.logic.TagPathCalculator
 import repositories.PathManager
 

--- a/app/model/command/PathUsageCheck.scala
+++ b/app/model/command/PathUsageCheck.scala
@@ -9,7 +9,7 @@ class PathUsageCheck(`type`: String, slug: String, sectionId: Option[Long]) exte
 
   type T = Map[String, Boolean]
 
-  override def process()(implicit user: Option[User] = None): Option[Map[String, Boolean]] = {
+  override def process()(implicit username: Option[String] = None): Option[Map[String, Boolean]] = {
     val calculatedPath = TagPathCalculator calculatePath(`type`, slug, sectionId)
 
     val inUse = PathManager isPathInUse(calculatedPath)

--- a/app/model/command/UpdateTagCommand.scala
+++ b/app/model/command/UpdateTagCommand.scala
@@ -12,7 +12,7 @@ case class UpdateTagCommand(tag: Tag) extends Command {
 
   type T = Tag
 
-  override def process()(implicit user: Option[User] = None): Option[Tag] = {
+  override def process()(implicit username: Option[String] = None): Option[Tag] = {
     Logger.info(s"updating tag ${tag.id}")
 
     val result = TagRepository.upsertTag(tag)

--- a/app/model/command/UpdateTagCommand.scala
+++ b/app/model/command/UpdateTagCommand.scala
@@ -1,6 +1,5 @@
 package model.command
 
-import com.gu.pandomainauth.model.User
 import com.gu.tagmanagement.{EventType, TagEvent}
 import model.{TagAudit, Tag}
 import play.api.Logger

--- a/app/model/jobs/MergeAndDeleteSteps.scala
+++ b/app/model/jobs/MergeAndDeleteSteps.scala
@@ -6,7 +6,7 @@ import model.TagAudit
 import play.api.Logger
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Format}
-import repositories.{ContentAPI, TagAuditRepository, TagRepository}
+import repositories.{PathManager, ContentAPI, TagAuditRepository, TagRepository}
 import services.KinesisStreams
 
 
@@ -40,6 +40,7 @@ case class RemoveTagStep(tagId: Long, originalUsername: Option[String]) extends 
     TagRepository.getTag(tagId) foreach { tag =>
 
       TagRepository.deleteTag(tagId)
+      PathManager.removePathForId(tag.pageId)
 
       KinesisStreams.tagUpdateStream.publishUpdate(tagId.toString, TagEvent(EventType.Delete, tagId, None))
 

--- a/app/model/jobs/MergeAndDeleteSteps.scala
+++ b/app/model/jobs/MergeAndDeleteSteps.scala
@@ -23,7 +23,7 @@ case class AllUsagesOfTagRemovedCheck(apiTagId: String, originalCount: Int, comp
   }
 }
 
-case class RemoveTagStep(tagId: Long, originalUser: Option[User]) extends Step {
+case class RemoveTagStep(tagId: Long, originalUsername: Option[String]) extends Step {
   /** runs the step and returns the updated state of the step, or None if the step has completed */
   override def process: Option[Step] = {
     Logger.info(s"deleting tag $tagId}")
@@ -33,7 +33,7 @@ case class RemoveTagStep(tagId: Long, originalUser: Option[User]) extends Step {
 
       KinesisStreams.tagUpdateStream.publishUpdate(tagId.toString, TagEvent(EventType.Delete, tagId, None))
 
-      TagAuditRepository.upsertTagAudit(TagAudit.deleted(tag, originalUser))
+      TagAuditRepository.upsertTagAudit(TagAudit.deleted(tag, originalUsername))
     }
     None
   }

--- a/app/model/jobs/MergeAndDeleteSteps.scala
+++ b/app/model/jobs/MergeAndDeleteSteps.scala
@@ -1,0 +1,56 @@
+package model.jobs
+
+import com.gu.pandomainauth.model.User
+import com.gu.tagmanagement.{EventType, TagEvent}
+import model.TagAudit
+import play.api.Logger
+import repositories.{ContentAPI, TagAuditRepository, TagRepository}
+import services.KinesisStreams
+
+
+case class AllUsagesOfTagRemovedCheck(apiTagId: String, originalCount: Int, completed: Int = 0) extends Step {
+  /** runs the step and returns the updated state of the step, or None if the step has completed */
+  override def process: Option[Step] = {
+    val currentCount = ContentAPI.countContentWithTag(apiTagId)
+    if (currentCount == 0) {
+      Logger.info(s"no content remains with tag $apiTagId")
+      None
+    } else {
+      val completedCount = originalCount - currentCount
+      Logger.info(s"removing tag $apiTagId from content, $completedCount completed out of $originalCount")
+      Some(this.copy(completed = completedCount))
+    }
+  }
+}
+
+case class RemoveTagStep(tagId: Long, originalUser: Option[User]) extends Step {
+  /** runs the step and returns the updated state of the step, or None if the step has completed */
+  override def process: Option[Step] = {
+    Logger.info(s"deleting tag $tagId}")
+    TagRepository.getTag(tagId) foreach { tag =>
+
+      TagRepository.deleteTag(tagId)
+
+      KinesisStreams.tagUpdateStream.publishUpdate(tagId.toString, TagEvent(EventType.Delete, tagId, None))
+
+      TagAuditRepository.upsertTagAudit(TagAudit.deleted(tag, originalUser))
+    }
+    None
+  }
+}
+
+case class TagRemovedCheck(apiTagId: String) extends Step {
+  /** runs the step and returns the updated state of the step, or None if the step has completed */
+  override def process: Option[Step] = {
+    ContentAPI.getTag(apiTagId) match {
+      case Some(tag) => {
+        Logger.info(s"tag $apiTagId still exists}")
+        Some(this)
+      }
+      case None => {
+        Logger.info(s"tag $apiTagId successfully removed")
+        None
+      }
+    }
+  }
+}

--- a/app/model/jobs/MergeAndDeleteSteps.scala
+++ b/app/model/jobs/MergeAndDeleteSteps.scala
@@ -4,6 +4,8 @@ import com.gu.pandomainauth.model.User
 import com.gu.tagmanagement.{EventType, TagEvent}
 import model.TagAudit
 import play.api.Logger
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Format}
 import repositories.{ContentAPI, TagAuditRepository, TagRepository}
 import services.KinesisStreams
 
@@ -23,6 +25,14 @@ case class AllUsagesOfTagRemovedCheck(apiTagId: String, originalCount: Int, comp
   }
 }
 
+object AllUsagesOfTagRemovedCheck {
+  implicit val allUsagesOfTagRemovedCheckFormat: Format[AllUsagesOfTagRemovedCheck] = (
+      (JsPath \ "apiTagId").format[String] and
+      (JsPath \ "originalCount").format[Int] and
+      (JsPath \ "completed").format[Int]
+    )(AllUsagesOfTagRemovedCheck.apply, unlift(AllUsagesOfTagRemovedCheck.unapply))
+}
+
 case class RemoveTagStep(tagId: Long, originalUsername: Option[String]) extends Step {
   /** runs the step and returns the updated state of the step, or None if the step has completed */
   override def process: Option[Step] = {
@@ -37,6 +47,13 @@ case class RemoveTagStep(tagId: Long, originalUsername: Option[String]) extends 
     }
     None
   }
+}
+
+object RemoveTagStep {
+  implicit val removeTagStepFormat: Format[RemoveTagStep] = (
+    (JsPath \ "tagId").format[Long] and
+      (JsPath \ "originalUsername").formatNullable[String]
+    )(RemoveTagStep.apply, unlift(RemoveTagStep.unapply))
 }
 
 case class TagRemovedCheck(apiTagId: String) extends Step {

--- a/app/model/jobs/Step.scala
+++ b/app/model/jobs/Step.scala
@@ -16,6 +16,9 @@ object Step {
     override def writes(c: Step): JsValue = c match {
       case b: BatchTagAddCompleteCheck => BatchTagAddCompleteCheck.batchTagAddCompleteCheck.writes(b).asInstanceOf[JsObject] + ("type", JsString("BatchTagAddCompleteCheck"))
       case b: BatchTagRemoveCompleteCheck => BatchTagRemoveCompleteCheck.batchTagRemoveCompleteCheck.writes(b).asInstanceOf[JsObject] + ("type", JsString("BatchTagRemoveCompleteCheck"))
+      case b: RemoveTagStep => RemoveTagStep.removeTagStepFormat.writes(b).asInstanceOf[JsObject] + ("type", JsString("RemoveTagStep"))
+      case b: AllUsagesOfTagRemovedCheck => AllUsagesOfTagRemovedCheck.allUsagesOfTagRemovedCheckFormat.writes(b).asInstanceOf[JsObject] + ("type", JsString("AllUsagesOfTagRemovedCheck"))
+      case trc: TagRemovedCheck => JsObject(Map("type" -> JsString("TagRemovedCheck"), "apiTagId" -> JsString(trc.apiTagId)))
       case other => {
         Logger.warn(s"unable to serialise step of type ${other.getClass}")
         throw new UnsupportedOperationException(s"unable to serialise step of type ${other.getClass}")
@@ -28,6 +31,9 @@ object Step {
       (json \ "type").get match {
         case JsString("BatchTagAddCompleteCheck") => BatchTagAddCompleteCheck.batchTagAddCompleteCheck.reads(json)
         case JsString("BatchTagRemoveCompleteCheck") => BatchTagRemoveCompleteCheck.batchTagRemoveCompleteCheck.reads(json)
+        case JsString("RemoveTagStep") => RemoveTagStep.removeTagStepFormat.reads(json)
+        case JsString("AllUsagesOfTagRemovedCheck") => AllUsagesOfTagRemovedCheck.allUsagesOfTagRemovedCheckFormat.reads(json)
+        case JsString("TagRemovedCheck") => (json \ "apiTagId").validate[String].map(TagRemovedCheck)
         case JsString(other) => JsError(s"unsupported command type $other}")
         case _ => JsError(s"unexpected command type value")
       }

--- a/app/repositories/ContentAPI.scala
+++ b/app/repositories/ContentAPI.scala
@@ -32,6 +32,17 @@ object ContentAPI {
     count
   }
 
+  def getTag(apiTagId: String) = {
+    val response = apiClient.getResponse(new ItemQuery(apiTagId))
+
+    Await.result(response.map(_.tag), 5 seconds)
+  }
+
+  def countContentWithTag(apiTagId: String) = {
+    val response = apiClient.getResponse(new SearchQuery().tag(apiTagId).pageSize(1))
+    Await.result(response.map(_.total), 5 seconds)
+  }
+
 
   def shutdown: Unit = {
     apiClient.shutdown()

--- a/app/repositories/TagRepository.scala
+++ b/app/repositories/TagRepository.scala
@@ -16,12 +16,16 @@ object TagRepository {
   }
 
   def upsertTag(tag: Tag) = {
-      try {
-        Dynamo.tagTable.putItem(tag.toItem)
-        Some(tag)
-      } catch {
-        case e: Error => None
-      }
+    try {
+      Dynamo.tagTable.putItem(tag.toItem)
+      Some(tag)
+    } catch {
+      case e: Error => None
+    }
+  }
+
+  def deleteTag(tagId: Long): Unit = {
+    Dynamo.tagTable.deleteItem("id", tagId)
   }
 
   def scanSearch(criteria: TagSearchCriteria) = {

--- a/conf/routes
+++ b/conf/routes
@@ -2,8 +2,8 @@
 GET        /                              controllers.App.index(id = "")
 GET        /tag/create                    controllers.App.index(id = "")
 GET        /tag/:id                       controllers.App.index(id)
-GET        /batch                     controllers.App.index(id = "")
-GET        /merge                     controllers.App.index(id = "")
+GET        /batch                         controllers.App.index(id = "")
+GET        /merge                         controllers.App.index(id = "")
 
 
 
@@ -13,6 +13,7 @@ POST       /api/tag                       controllers.TagManagementApi.createTag
 
 GET        /api/tag/:id                   controllers.TagManagementApi.getTag(id: Long)
 PUT        /api/tag/:id                   controllers.TagManagementApi.updateTag(id: Long)
+DELETE     /api/tag/:id                   controllers.TagManagementApi.deleteTag(id: Long)
 
 GET        /api/sections                  controllers.TagManagementApi.listSections
 GET        /api/section/:id               controllers.TagManagementApi.getSection(id: Long)
@@ -22,6 +23,8 @@ GET        /api/referenceTypes            controllers.TagManagementApi.listRefer
 
 GET        /api/checkPathInUse            controllers.TagManagementApi.checkPathInUse(type: String, slug: String, section: Option[Long])
 POST       /api/batchTag                  controllers.TagManagementApi.batchTag
+POST       /api/mergeTag                  controllers.TagManagementApi.mergeTag
+
 
 GET        /api/audit/tag/:tagId          controllers.TagManagementApi.getAuditForTag(tagId: Long)
 GET        /api/audit/operation/:op       controllers.TagManagementApi.getAuditForOperation(op: String)


### PR DESCRIPTION
Adds api endpoints and jobs for tag merge and delete. I've not added the UI changes to trigger deletes and merges here but think it's probably a good idea to get this code out to the team before I head off to the states. the endpoints should probably be permissioned as well...

flexible feeds changes to support merging are here: https://github.com/guardian/flexible-feeds/pull/7