### PR TITLE
Hypermedia API for integrating with Flexible Content

### DIFF
--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -17,8 +17,8 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
   def tags = APIAuthAction { req =>
     if(req.queryString.isEmpty) {
       val res = EmptyResponse()
-        .addLink("tags", "/api/tag/{id}")
-        .addLink("tags", "/tags{?offset,limit,query,type,internalName,externalName,externalReferenceType,externalReferenceToken}")
+        .addLink("tags-item", fullUri("/hyper/tags/{id}"))
+        .addLink("tags", fullUri("/hyper/tags{?offset,limit,query,type,internalName,externalName,externalReferenceType,externalReferenceToken}"))
       Ok(Json.toJson(res))
 
     } else {
@@ -44,4 +44,5 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
   }
 
   def tagUri(id: Long): String = s"https://tagmanager.${conf.pandaDomain}/hyper/tags/${id}"
+  def fullUri(path: String): String = s"https://tagmanager.${conf.pandaDomain}${path}"
 }

--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -1,0 +1,48 @@
+package controllers
+
+import model.{Tag, EntityResponse, EmptyResponse, CollectionResponse, EmbeddedEntity}
+import play.api.libs.json._
+import play.api.mvc.{Action, Controller}
+import repositories._
+import services.Config.conf
+
+
+object HyperMediaApi extends Controller with PanDomainAuthActions {
+  def tag(id: Long) = APIAuthAction {
+    TagRepository.getTag(id).map { tag =>
+      Ok(Json.toJson(EntityResponse(tag)))
+    }.getOrElse(NotFound)
+  }
+
+  def tags = APIAuthAction { req =>
+    if(req.queryString.isEmpty) {
+      val res = EmptyResponse()
+        .addLink("tags", "/api/tag/{id}")
+        .addLink("tags", "/tags{?offset,limit,query,type,internalName,externalName,externalReferenceType,externalReferenceToken}")
+      Ok(Json.toJson(res))
+
+    } else {
+      val criteria = TagSearchCriteria(
+        q = req.getQueryString("query"),
+        searchField = req.getQueryString("searchField"),
+        types = req.getQueryString("types").map(_.split(",").toList),
+        referenceType = req.getQueryString("externalReferenceType"),
+        internalName = req.getQueryString("internalName"),
+        externalName = req.getQueryString("externalName"),
+        referenceToken = req.getQueryString("externalReferenceToken")
+      )
+
+      val limit = req.getQueryString("limit").getOrElse("25").toInt
+      val offset = req.getQueryString("offset").getOrElse("0").toInt
+
+      val tags = TagLookupCache.search(criteria).drop(offset).take(limit).map { tag =>
+        EmbeddedEntity(tagUri(tag.id), Some(tag))
+      }
+
+      val res = CollectionResponse(0, limit, Some(tags.size), tags)
+      Ok(Json.toJson(res))
+}
+  }
+
+  def tagUri(id: Long): String = s"https://tagmanager.${conf.pandaDomain}/hyper/tags/${id}"
+}

--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -35,7 +35,7 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
   def hyper = CORSable(conf.corsableDomains: _*) {
     Action {
       val res = EmptyResponse()
-        .addLink("tags-item", fullUri("/hyper/tags/{id}"))
+        .addLink("tag-item", fullUri("/hyper/tags/{id}"))
         .addLink("tags", fullUri("/hyper/tags{?offset,limit,query,type,internalName,externalName,externalReferenceType,externalReferenceToken}"))
       Ok(Json.toJson(res))
     }
@@ -51,11 +51,16 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
 
   def tags = CORSable(conf.corsableDomains: _*) {
     Action { implicit req =>
+      // we need to map keyword to topic in the types changes
+      val types = req.getQueryString("type").map(_.split(",").toList.map { x =>
+        if(x.toLowerCase() == "keyword") "topic" else x
+      })
+
       val criteria = TagSearchCriteria(
         q = req.getQueryString("query"),
         searchField = req.getQueryString("searchField"),
 
-        types = req.getQueryString("type").map(_.split(",").toList),
+        types = types,
         referenceType = req.getQueryString("externalReferenceType"),
         internalName = req.getQueryString("internalName"),
         externalName = req.getQueryString("externalName"),

--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -51,7 +51,7 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
 
   def tags = CORSable(conf.corsableDomains: _*) {
     Action { implicit req =>
-      // we need to map keyword to topic in the types changes
+      // we need to map keyword to topic in the types changes as flex searches for keywords - this might change (07/01/2016)
       val types = req.getQueryString("type").map(_.split(",").toList.map { x =>
         if(x.toLowerCase() == "keyword") "topic" else x
       })
@@ -59,7 +59,6 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
       val criteria = TagSearchCriteria(
         q = req.getQueryString("query"),
         searchField = req.getQueryString("searchField"),
-
         types = types,
         referenceType = req.getQueryString("externalReferenceType"),
         internalName = req.getQueryString("internalName"),

--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -25,7 +25,7 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
       val criteria = TagSearchCriteria(
         q = req.getQueryString("query"),
         searchField = req.getQueryString("searchField"),
-        types = req.getQueryString("types").map(_.split(",").toList),
+        types = req.getQueryString("type").map(_.split(",").toList),
         referenceType = req.getQueryString("externalReferenceType"),
         internalName = req.getQueryString("internalName"),
         externalName = req.getQueryString("externalName"),
@@ -39,9 +39,8 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
         EmbeddedEntity(tagUri(tag.id), Some(tag))
       }
 
-      val res = CollectionResponse(0, limit, Some(tags.size), tags)
-      Ok(Json.toJson(res))
-}
+      Ok(Json.toJson(CollectionResponse(offset, limit, Some(tags.size), tags)))
+    }
   }
 
   def tagUri(id: Long): String = s"https://tagmanager.${conf.pandaDomain}/hyper/tags/${id}"

--- a/app/model/HyperMedia.scala
+++ b/app/model/HyperMedia.scala
@@ -1,5 +1,7 @@
 package model
 import play.api.libs.json._
+import services.Config.conf
+
 
 case class LinkEntity(rel: String, href: String)
 object LinkEntity { implicit val jsonWrites = Json.writes[LinkEntity] }
@@ -7,7 +9,6 @@ object LinkEntity { implicit val jsonWrites = Json.writes[LinkEntity] }
 case class EmbeddedEntity[T](uri: String,
                              data: Option[T] = None,
                              links: Option[List[LinkEntity]] = None) {
-
   def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
 }
 object EmbeddedEntity {
@@ -59,3 +60,8 @@ case class EmptyResponse(links: Option[List[LinkEntity]] = None) {
   def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
 }
 object EmptyResponse { implicit val jsonWrites = Json.writes[EmptyResponse] }
+
+object HyperMediaHelpers {
+  def tagUri(id: Long): String = s"https://tagmanager.${conf.pandaDomain}/hyper/tags/${id}"
+  def fullUri(path: String): String = s"https://tagmanager.${conf.pandaDomain}${path}"
+}

--- a/app/model/HyperMedia.scala
+++ b/app/model/HyperMedia.scala
@@ -1,0 +1,40 @@
+package model
+
+case class EntityResponse[T](data: T, links: Option[List[LinkEntity]] = None) {
+
+  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
+}
+
+case class CollectionResponse[T](
+  offset: Int,
+  limit: Int,
+  total: Option[Int],
+  data: List[T],
+  links: Option[List[LinkEntity]] = None
+) {
+
+  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
+}
+
+case class EmptyResponse(links: Option[List[LinkEntity]] = None) {
+
+  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
+}
+
+
+
+case class LinkEntity(rel: String, href: String)
+
+case class EmbeddedEntity[T](uri: String,
+                             data: Option[T] = None,
+                             links: Option[List[LinkEntity]] = None) {
+
+  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
+}
+
+case class EmbeddedCollection[T](uri: String,
+                                 data: Option[List[T]] = None,
+                                 links: Option[List[LinkEntity]] = None) {
+
+  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
+}

--- a/app/model/HyperMedia.scala
+++ b/app/model/HyperMedia.scala
@@ -1,40 +1,35 @@
 package model
-
-case class EntityResponse[T](data: T, links: Option[List[LinkEntity]] = None) {
-
-  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
-}
-
-case class CollectionResponse[T](
-  offset: Int,
-  limit: Int,
-  total: Option[Int],
-  data: List[T],
-  links: Option[List[LinkEntity]] = None
-) {
-
-  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
-}
-
-case class EmptyResponse(links: Option[List[LinkEntity]] = None) {
-
-  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
-}
-
-
+import play.api.libs.json._
 
 case class LinkEntity(rel: String, href: String)
+object LinkEntity { implicit val jsonWrites = Json.writes[LinkEntity] }
 
-case class EmbeddedEntity[T](uri: String,
-                             data: Option[T] = None,
+case class EmbeddedEntity(uri: String,
+                             data: Option[Tag] = None,
                              links: Option[List[LinkEntity]] = None) {
 
   def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
 }
+object EmbeddedEntity { implicit val jsonWrites = Json.writes[EmbeddedEntity] }
 
-case class EmbeddedCollection[T](uri: String,
-                                 data: Option[List[T]] = None,
-                                 links: Option[List[LinkEntity]] = None) {
-
+case class EntityResponse(data: Tag, links: Option[List[LinkEntity]] = None) {
   def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
 }
+object EntityResponse { implicit val jsonWrites = Json.writes[EntityResponse] }
+
+case class CollectionResponse(
+  offset: Int,
+  limit: Int,
+  total: Option[Int],
+  data: List[EmbeddedEntity],
+  links: Option[List[LinkEntity]] = None
+) {
+  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
+}
+object CollectionResponse { implicit val jsonWrites = Json.writes[CollectionResponse] }
+
+
+case class EmptyResponse(links: Option[List[LinkEntity]] = None) {
+  def addLink(rel: String, href: String) = copy(links = Some(LinkEntity(rel, href) :: (links getOrElse Nil)))
+}
+object EmptyResponse { implicit val jsonWrites = Json.writes[EmptyResponse] }

--- a/app/model/TagEntity.scala
+++ b/app/model/TagEntity.scala
@@ -1,5 +1,6 @@
 package model
 import play.api.libs.json._
+import repositories.SectionRepository
 
 //used for responses in the hypermedia api
 
@@ -15,7 +16,7 @@ case class TagEntity(
   legallySensitive: Boolean = false,
   comparableValue: String,
   categories: Set[String] = Set(),
-  section: Option[Long],
+  section: Option[Section],
   description: Option[String] = None,
   podcastMetadata: Option[PodcastMetadata] = None,
   contributorInformation: Option[ContributorInformation] = None,
@@ -37,7 +38,7 @@ object TagEntity {
         tag.legallySensitive,
         tag.comparableValue,
         tag.categories,
-        tag.section,
+        getTagSection(tag.section),
         tag.description,
         tag.podcastMetadata,
         tag.contributorInformation,
@@ -45,6 +46,13 @@ object TagEntity {
         tag.references
       )
   }
+
+  def getTagSection(id: Option[Long]): Option[Section] = {
+    id.map( sectionId =>
+      SectionRepository.getSection(sectionId)
+    ).flatten
+  }
+
 
   implicit def tagEntityWrites: Writes[TagEntity] = new Writes[TagEntity] {
     def writes(te: TagEntity) = JsObject(Seq(
@@ -59,8 +67,8 @@ object TagEntity {
       "legallySensitive" -> JsBoolean(te.legallySensitive),
       "comparableValue" -> JsString(te.comparableValue),
       "categories" -> JsArray(te.categories.map(JsString(_)).toSeq),
-      "section" -> JsNumber(te.section.getOrElse(0).toString.toInt),
-      "descripton" -> JsString(te.description.getOrElse(Nil).toString),
+      "section" -> te.section.map(Json.toJson(_)).getOrElse(JsNull),
+      "descripton" -> JsString(te.description.getOrElse("")),
       "podcastMetadata" -> te.podcastMetadata.map(Json.toJson(_)).getOrElse(JsNull),
       "contributorInformation" -> te.contributorInformation.map(Json.toJson(_)).getOrElse(JsNull),
       "parents" -> JsArray(te.parents.map(Json.toJson(_)).toSeq)

--- a/app/model/TagEntity.scala
+++ b/app/model/TagEntity.scala
@@ -1,0 +1,87 @@
+package model
+import play.api.libs.json._
+
+//used for responses in the hypermedia api
+
+case class TagEntity(
+  id: Long,
+  path: String,
+  pageId: Long,
+  `type`: String,
+  internalName: String,
+  externalName: String,
+  slug: String,
+  hidden: Boolean = false,
+  legallySensitive: Boolean = false,
+  comparableValue: String,
+  categories: Set[String] = Set(),
+  section: Option[Long],
+  description: Option[String] = None,
+  podcastMetadata: Option[PodcastMetadata] = None,
+  contributorInformation: Option[ContributorInformation] = None,
+  parents: Set[EmbeddedEntity[TagEntity]] = Set(),
+  references: List[Reference] = Nil
+)
+
+object TagEntity {
+  def apply(tag: Tag): TagEntity = {
+      TagEntity(
+        tag.id,
+        tag.path,
+        tag.pageId,
+        tag.`type`,
+        tag.internalName,
+        tag.externalName,
+        tag.slug,
+        tag.hidden,
+        tag.legallySensitive,
+        tag.comparableValue,
+        tag.categories,
+        tag.section,
+        tag.description,
+        tag.podcastMetadata,
+        tag.contributorInformation,
+        tag.parents.map(x => EmbeddedEntity[TagEntity](HyperMediaHelpers.tagUri(x))),
+        tag.references
+      )
+  }
+
+  implicit def tagEntityWrites: Writes[TagEntity] = new Writes[TagEntity] {
+    def writes(te: TagEntity) = JsObject(Seq(
+      "id" -> JsNumber(te.id),
+      "path" -> JsString(te.path),
+      "pageId" -> JsNumber(te.pageId),
+      "type" -> JsString(te.`type`),
+      "internalName" -> JsString(te.internalName),
+      "externalName" -> JsString(te.externalName),
+      "slug" -> JsString(te.slug),
+      "hidden" -> JsBoolean(te.hidden),
+      "legallySensitive" -> JsBoolean(te.legallySensitive),
+      "comparableValue" -> JsString(te.comparableValue),
+      "categories" -> JsArray(te.categories.map(JsString(_)).toSeq),
+      "section" -> JsNumber(te.section.getOrElse(0).toString.toInt),
+      "descripton" -> JsString(te.description.getOrElse(Nil).toString),
+      "podcastMetadata" -> te.podcastMetadata.map(Json.toJson(_)).getOrElse(JsNull),
+      "contributorInformation" -> te.contributorInformation.map(Json.toJson(_)).getOrElse(JsNull),
+      "parents" -> JsArray(te.parents.map(Json.toJson(_)).toSeq)
+    ))
+  }
+
+}
+  // id: Long,
+  // path: String,
+  // pageId: Long,
+  // `type`: String,
+  // internalName: String,
+  // externalName: String,
+  // slug: String,
+  // hidden: Boolean = false,
+  // legallySensitive: Boolean = false,
+  // comparableValue: String,
+  // categories: Set[String] = Set(),
+  // section: Option[Long],
+  // description: Option[String] = None,
+  // podcastMetadata: Option[PodcastMetadata] = None,
+  // contributorInformation: Option[ContributorInformation] = None,
+  // parents: Set[EmbeddedEntity[TagEntity]] = Set(),
+  // references: List[Reference] = Nil

--- a/app/model/TagEntity.scala
+++ b/app/model/TagEntity.scala
@@ -2,7 +2,11 @@ package model
 import play.api.libs.json._
 import repositories.SectionRepository
 
-//used for responses in the hypermedia api
+/* Flex expects the old api so this essentially mimics the old functionality
+ * by adding a SectionEntity and TagEntity. It does mean that some of the new
+ * data about tags and sections is missing but this can be rectified by altering
+ * flex.
+ */
 
 case class TagEntity(
   id: Long,
@@ -17,6 +21,7 @@ case class TagEntity(
 
 object TagEntity {
   def apply(tag: Tag): TagEntity = {
+    /* The Section is implicitly populated when this is called */
       TagEntity(
         tag.id,
         tag.`type`,

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -92,7 +92,6 @@ sealed trait Config {
 
   def composerDomain: String
   def corsableDomains: Seq[String]
-
 }
 
 class DevConfig extends Config {

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -90,6 +90,9 @@ sealed trait Config {
   def pandaDomain: String
   def pandaAuthCallback: String
 
+  def composerDomain: String
+  def corsableDomains: Seq[String]
+
 }
 
 class DevConfig extends Config {
@@ -115,6 +118,9 @@ class DevConfig extends Config {
   override def logShippingStreamName = Some("elk-CODE-KinesisStream-M03ERGK5PVD9")
   override def pandaDomain: String = "local.dev-gutools.co.uk"
   override def pandaAuthCallback: String = "https://tagmanager.local.dev-gutools.co.uk/oauthCallback"
+
+  override def composerDomain: String = "https://composer.local.dev-gutools.co.uk"
+  override def corsableDomains: Seq[String] = Seq(composerDomain)
 
 
 }
@@ -144,6 +150,10 @@ class CodeConfig extends Config {
   override def pandaDomain: String = "code.dev-gutools.co.uk"
   override def pandaAuthCallback: String = "https://tagmanager.code.dev-gutools.co.uk/oauthCallback"
 
+  override def composerDomain: String = "https://composer.code.dev-gutools.co.uk"
+  override def corsableDomains: Seq[String] = Seq(composerDomain)
+
+
 }
 
 class ProdConfig extends Config {
@@ -169,5 +179,8 @@ class ProdConfig extends Config {
   override def logShippingStreamName = Some("elk-PROD-KinesisStream-1PYU4KS1UEQA")
   override def pandaDomain: String = "gutools.co.uk"
   override def pandaAuthCallback: String = "https://tagmanager.gutools.co.uk/oauthCallback"
+
+  override def composerDomain: String = "https://composer.gutools.co.uk"
+  override def corsableDomains: Seq[String] = Seq(composerDomain)
 
 }

--- a/conf/routes
+++ b/conf/routes
@@ -35,7 +35,8 @@ GET        /api/audit/operation/:op       controllers.TagManagementApi.getAuditF
 
 GET        /api/jobs                      controllers.TagManagementApi.getJobs(tagId: Option[Long])
 
-
+GET        /hyper/tags                    controllers.HyperMediaApi.tags
+GET        /hyper/tags/:id                controllers.HyperMediaApi.tag(id: Long)
 
 GET        /hello                         controllers.App.hello
 GET        /testScan                      controllers.App.testScan

--- a/conf/routes
+++ b/conf/routes
@@ -35,8 +35,11 @@ GET        /api/audit/operation/:op       controllers.TagManagementApi.getAuditF
 
 GET        /api/jobs                      controllers.TagManagementApi.getJobs(tagId: Option[Long])
 
+# Hypmedia API
+GET        /hyper                         controllers.HyperMediaApi.hyper
 GET        /hyper/tags                    controllers.HyperMediaApi.tags
 GET        /hyper/tags/:id                controllers.HyperMediaApi.tag(id: Long)
+OPTIONS    /*all                          controllers.HyperMediaApi.preflight(all: String)
 
 GET        /hello                         controllers.App.hello
 GET        /testScan                      controllers.App.testScan


### PR DESCRIPTION
This adds a Hypermedia API that essentially just mimics the existing tag api. This is so that we can make minimal changes to flex. I've had to make two additional classes ```TagEntity``` and ```SectionEntity``` so that the API returns the tags in the format flex expects. 

We should test this a lot but it should be as simple as dropping the root hyper url into flex and watching it work.