### PR TITLE
Update the XML export to match what comes out of R2

### DIFF
--- a/app/controllers/ReadOnly.scala
+++ b/app/controllers/ReadOnly.scala
@@ -8,7 +8,7 @@ import repositories._
 
 object ReadOnlyApi extends Controller {
   def getTagsAsXml() = Action.async {
-    Future(TagLookupCache.allTags.get.map(_.axExportedXml)) map { tags =>
+    Future(TagLookupCache.allTags.get.map(_.asExportedXml)) map { tags =>
       Ok(<tags>
         {tags.seq.map { x => x }}
         </tags>)
@@ -17,7 +17,7 @@ object ReadOnlyApi extends Controller {
 
   def tagAsXml(id: Long) = Action {
     TagRepository.getTag(id).map { tag =>
-      Ok(tag.axExportedXml)
+      Ok(tag.asExportedXml)
     }.getOrElse(NotFound)
   }
 }

--- a/app/controllers/ReadOnly.scala
+++ b/app/controllers/ReadOnly.scala
@@ -8,10 +8,16 @@ import repositories._
 
 object ReadOnlyApi extends Controller {
   def getTagsAsXml() = Action.async {
-    Future(TagLookupCache.allTags.get.map(_.asXml)) map { tags =>
+    Future(TagLookupCache.allTags.get.map(_.axExportedXml)) map { tags =>
       Ok(<tags>
         {tags.seq.map { x => x }}
         </tags>)
     }
+  }
+
+  def tagAsXml(id: Long) = Action {
+    TagRepository.getTag(id).map { tag =>
+      Ok(tag.axExportedXml)
+    }.getOrElse(NotFound)
   }
 }

--- a/app/helpers/XmlHelpers.scala
+++ b/app/helpers/XmlHelpers.scala
@@ -1,0 +1,17 @@
+package helpers
+
+import xml._
+
+object XmlHelpers {
+  def createAttribute(name: String, value: Option[Any]) = {
+    value.map { result =>
+      Attribute(None, name, Text(result.toString), Null)
+    } getOrElse Null
+  }
+
+  def addChild(n: Node, newChild: Node): Node = n match {
+    case Elem(prefix, label, attribs, scope, child @ _*) =>
+      Elem(prefix, label, attribs, scope, child ++ newChild : _*)
+    case _ => error("Can only add children to elements!")
+  }
+}

--- a/app/model/ContributorInformation.scala
+++ b/app/model/ContributorInformation.scala
@@ -19,10 +19,10 @@ case class ContributorInformation(
     twitterHandle =     twitterHandle,
     contactEmail =      contactEmail
   )
-  def asXml = {
+  def axExportedXml = {
     <rcsId>{this.rcsId.getOrElse("")}</rcsId>
-    <bylineImage>{this.bylineImage.map(_.asXml).getOrElse("")}</bylineImage>
-    <largeBylineImage>{this.largeBylineImage.map(_.asXml).getOrElse("")}</largeBylineImage>
+    <bylineImage>{this.bylineImage.map(_.axExportedXml).getOrElse("")}</bylineImage>
+    <largeBylineImage>{this.largeBylineImage.map(_.axExportedXml).getOrElse("")}</largeBylineImage>
     <twitterHandle>{this.twitterHandle.getOrElse("")}</twitterHandle>
     <contactEmail>{this.contactEmail.getOrElse("")}</contactEmail>
   }

--- a/app/model/ContributorInformation.scala
+++ b/app/model/ContributorInformation.scala
@@ -19,10 +19,10 @@ case class ContributorInformation(
     twitterHandle =     twitterHandle,
     contactEmail =      contactEmail
   )
-  def axExportedXml = {
+  def asExportedXml = {
     <rcsId>{this.rcsId.getOrElse("")}</rcsId>
-    <bylineImage>{this.bylineImage.map(_.axExportedXml).getOrElse("")}</bylineImage>
-    <largeBylineImage>{this.largeBylineImage.map(_.axExportedXml).getOrElse("")}</largeBylineImage>
+    <bylineImage>{this.bylineImage.map(_.asExportedXml).getOrElse("")}</bylineImage>
+    <largeBylineImage>{this.largeBylineImage.map(_.asExportedXml).getOrElse("")}</largeBylineImage>
     <twitterHandle>{this.twitterHandle.getOrElse("")}</twitterHandle>
     <contactEmail>{this.contactEmail.getOrElse("")}</contactEmail>
   }

--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -25,7 +25,7 @@ case class PodcastMetadata( linkUrl: String,
     image =             image.map(_.asThrift)
   )
 
-  def axExportedXml = {
+  def asExportedXml = {
     <linkUrl>{this.linkUrl}</linkUrl>
     <copyrightText>{this.copyrightText.getOrElse("")}</copyrightText>
     <authorText>{this.authorText.getOrElse("")}</authorText>
@@ -33,7 +33,7 @@ case class PodcastMetadata( linkUrl: String,
     <iTunesBlock>{this.iTunesBlock}</iTunesBlock>
     <clean>{this.clean}</clean>
     <explicit>{this.explicit}</explicit>
-    <image>{this.image.map(x => x.axExportedXml).getOrElse("")}</image>
+    <image>{this.image.map(x => x.asExportedXml).getOrElse("")}</image>
   }
 }
 

--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -25,7 +25,7 @@ case class PodcastMetadata( linkUrl: String,
     image =             image.map(_.asThrift)
   )
 
-  def asXml = {
+  def axExportedXml = {
     <linkUrl>{this.linkUrl}</linkUrl>
     <copyrightText>{this.copyrightText.getOrElse("")}</copyrightText>
     <authorText>{this.authorText.getOrElse("")}</authorText>
@@ -33,7 +33,7 @@ case class PodcastMetadata( linkUrl: String,
     <iTunesBlock>{this.iTunesBlock}</iTunesBlock>
     <clean>{this.clean}</clean>
     <explicit>{this.explicit}</explicit>
-    <image>{this.image.map(x => x.asXml).getOrElse("")}</image>
+    <image>{this.image.map(x => x.axExportedXml).getOrElse("")}</image>
   }
 }
 

--- a/app/model/PublicationInformation.scala
+++ b/app/model/PublicationInformation.scala
@@ -14,7 +14,7 @@ case class PublicationInformation(
     newspaperBooks =             newspaperBooks
   )
 
-  def axExportedXml = {
+  def asExportedXml = {
     <mainNewspaperBookSectionId>{this.mainNewspaperBookSectionId.getOrElse("")}</mainNewspaperBookSectionId>
     <newspaperBooks>{this.newspaperBooks}</newspaperBooks>
   }

--- a/app/model/PublicationInformation.scala
+++ b/app/model/PublicationInformation.scala
@@ -14,7 +14,7 @@ case class PublicationInformation(
     newspaperBooks =             newspaperBooks
   )
 
-  def asXml = {
+  def axExportedXml = {
     <mainNewspaperBookSectionId>{this.mainNewspaperBookSectionId.getOrElse("")}</mainNewspaperBookSectionId>
     <newspaperBooks>{this.newspaperBooks}</newspaperBooks>
   }

--- a/app/model/Reference.scala
+++ b/app/model/Reference.scala
@@ -3,14 +3,23 @@ package model
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import com.gu.tagmanagement.{Reference => ThriftReference}
-
+import xml.{Elem, TopScope, Node, Null, Text}
+import helpers.XmlHelpers._
 
 case class Reference(`type`: String, value: String) {
   def asThrift = ThriftReference(`type`, value)
-  def axExportedXml = {<reference>
-               <type>{this.`type`}</type>
-               <value>{this.value}</value>
-               </reference>}
+
+
+  def asExportedXml = {
+    val el = Elem(null, "external-reference", Null, TopScope, Text(""))
+    val `type` = createAttribute("type", Some(this.`type`))
+
+    // these are identical but it's what inCopy wants
+    val topic = createAttribute("topic", Some(this.value))
+    val display = createAttribute("display-name", Some(this.value))
+
+    el % `type` % topic % display
+  }
 }
 
 object Reference {

--- a/app/model/Reference.scala
+++ b/app/model/Reference.scala
@@ -3,7 +3,7 @@ package model
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import com.gu.tagmanagement.{Reference => ThriftReference}
-import xml.{Elem, TopScope, Node, Null, Text}
+import xml.{Elem, TopScope, Null, Text}
 import helpers.XmlHelpers._
 
 case class Reference(`type`: String, value: String) {

--- a/app/model/Reference.scala
+++ b/app/model/Reference.scala
@@ -7,7 +7,7 @@ import com.gu.tagmanagement.{Reference => ThriftReference}
 
 case class Reference(`type`: String, value: String) {
   def asThrift = ThriftReference(`type`, value)
-  def asXml = {<reference>
+  def axExportedXml = {<reference>
                <type>{this.`type`}</type>
                <value>{this.value}</value>
                </reference>}

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -5,7 +5,7 @@ import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import com.gu.tagmanagement.{Tag => ThriftTag, TagType}
-import xml._
+import xml.{Elem, TopScope, Null, Text, Node}
 import helpers.XmlHelpers._
 import repositories.SectionRepository
 import scala.util.control.NonFatal
@@ -60,8 +60,8 @@ case class Tag(
     val el = Elem(null, "tag", Null, TopScope, Text(""))
     val section = SectionRepository.getSection(this.id)
     val id = createAttribute("id", Some(this.id))
-    val externalName = createAttribute("externalName", Some(this.externalName))
-    val internalName = createAttribute("internalName", Some(this.internalName))
+    val externalName = createAttribute("externalname", Some(this.externalName))
+    val internalName = createAttribute("internalname", Some(this.internalName))
     val urlWords = createAttribute("words-for-url", Some(this.slug))
     val sectionId = createAttribute("section-id", this.section)
     val sectionName = createAttribute("section", section.map(_.name))

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -6,6 +6,7 @@ import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import com.gu.tagmanagement.{Tag => ThriftTag, TagType}
 import xml._
+import helpers.XmlHelpers._
 import repositories.SectionRepository
 import scala.util.control.NonFatal
 
@@ -54,22 +55,9 @@ case class Tag(
     publicationInformation = publicationInformation.map(_.asThrift)
   )
 
-  def createAttribute(name: String, value: Option[Any]) = {
-    value.map { result =>
-      Attribute(None, name, Text(result.toString), Null)
-    } getOrElse Null
-  }
-
-  def addChild(n: Node, newChild: Node): Node = n match {
-    case Elem(prefix, label, attribs, scope, child @ _*) =>
-      Elem(prefix, label, attribs, scope, child ++ newChild : _*)
-    case _ => error("Can only add children to elements!")
-  }
-
   // in this limited format for inCopy to consume
-  def axExportedXml = {
+  def asExportedXml = {
     val el = Elem(null, "tag", Null, TopScope, Text(""))
-
     val section = SectionRepository.getSection(this.id)
     val id = createAttribute("id", Some(this.id))
     val externalName = createAttribute("externalName", Some(this.externalName))

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -5,7 +5,8 @@ import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import com.gu.tagmanagement.{Tag => ThriftTag, TagType}
-
+import xml._
+import repositories.SectionRepository
 import scala.util.control.NonFatal
 
 case class Tag(
@@ -53,29 +54,44 @@ case class Tag(
     publicationInformation = publicationInformation.map(_.asThrift)
   )
 
-  def asXml = {
-      <tag>
-        <id>{this.id}</id>
-        <path>{this.path}</path>
-        <pageId>{this.pageId}</pageId>
-        <type>{this.`type`}</type>
-        <internalName>{this.internalName}</internalName>
-        <externalName>{this.externalName}</externalName>
-        <slug>{this.slug}</slug>
-        <hidden>{this.hidden}</hidden>
-        <legallySensitive>{this.legallySensitive}</legallySensitive>
-        <comparableValue>{this.comparableValue}</comparableValue>
-        <section>{this.section.getOrElse("")}</section>
-        <publication>{this.publication.getOrElse("")}</publication>
-        <description>{this.description.getOrElse("")}</description>
-        <parents>{this.parents}</parents>
-        <references>{this.references.map(_.asXml)}</references>
-        <podcastMetadata>{this.podcastMetadata.map(_.asXml).getOrElse("")}</podcastMetadata>
-        <contributorInformation>{this.contributorInformation.map(_.asXml).getOrElse("")}</contributorInformation>
-        <publicationInformation>{this.publicationInformation.map(_.asXml).getOrElse("")}</publicationInformation>
-      </tag>
+  def createAttribute(name: String, value: Option[Any]) = {
+    value.map { result =>
+      Attribute(None, name, Text(result.toString), Null)
+    } getOrElse Null
   }
 
+  def addChild(n: Node, newChild: Node): Node = n match {
+    case Elem(prefix, label, attribs, scope, child @ _*) =>
+      Elem(prefix, label, attribs, scope, child ++ newChild : _*)
+    case _ => error("Can only add children to elements!")
+  }
+
+  // in this limited format for inCopy to consume
+  def axExportedXml = {
+    val el = Elem(null, "tag", Null, TopScope, Text(""))
+
+    val section = SectionRepository.getSection(this.id)
+    val id = createAttribute("id", Some(this.id))
+    val externalName = createAttribute("externalName", Some(this.externalName))
+    val internalName = createAttribute("internalName", Some(this.internalName))
+    val urlWords = createAttribute("words-for-url", Some(this.slug))
+    val sectionId = createAttribute("section-id", this.section)
+    val sectionName = createAttribute("section", section.map(_.name))
+    val sectionUrl = createAttribute("section-words-for-url", section.map(_.wordsForUrl))
+    val `type` = createAttribute("type", Some(this.`type`))
+
+    val withAttrs = el % id % externalName % internalName % urlWords % sectionId % sectionName % sectionUrl % `type`
+
+    val withRefs: Node = this.references.foldLeft(withAttrs: Node) { (x, y) =>
+      addChild(x, y.asExportedXml)
+    }
+    val withParents: Node = this.parents.foldLeft(withRefs: Node) { (x, parent) =>
+      val el = Elem(null, "parent", Null, TopScope, Text("")) % createAttribute("id",
+ Some(parent))
+      addChild(x, el)
+     }
+    withParents
+  }
 }
 
 object Tag {

--- a/app/model/image.scala
+++ b/app/model/image.scala
@@ -10,9 +10,9 @@ case class Image(imageId: String, assets: List[ImageAsset]) {
     imageId = imageId,
     assets = assets.map(_.asThrift)
   )
-  def asXml = {
+  def axExportedXml = {
     <imageId>{this.imageId}</imageId>
-    <assets>{this.assets.map(_.asXml)}</assets>
+    <assets>{this.assets.map(_.axExportedXml)}</assets>
   }
 }
 
@@ -33,7 +33,7 @@ object Image {
 
 case class ImageAsset(imageUrl: String, width: Long, height: Long, mimeType: String) {
   def asThrift = ThriftImageAsset(imageUrl, width, height, mimeType)
-  def asXml = {<imageAsset>
+  def axExportedXml = {<imageAsset>
     <imageUrl>{this.imageUrl}</imageUrl>
     <width>{this.width}</width>
     <height>{this.height}</height>

--- a/app/model/image.scala
+++ b/app/model/image.scala
@@ -10,9 +10,9 @@ case class Image(imageId: String, assets: List[ImageAsset]) {
     imageId = imageId,
     assets = assets.map(_.asThrift)
   )
-  def axExportedXml = {
+  def asExportedXml = {
     <imageId>{this.imageId}</imageId>
-    <assets>{this.assets.map(_.axExportedXml)}</assets>
+    <assets>{this.assets.map(_.asExportedXml)}</assets>
   }
 }
 
@@ -33,7 +33,7 @@ object Image {
 
 case class ImageAsset(imageUrl: String, width: Long, height: Long, mimeType: String) {
   def asThrift = ThriftImageAsset(imageUrl, width, height, mimeType)
-  def axExportedXml = {<imageAsset>
+  def asExportedXml = {<imageAsset>
     <imageUrl>{this.imageUrl}</imageUrl>
     <width>{this.width}</width>
     <height>{this.height}</height>

--- a/conf/routes
+++ b/conf/routes
@@ -46,7 +46,8 @@ GET        /hyper/tags                    controllers.HyperMediaApi.tags
 GET        /hyper/tags/:id                controllers.HyperMediaApi.tag(id: Long)
 OPTIONS    /*all                          controllers.HyperMediaApi.preflight(all: String)
 
-GET        /api/xml                       controllers.ReadOnlyApi.getTagsAsXml
+GET        /tags/export/all               controllers.ReadOnlyApi.getTagsAsXml
+GET        /tags/export/single/:id         controllers.ReadOnlyApi.tagsAsXml(id: Long)
 
 
 GET        /hello                         controllers.App.hello

--- a/conf/routes
+++ b/conf/routes
@@ -47,7 +47,7 @@ GET        /hyper/tags/:id                controllers.HyperMediaApi.tag(id: Long
 OPTIONS    /*all                          controllers.HyperMediaApi.preflight(all: String)
 
 GET        /tags/export/all               controllers.ReadOnlyApi.getTagsAsXml
-GET        /tags/export/single/:id         controllers.ReadOnlyApi.tagsAsXml(id: Long)
+GET        /tags/export/single/:id         controllers.ReadOnlyApi.tagAsXml(id: Long)
 
 
 GET        /hello                         controllers.App.hello


### PR DESCRIPTION
This changes the XML exported from tags and references to match what comes out of R2. This is needed so that inCopy (and Pluto?) can consume the right feed. 

I've also added the routes so that you can get a single tag. I will add the existing routes later.

\cc @clloyd 