### PR TITLE
Fix some issues with merging

### DIFF
--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -56,6 +56,17 @@ object TagAudit {
     TagAudit(tag.id, "deleted", new DateTime(), username.getOrElse("default user"), s"tag '${tag.internalName}' deleted", TagSummary(tag), None)
   }
 
+  def merged(removingTag: Tag, replacementTag: Tag, username: Option[String]): TagAudit = {
+    TagAudit(removingTag.id,
+      "merged" ,
+      new DateTime(),
+      username.getOrElse("default user"),
+      s"tag '${removingTag.internalName}' merged with '${replacementTag.internalName}'",
+      TagSummary(removingTag),
+      Some(TagSummary(replacementTag))
+    )
+  }
+
   def batchTag(tag: Tag, operation: String, contentCount: Int)(implicit user: Option[User] = None): TagAudit = {
     val message = operation match {
       case "remove" => s"tag '${tag.internalName}' removed from $contentCount items(s)"

--- a/app/model/jobs/Job.scala
+++ b/app/model/jobs/Job.scala
@@ -74,7 +74,7 @@ object JobRunner {
 }
 
 
-case class Merge(  id: Long,
+case class Merge(id: Long,
   started: DateTime,
   startedBy: Option[String],
   tagIds: List[Long],

--- a/app/model/jobs/Step.scala
+++ b/app/model/jobs/Step.scala
@@ -19,7 +19,7 @@ object Step {
       case b: RemoveTagStep => RemoveTagStep.removeTagStepFormat.writes(b).asInstanceOf[JsObject] + ("type", JsString("RemoveTagStep"))
       case b: AllUsagesOfTagRemovedCheck => AllUsagesOfTagRemovedCheck.allUsagesOfTagRemovedCheckFormat.writes(b).asInstanceOf[JsObject] + ("type", JsString("AllUsagesOfTagRemovedCheck"))
       case trc: TagRemovedCheck => JsObject(Map("type" -> JsString("TagRemovedCheck"), "apiTagId" -> JsString(trc.apiTagId)))
-
+      case mas: MergeAuditStep => MergeAuditStep.mergeAuditStepFormat.writes(mas).asInstanceOf[JsObject] + ("type" -> JsString("MergeAuditStep"))
       case ridx: ReindexTags => ReindexTags.reindexTagsFormat.writes(ridx).asInstanceOf[JsObject] + ("type", JsString("ReindexTags"))
 
       case other => {
@@ -37,6 +37,7 @@ object Step {
         case JsString("RemoveTagStep") => RemoveTagStep.removeTagStepFormat.reads(json)
         case JsString("AllUsagesOfTagRemovedCheck") => AllUsagesOfTagRemovedCheck.allUsagesOfTagRemovedCheckFormat.reads(json)
         case JsString("TagRemovedCheck") => (json \ "apiTagId").validate[String].map(TagRemovedCheck)
+        case JsString("MergeAuditStep") => MergeAuditStep.mergeAuditStepFormat.reads(json)
         case JsString("ReindexTags") => ReindexTags.reindexTagsFormat.reads(json)
         case JsString(other) => JsError(s"unsupported command type $other}")
         case _ => JsError(s"unexpected command type value")

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -106,7 +106,7 @@ class DevConfig extends Config {
   override def sequenceTableName: String = "tag-manager-sequences-dev"
   override def referencesTypeTableName: String = "tag-manager-reference-type-dev"
 
-  override def jobTableName: String = "tag-manager-jobs-dev"
+  override def jobTableName: String = "tag-manager-jobs-DEV-HG"
   override def tagAuditTableName: String = "tag-manager-tag-audit-dev"
   override def sectionAuditTableName: String = "tag-manager-section-audit-dev"
   override def clusterStatusTableName: String = "tag-manager-cluster-status-dev"


### PR DESCRIPTION
This adds a new step that will upload the merge operation to the audit table as previously we were just tracking  the old tag being deleted and we need to keep track of the whole merge.