### PR TITLE
Speedup the all tags XML route

### DIFF
--- a/app/controllers/ReadOnly.scala
+++ b/app/controllers/ReadOnly.scala
@@ -9,12 +9,12 @@ import repositories._
 
 
 object ReadOnlyApi extends Controller {
-  def getTagsAsXml() = Action.async {
-    Future(TagLookupCache.allTags.get.map(_.asExportedXml)) map { tags =>
-      Ok(<tags>
-        {tags.seq.map { x => x }}
-        </tags>)
-    }
+  def getTagsAsXml() = Action {
+    val tags = TagLookupCache.allTags
+    val xmlTags = tags.get.map(_.asExportedXml)
+    Ok(<tags>
+      {xmlTags.seq.map { x => x }}
+      </tags>)
   }
 
   def tagAsXml(id: Long) = Action {

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -6,7 +6,7 @@ import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import com.gu.tagmanagement.{Tag => ThriftTag, TagType, TagReindexBatch}
 import helpers.XmlHelpers._
-import repositories.SectionRepository
+import repositories.SectionLookupCache
 import scala.util.control.NonFatal
 import scala.xml.Node
 
@@ -58,7 +58,7 @@ case class Tag(
   // in this limited format for inCopy to consume
   def asExportedXml = {
     val el = createElem("tag")
-    val section = SectionRepository.getSection(this.id)
+    val section = SectionLookupCache.getSection(this.section)
     val id = createAttribute("id", Some(this.id))
     val externalName = createAttribute("externalname", Some(this.externalName))
     val internalName = createAttribute("internalname", Some(this.internalName))

--- a/app/modules/clustersync/ClusterSynchronisation.scala
+++ b/app/modules/clustersync/ClusterSynchronisation.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject._
 import play.api.Logger
-import repositories.TagLookupCache
+import repositories.{TagLookupCache, SectionLookupCache}
 import services.{Config, KinesisConsumer}
 
 import scala.collection.convert.wrapAll._
@@ -37,6 +37,9 @@ class ClusterSynchronisation @Inject() (lifecycle: ApplicationLifecycle) {
 
       Logger.info("loading tag cache")
       TagLookupCache.refresh
+
+      Logger.info("loading section cache")
+      SectionLookupCache.refresh
 
       val tagUpdateConsumer = new KinesisConsumer(Config().tagUpdateStreamName, s"tag-cache-syncroniser-${ns.nodeId}", TagSyncUpdateProcessor)
       Logger.info("starting sync consumer")

--- a/app/modules/clustersync/SectionSyncUpdateProcessor.scala
+++ b/app/modules/clustersync/SectionSyncUpdateProcessor.scala
@@ -1,0 +1,31 @@
+package modules.clustersync
+
+import com.amazonaws.services.kinesis.model.Record
+import com.gu.tagmanagement.{EventType, SectionEvent}
+import model.Section
+import play.api.Logger
+import repositories.SectionLookupCache
+import services.KinesisStreamRecordProcessor
+
+object SectionSyncUpdateProcessor extends KinesisStreamRecordProcessor {
+
+  import services.KinesisRecordPayloadConversions._
+
+  override def process(record: Record) {
+    val sectionEvent = SectionEvent.decode(record)
+
+    sectionEvent.eventType match {
+      case EventType.Update => {
+        Logger.info(s"inserting updated section ${sectionEvent.sectionId} into lookup cache")
+        sectionEvent.section.foreach { s => SectionLookupCache.insertSection(Section(s)) }
+      }
+      case EventType.Delete => {
+        Logger.info(s"removing section ${sectionEvent.sectionId} from lookup cache")
+        SectionLookupCache.removeSection(sectionEvent.sectionId)
+      }
+      case et => {
+        Logger.warn(s"unrecognised event type ${et.name}")
+      }
+    }
+  }
+}

--- a/app/repositories/SectionRepository.scala
+++ b/app/repositories/SectionRepository.scala
@@ -35,9 +35,7 @@ object SectionLookupCache {
   def refresh = {
     val sections = SectionRepository.loadAllSections
     sections.foreach { section =>
-      val id = section.id
-      val current = allSections.get
-      allSections.getAndSet(current + (id -> section))
+      insertSection(section)
     }
   }
 
@@ -45,5 +43,15 @@ object SectionLookupCache {
     id.flatMap { i =>
       allSections.get.get(i)
     }
+  }
+
+  def insertSection(section: Section): Map[Long, Section] = {
+    val current = allSections.get
+    allSections.getAndSet(current + (section.id -> section))
+  }
+
+  def removeSection(id: Long): Map[Long, Section] = {
+    val current = allSections.get
+    allSections.getAndSet(current - id)
   }
 }


### PR DESCRIPTION
This speeds up the XML all tabs route quite significantly. We should check it and see we also want to an export to S3 and just download that when it's requested but for now this seems like a pretty efficient way to grab all the tags.

I have also created a section cache since the tag sections needs to be exported in the XML