### PR TITLE
Added compression byte to all kinesis streams

### DIFF
--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -64,7 +64,7 @@ object SQS {
   lazy val jobQueue = new SQSQueue(Config().jobQueueName)
 }
 
-class KinesisStreamProducer(streamName: String) {
+class KinesisStreamProducer(streamName: String, requireCompressionByte: Boolean = false) {
 
   def publishUpdate(key: String, data: String) {
     publishUpdate(key, ByteBuffer.wrap(data.getBytes("UTF-8")))
@@ -75,7 +75,7 @@ class KinesisStreamProducer(streamName: String) {
   }
 
   def publishUpdate(key: String, struct: ThriftStruct) {
-    publishUpdate(key, ByteBuffer.wrap(ThriftSerializer.serializeToBytes(struct)))
+    publishUpdate(key, ByteBuffer.wrap(ThriftSerializer.serializeToBytes(struct, requireCompressionByte)))
   }
 
   def publishUpdate(key: String, dataBuffer: ByteBuffer) {
@@ -84,7 +84,7 @@ class KinesisStreamProducer(streamName: String) {
 }
 
 object KinesisStreams {
-  lazy val tagUpdateStream = new KinesisStreamProducer(Config().tagUpdateStreamName)
-  lazy val sectionUpdateStream = new KinesisStreamProducer(Config().sectionUpdateStreamName)
-  lazy val taggingOperationsStream = new KinesisStreamProducer(Config().taggingOperationsStreamName)
+  lazy val tagUpdateStream = new KinesisStreamProducer(Config().tagUpdateStreamName, true)
+  lazy val sectionUpdateStream = new KinesisStreamProducer(Config().sectionUpdateStreamName, true)
+  lazy val taggingOperationsStream = new KinesisStreamProducer(Config().taggingOperationsStreamName, false)
 }

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -86,5 +86,5 @@ class KinesisStreamProducer(streamName: String, requireCompressionByte: Boolean 
 object KinesisStreams {
   lazy val tagUpdateStream = new KinesisStreamProducer(Config().tagUpdateStreamName, true)
   lazy val sectionUpdateStream = new KinesisStreamProducer(Config().sectionUpdateStreamName, true)
-  lazy val taggingOperationsStream = new KinesisStreamProducer(Config().taggingOperationsStreamName, false)
+  lazy val taggingOperationsStream = new KinesisStreamProducer(Config().taggingOperationsStreamName, true)
 }

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -80,7 +80,12 @@ trait KinesisStreamRecordProcessor{
 
 object KinesisRecordPayloadConversions {
   implicit def kinesisRecordAsThriftCompactProtocol(rec: Record): TProtocol = {
-    val bbis = new ByteBufferBackedInputStream(rec.getData)
+
+    val data = rec.getData
+
+    val settings = data.get() //compression bit
+
+    val bbis = new ByteBufferBackedInputStream(data)
     val transport = new TIOStreamTransport(bbis)
     new TCompactProtocol(transport)
   }

--- a/app/services/ThriftSerializer.scala
+++ b/app/services/ThriftSerializer.scala
@@ -8,11 +8,19 @@ object ThriftSerializer {
 
   val ThriftBufferInitialSize = 128
 
-  def serializeToBytes(struct: ThriftStruct): Array[Byte] = {
+  def serializeToBytes(struct: ThriftStruct, includeCompressionFlag: Boolean): Array[Byte] = {
     val buffer = new TMemoryBuffer(ThriftBufferInitialSize)
     val protocol = new TCompactProtocol(buffer)
     struct.write(protocol)
-    buffer.getArray
+
+    includeCompressionFlag match {
+      case true => compressionByte +: buffer.getArray
+      case false => buffer.getArray
+    }
+  }
+
+  val compressionByte: Byte = {
+    0x00.toByte
   }
 
 }


### PR DESCRIPTION
This adds a compression byte (currently set to 0x00) to all kinesis streams so CAPI can consume. Also adds ability for consumer to strip the compression byte

Fixes #61 
