### PR TITLE
Add Github SSH keys and PathManager Timeout

### DIFF
--- a/app/repositories/PathManager.scala
+++ b/app/repositories/PathManager.scala
@@ -27,6 +27,7 @@ object PathManager {
       .post(formBody)
       .build
 
+    httpClient.setConnectTimeout(5, TimeUnit.SECONDS)
     val resp = httpClient.newCall(req).execute
 
     resp.code match {
@@ -48,6 +49,7 @@ object PathManager {
   def removePathForId(id: Long) = {
     Logger.info(s"removing path entries for $id")
 
+    httpClient.setConnectTimeout(5, TimeUnit.SECONDS)
     val req = new Request.Builder().url(s"${Config().pathManagerUrl}paths/$id").delete().build
     val resp = httpClient.newCall(req).execute
 
@@ -62,7 +64,7 @@ object PathManager {
 
   def isPathInUse(path: String): Boolean = {
 
-    httpClient.setConnectTimeout(5, TimeUnit.SECONDS)
+    httpClient.setConnectTimeout(2, TimeUnit.SECONDS)
     val req = new Request.Builder().url(s"${Config().pathManagerUrl}paths?path=$path").build
     val resp = httpClient.newCall(req).execute
 

--- a/app/repositories/PathManager.scala
+++ b/app/repositories/PathManager.scala
@@ -4,6 +4,7 @@ import com.squareup.okhttp.{FormEncodingBuilder, OkHttpClient, Request}
 import play.api.Logger
 import play.api.libs.json.Json
 import services.Config
+import java.util.concurrent.TimeUnit
 
 
 case class PathRegistrationFailed(m: String) extends RuntimeException(m)
@@ -13,6 +14,7 @@ object PathManager {
 
   val httpClient = new OkHttpClient()
 
+
   def registerPathAndGetPageId(path: String): Long = {
     Logger.info(s"registering path $path")
 
@@ -20,7 +22,11 @@ object PathManager {
       .add("path", path)
       .add("system", "tagmanager")
       .build()
-    val req = new Request.Builder().url(s"${Config().pathManagerUrl}paths").post(formBody).build
+    val req = new Request.Builder()
+      .url(s"${Config().pathManagerUrl}paths")
+      .post(formBody)
+      .build
+
     val resp = httpClient.newCall(req).execute
 
     resp.code match {
@@ -55,6 +61,8 @@ object PathManager {
   }
 
   def isPathInUse(path: String): Boolean = {
+
+    httpClient.setConnectTimeout(5, TimeUnit.SECONDS)
     val req = new Request.Builder().url(s"${Config().pathManagerUrl}paths?path=$path").build
     val resp = httpClient.newCall(req).execute
 

--- a/cloudformation/tag-manager.json
+++ b/cloudformation/tag-manager.json
@@ -36,6 +36,11 @@
       "Description": "Ip range for the office",
       "Type": "String",
       "Default": "77.91.248.0/21"
+    },
+    "GithubTeamName": {
+      "Description": "Github team name, used for giving ssh access to members of the team.",
+      "Type": "String",
+      "Default": "Editorial-Tools-SSHAccess"
     }
   },
   "Mappings": {
@@ -122,6 +127,28 @@
               "Effect": "Allow",
               "Action": ["s3:GetObject"],
               "Resource": ["arn:aws:s3:::pan-domain-auth-settings/*"]
+            }
+          ]
+        },
+        "Roles": [{"Ref": "TagManagerRole"}]
+      }
+    },
+
+    "TagManagerGetTeamKeysPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "TagManagerGetTeamKeysPolicy",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": ["arn:aws:s3:::github-team-keys/*"]
+            },
+            {
+              "Effect":"Allow",
+              "Action": ["s3:ListBucket"],
+              "Resource":"arn:aws:s3:::github-team-keys"
             }
           ]
         },
@@ -381,6 +408,7 @@
           "Fn::Base64":{
             "Fn::Join":["", [
               "#!/bin/bash -ev\n",
+              { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -b github-team-keys -t ", {"Ref":"GithubTeamName"}, " -l || true\n"] ] },
               "/opt/features/native-packager/install.sh -b composer-dist -t tgz -s\n"
             ]]
           }

--- a/deploy.json
+++ b/deploy.json
@@ -17,7 +17,7 @@
         "cloudFormationStackName": "TagManager",
         "prependStackToCloudFormationStackName": false,
         "templateParameters": {
-          "MachineImagesAMI": "ami-5e75a92d"
+          "MachineImagesAMI": "ami-a09931d3"
         }
       }
     }


### PR DESCRIPTION
This adds 
- @philmcmahon's github team ssh access :fireworks: 
- A much shorter connect timeout on the three requests made to pathmanager (previously they would timeout after 60s)
- Bumps AMI to latest