### PR TITLE
Removed categories component from view until after release

### DIFF
--- a/public/components/TagEdit/TagEdit.react.js
+++ b/public/components/TagEdit/TagEdit.react.js
@@ -55,15 +55,17 @@ export default class TagEdit extends React.Component {
                 disabled={this.props.pathLocked || !this.props.tagEditable}
               />
           </div>
-          <div className="tag-edit__input-group" key="topic-category">
-            <label className="tag-edit__input-group__header">Category</label>
-              <TopicCategories
-                selectedCategories={this.props.tag.categories}
-                onChange={this.onUpdateCategory.bind(this)}
-                tagEditable={this.props.tagEditable}/>
-          </div>
         </div>
       );
+
+      //Removed:
+      //<div className="tag-edit__input-group" key="topic-category">
+      //   <label className="tag-edit__input-group__header">Category</label>
+      //     <TopicCategories
+      //       selectedCategories={this.props.tag.categories}
+      //       onChange={this.onUpdateCategory.bind(this)}
+      //       tagEditable={this.props.tagEditable}/>
+      // </div>
     }
 
     renderSeriesFields() {

--- a/public/components/TagEdit/TagEdit.react.js
+++ b/public/components/TagEdit/TagEdit.react.js
@@ -58,7 +58,7 @@ export default class TagEdit extends React.Component {
         </div>
       );
 
-      //Removed:
+      //TODO RE-ADD THIS COMPONENT:
       //<div className="tag-edit__input-group" key="topic-category">
       //   <label className="tag-edit__input-group__header">Category</label>
       //     <TopicCategories


### PR DESCRIPTION
This comments out the TopicCategories select which won't be supported at launch (but added in soon after)

fixes #94 