### PR TITLE
All XML routes in existing R2 index

### DIFF
--- a/app/controllers/ReadOnly.scala
+++ b/app/controllers/ReadOnly.scala
@@ -25,7 +25,7 @@ object ReadOnlyApi extends Controller {
   def mergesAsXml(since: Long) = Action {
     val merges = JobRepository.getMerges().map { job =>
       Merge(job)
-    }
+    }.filter(_.started.getMillis > since)
 
     Ok(<merges>
       {merges.map( x => x.asExportedXml)}

--- a/app/controllers/ReadOnly.scala
+++ b/app/controllers/ReadOnly.scala
@@ -3,8 +3,9 @@ package controllers
 import play.api.mvc.{Action, Controller}
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-
+import model.jobs.Merge
 import repositories._
+import play.api.libs.json._
 
 object ReadOnlyApi extends Controller {
   def getTagsAsXml() = Action.async {
@@ -19,5 +20,16 @@ object ReadOnlyApi extends Controller {
     TagRepository.getTag(id).map { tag =>
       Ok(tag.asExportedXml)
     }.getOrElse(NotFound)
+  }
+
+  def mergesAsXml(since: Long) = Action {
+    val merges = JobRepository.getMerges().map { job =>
+      Merge(job)
+    }
+
+    Ok(<merges>
+      {merges.map( x => x.asExportedXml)}
+      </merges>
+    )
   }
 }

--- a/app/model/jobs/Job.scala
+++ b/app/model/jobs/Job.scala
@@ -1,8 +1,9 @@
 package model.jobs
 
 import com.amazonaws.services.dynamodbv2.document.Item
-import model.command.Command
+import model.command.{Command, MergeTagCommand}
 import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
 import play.api.Logger
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -73,3 +74,36 @@ object JobRunner {
 }
 
 
+case class Merge(  id: Long,
+  started: DateTime,
+  startedBy: Option[String],
+  tagIds: List[Long],
+  command: MergeTagCommand
+) {
+
+  def asExportedXml = {
+    import xml.{Elem, TopScope, Null, Text}
+    import helpers.XmlHelpers._
+
+    val el = Elem(null, "merge", Null, TopScope, Text(""))
+    val from = createAttribute("from", Some(this.command.removingTagId))
+    val to = createAttribute("to", Some(this.command.replacementTagId))
+    val timestamp = createAttribute("timestamp", Some(this.started.getMillis))
+    val date = createAttribute("date", Some(this.started.toString("MM/dd/yyy HH:mm:ss")))
+
+    el % from % to % timestamp % date
+  }
+}
+
+object Merge {
+  def apply(job: Job): Merge = {
+    val merge = commandToMergeCommand(job.command)
+    Merge(job.id, job.started, job.startedBy, job.tagIds, merge)
+  }
+
+  private def commandToMergeCommand(command: Command): MergeTagCommand = {
+    val json = Json.toJson(command)
+    val merge : MergeTagCommand = json.as[MergeTagCommand]
+    merge
+  }
+}

--- a/app/model/jobs/Job.scala
+++ b/app/model/jobs/Job.scala
@@ -91,7 +91,7 @@ case class Merge(  id: Long,
     val timestamp = createAttribute("timestamp", Some(this.started.getMillis))
     val date = createAttribute("date", Some(this.started.toString("MM/dd/yyy HH:mm:ss")))
 
-    el % from % to % timestamp % date
+    el % timestamp % date % to % from
   }
 }
 

--- a/app/repositories/JobRepository.scala
+++ b/app/repositories/JobRepository.scala
@@ -37,4 +37,5 @@ object JobRepository {
     Dynamo.jobTable.scan(new ScanFilter("tagIds").contains(tagId)).map(Job.fromItem).toList
   }
 
+  def getMerges(): List[Job] = loadAllJobs.filter(_.`type` == "Merge tag")
 }

--- a/conf/routes
+++ b/conf/routes
@@ -47,8 +47,8 @@ GET        /hyper/tags/:id                controllers.HyperMediaApi.tag(id: Long
 OPTIONS    /*all                          controllers.HyperMediaApi.preflight(all: String)
 
 GET        /tags/export/all               controllers.ReadOnlyApi.getTagsAsXml
-GET        /tags/export/single/:id         controllers.ReadOnlyApi.tagAsXml(id: Long)
-
+GET        /tags/export/single/:id        controllers.ReadOnlyApi.tagAsXml(id: Long)
+GET        /tags/export/merges/:since     controllers.ReadOnlyApi.mergesAsXml(since: Long)
 
 GET        /hello                         controllers.App.hello
 GET        /testScan                      controllers.App.testScan


### PR DESCRIPTION
This finalises all the routes in the current index. Still need to discuss the ones that currently 404 in code and see how they are used. 

The routes for fetching XML info about the tags are:
```
/tags/export/all
/tags/export/single/:id
/tags/export/merges/:since
```