### PR TITLE
Tag with no content fix + UI Improvements

### DIFF
--- a/app/repositories/ContentAPI.scala
+++ b/app/repositories/ContentAPI.scala
@@ -55,7 +55,7 @@ object ContentAPI {
 
     val allIds = ids ::: resultPage.results.map(_.id)
 
-    if (page == resultPage.pages) {
+    if (page >= resultPage.pages) {
       allIds
     } else {
       getContentIdsForTag(apiTagId, page + 1, allIds)

--- a/public/components/Tag/TypeSelect.react.js
+++ b/public/components/Tag/TypeSelect.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as tagTypes from '../../constants/tagTypes';
 
 export default class TypeSelect extends React.Component {
 
@@ -20,8 +21,15 @@ export default class TypeSelect extends React.Component {
       <select value={this.props.selectedType} onChange={this.props.onChange} disabled={!!this.props.forceDisabled}>
         {!this.props.selectedType ? <option></option> : false}
         {this.props.types.sort((a, b) => {return a > b ? 1 : -1;}).map(function(type) {
+
+          const tagTypeKey = Object.keys(tagTypes).filter((tagTypeKey) => {
+            return tagTypes[tagTypeKey].name === type;
+          })[0];
+
           return (
-            <option value={type} key={this.props.selectedType + '_' + type}>{type}</option>
+            <option value={type} key={this.props.selectedType + '_' + type}>
+              {tagTypes[tagTypeKey] ? tagTypes[tagTypeKey].displayName : type}
+            </option>
           );
         }, this)}
       </select>

--- a/public/components/TagEdit/TagEdit.react.js
+++ b/public/components/TagEdit/TagEdit.react.js
@@ -11,7 +11,6 @@ import ContributorInfoEdit from './formComponents/contributor/ContributorInfoEdi
 import PublicationInfoEdit from './formComponents/publication/PublicationInfoEdit.react';
 import NewspaperBookInfoEdit from './formComponents/newspaperbook/NewspaperBookInfoEdit.react';
 
-
 import * as tagTypes from '../../constants/tagTypes';
 
 export default class TagEdit extends React.Component {
@@ -79,23 +78,23 @@ export default class TagEdit extends React.Component {
         return false;
       }
 
-      if (this.props.tag.type === tagTypes.topic) {
+      if (this.props.tag.type === tagTypes.topic.name) {
         return this.renderTopicFields();
       }
 
-      if (this.props.tag.type === tagTypes.series) {
+      if (this.props.tag.type === tagTypes.series.name) {
         return this.renderSeriesFields();
       }
 
-      if (this.props.tag.type === tagTypes.contributor) {
+      if (this.props.tag.type === tagTypes.contributor.name) {
         return this.renderContributorFields();
       }
 
-      if (this.props.tag.type === tagTypes.publication) {
+      if (this.props.tag.type === tagTypes.publication.name) {
         return this.renderPublicationFields();
       }
 
-      if (this.props.tag.type === tagTypes.newspaperBook) {
+      if (this.props.tag.type === tagTypes.newspaperBook.name) {
         return this.renderNewspaperBookFields();
       }
 

--- a/public/components/TagEdit/formComponents/TagName.react.js
+++ b/public/components/TagEdit/formComponents/TagName.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as tagTypes from '../../../constants/tagTypes';
 
 function slugify(text) {
   return text ? text.toLowerCase().replace(/[^a-z0-9-]/g, '-') : '';
@@ -105,12 +106,34 @@ export default class TagNameEdit extends React.Component {
   }
 
   getPathPrefixForSection() {
-    if (!this.props.sections || !this.props.tag.section) {
-      return '???/';
+
+    //Infer from Tag Type
+    if (!this.props.tag.type) {
+      return '/';
     }
+
+    const tagTypeKey = Object.keys(tagTypes).filter((tagTypeKey) => {
+      return tagTypes[tagTypeKey].name === this.props.tag.type;
+    })[0];
+
+    if (tagTypes[tagTypeKey].pathPrefix) {
+      return tagTypes[tagTypeKey].pathPrefix + '/';
+    }
+
+    //Infer from section
+
+    if (!this.props.sections || !this.props.tag.section) {
+      return '/';
+    }
+
     var section = this.props.sections.filter((section) => section.id === this.props.tag.section);
 
     if (section.length) {
+
+      if (tagTypes[tagTypeKey].additionalPathPrefix) {
+        return section[0].wordsForUrl + '/' + tagTypes[tagTypeKey].additionalPathPrefix + '/';
+      }
+
       return section[0].wordsForUrl + '/';
     } else {
       return '/';
@@ -145,7 +168,6 @@ export default class TagNameEdit extends React.Component {
     if (!this.state.slugLocked && !this.state.comparableValueLocked) {
       classNames.externalName.link = this.state.externalNameLocked ? 'tag-edit__linked-field__link--corner' : 'tag-edit__linked-field__link';
     }
-
     return (
       <div className="tag-edit__input-group">
         <div className="tag-edit__name">
@@ -172,8 +194,8 @@ export default class TagNameEdit extends React.Component {
             <div className={classNames.slug.lock} onClick={this.toggleSlugLock.bind(this)}></div>
             <label>Slug</label>
             <div className="tag-edit__linked-field__input-container">
-              <span>{this.getPathPrefixForSection()}</span>
-              <input type="text" disabled={this.props.pathLocked} value={this.props.tag.slug} onChange={this.onUpdateSlug.bind(this)}/>
+              <span>{!this.props.pathLocked ? this.getPathPrefixForSection() : this.props.tag.path}</span>
+              {!this.props.pathLocked ? <input type="text" disabled={this.props.pathLocked} value={this.props.tag.slug} onChange={this.onUpdateSlug.bind(this)}/> : false}
             </div>
           </div>
         </div>

--- a/public/components/TagEdit/formComponents/TagTypeCustomFields.react.js
+++ b/public/components/TagEdit/formComponents/TagTypeCustomFields.react.js
@@ -37,7 +37,7 @@ export default class TagTypeCustomFields extends React.Component {
         return false;
       }
 
-      if (this.props.tag.type === tagTypes.topic) {
+      if (this.props.tag.type === tagTypes.topic.name) {
         return [
           (<div className="tag-edit__input-group" key="keyword-section">
             <label className="tag-edit__input-group__header">Section</label>
@@ -48,7 +48,7 @@ export default class TagTypeCustomFields extends React.Component {
               <TopicCategories selectedCategories={this.props.tag.categories} onChange={this.onUpdateCategory.bind(this)}/>
           </div>)
         ];
-      } else if (this.props.tag.type === tagTypes.series) {
+      } else if (this.props.tag.type === tagTypes.series.name) {
         return <PodcastMetadata tag={this.props.tag} updateTag={this.props.updateTag}/>;
       }
     }

--- a/public/components/TagList/TagList.react.js
+++ b/public/components/TagList/TagList.react.js
@@ -1,11 +1,19 @@
 import React from 'react';
 import history from '../../routes/history';
+import * as tagTypes from '../../constants/tagTypes';
 
 export default class TagList extends React.Component {
 
     constructor(props) {
         super(props);
         this.renderListItem = this.renderListItem.bind(this);
+
+        //Much more convenient form of this information, removes need to calculate per row below.
+        this.tagTypesMap = Object.keys(tagTypes).reduce((previous, tagTypeKey) => {
+          const newObject = {};
+          newObject[tagTypes[tagTypeKey].name] = tagTypes[tagTypeKey].displayName;
+          return Object.assign({}, previous, newObject);
+        }, {});
     }
 
     renderListItem(tag) {
@@ -18,7 +26,7 @@ export default class TagList extends React.Component {
 
       return (
           <tr key={tag.id} className="taglist__results-item" onClick={this.onTagClick.bind(this, tag)}>
-            <td>{tag.type}</td>
+            <td>{this.tagTypesMap[tag.type] ? this.tagTypesMap[tag.type] : tag.type}</td>
             <td>{tag.internalName}</td>
             <td>{sectionName}</td>
             <td>{tag.path}</td>

--- a/public/components/utils/TagSelect.js
+++ b/public/components/utils/TagSelect.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import tagManagerApi from '../../util/tagManagerApi';
 import debounce from 'lodash.debounce';
+import * as tagTypes from '../../constants/tagTypes';
 
 const BLANK_STATE = {
   selectedTag: undefined,
@@ -49,19 +50,41 @@ export default class TagSelect extends React.Component {
         });
     }
 
+    renderSuggestions() {
+      if (!this.state.suggestions.length) {
+        return false;
+      }
+
+      return (
+        <div className="tag-select__suggestions">
+          <ul>
+            {this.state.suggestions.map(tag => {
+
+              const tagTypeKey = Object.keys(tagTypes).filter((tagTypeKey) => {
+                return tagTypes[tagTypeKey].name === tag.type;
+              })[0];
+
+              return (
+                <li key={tag.id} onClick={this.onClickTag.bind(this, tag)}>
+                  <div className="tag-select__name">{tag.internalName}</div>
+                  <div className="tag-select__tag-type">
+                    {tagTypes[tagTypeKey] ? tagTypes[tagTypeKey].displayName : ''}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      );
+    }
+
     render() {
       return (
         <div className={this.props.showResultsAbove ? 'tag-select--results-above' : 'tag-select'}>
             <div>
               <input className="tag-select__input" type="text" autoFocus={true} value={this.state.tagSearchTerm} onChange={this.onUpdateSearchField.bind(this)}/>
             </div>
-            <div className="tag-select__suggestions">
-              <ul>
-                {this.state.suggestions.map(tag => {
-                  return <li key={tag.id} onClick={this.onClickTag.bind(this, tag)}>{tag.internalName}</li>;
-                })}
-              </ul>
-            </div>
+            {this.renderSuggestions()}
         </div>
       );
     }

--- a/public/constants/tagTypes.js
+++ b/public/constants/tagTypes.js
@@ -5,27 +5,32 @@ export const topic = {
 
 export const series = {
   name: 'Series',
-  displayName: 'Series'
+  displayName: 'Series',
+  additionalPathPrefix: 'series' //This is in addition to regular section prefix.
 };
 
 export const contributor = {
   name: 'Contributor',
-  displayName: 'Contributor'
+  displayName: 'Contributor',
+  pathPrefix: 'profile'
 };
 
 export const tone = {
   name: 'Tone',
-  displayName: 'Tone'
+  displayName: 'Tone',
+  pathPrefix: 'tone'
 };
 
 export const contentType = {
   name: 'ContentType',
-  displayName: 'Content Type'
+  displayName: 'Content Type',
+  pathPrefix: 'type'
 };
 
 export const publication = {
   name: 'Publication',
-  displayName: 'Publication'
+  displayName: 'Publication',
+  pathPrefix: 'publication'
 };
 
 export const newspaperBook = {

--- a/public/constants/tagTypes.js
+++ b/public/constants/tagTypes.js
@@ -1,5 +1,39 @@
-export const topic = 'Topic';
-export const series = 'Series';
-export const contributor = 'Contributor';
-export const publication = 'Publication';
-export const newspaperBook = 'NewspaperBook';
+export const topic = {
+  name: 'Topic',
+  displayName: 'Topic'
+};
+
+export const series = {
+  name: 'Series',
+  displayName: 'Series'
+};
+
+export const contributor = {
+  name: 'Contributor',
+  displayName: 'Contributor'
+};
+
+export const tone = {
+  name: 'Tone',
+  displayName: 'Tone'
+};
+
+export const contentType = {
+  name: 'ContentType',
+  displayName: 'Content Type'
+};
+
+export const publication = {
+  name: 'Publication',
+  displayName: 'Publication'
+};
+
+export const newspaperBook = {
+  name: 'NewspaperBook',
+  displayName: 'Newspaper Book'
+};
+
+export const newspaperBookSection = {
+  name: 'NewspaperBookSection',
+  displayName: 'Newspaper Book Section'
+};

--- a/public/style/components/merge-tag/_index.scss
+++ b/public/style/components/merge-tag/_index.scss
@@ -20,10 +20,6 @@
   .tag-select {
     display: block;
   }
-
-  .tag-select__input {
-    width: 100%;
-  }
 }
 
 .merge__select__header {

--- a/public/style/components/tag-select/_index.scss
+++ b/public/style/components/tag-select/_index.scss
@@ -1,7 +1,17 @@
 .tag-select,
 .tag-select--results-above {
+
+  @extend %f-header;
+  @extend %fs-data-3;
+
   display: inline-block;
   position: relative;
+
+  min-width: 200px;
+}
+
+.tag-select__input {
+  width: 100%;
 }
 
 .tag-select__suggestions {
@@ -12,9 +22,14 @@
   border: 1px solid $c-grey-300;
   background-color: $c-grey-100;
 
+  width: 100%;
+
+  z-index: 2;
+
 
   li {
-    display: block;
+    position: relative;
+    display: flex;
     padding: $standard-padding/2 $standard-padding;
 
     cursor: pointer;
@@ -28,4 +43,24 @@
     top: auto;
     bottom: 20px;
   }
+}
+
+
+.tag-select__name {
+  flex-grow: 1;
+}
+
+.tag-select__tag-type {
+
+  flex-grow: 0;
+
+
+  background-color: $c-grey-300;
+
+  border-radius: 4px;
+
+  padding: 0 6px;
+
+  vertical-align: center;
+
 }

--- a/public/util/validateTag.js
+++ b/public/util/validateTag.js
@@ -48,9 +48,9 @@ export function validateTag(tag) {
 
   let additionalErrors = []; //Use this to store other validation errors
 
-  if (tag.type === tagTypes.topic) {
+  if (tag.type === tagTypes.topic.name) {
     mandatoryFields = mandatoryFields.concat(['section']);
-  } else if (tag.type === tagTypes.series) {
+  } else if (tag.type === tagTypes.series.name) {
     additionalErrors = additionalErrors.concat(validatePodcast(tag));
   }
 


### PR DESCRIPTION
Fix for delete entering loop when no content returned from CAPI.

This fixes a few UI issues: 

 - `<TagSelect />` now shows the tag type,
 - `<TagSelect />` is now a sensible width
 - `<TagSelect />` suggestions should now appear above other ui elements,
 - `<TagNaming />` should now guess slugs much more accurately,
 - Tag types should now be referred to with a nicer name (Spaces not just camel case)

