### PR TITLE
Limits Blog Tag creation, show deprecation

### DIFF
--- a/app/permissions/TagSpecificPermissions.scala
+++ b/app/permissions/TagSpecificPermissions.scala
@@ -15,6 +15,7 @@ object TagTypePermissionMap {
   def apply(tagType: String): Option[Permission] = {
     tagType match {
       case TagType.Tone.name => Some(Permissions.TagSuperAdmin)
+      case TagType.Blog.name => Some(Permissions.TagSuperAdmin) //Blog is to be deprecated
       case TagType.Publication.name => Some(Permissions.TagAdmin)
       case TagType.NewspaperBook.name => Some(Permissions.TagAdmin)
       case TagType.NewspaperBookSection.name => Some(Permissions.TagAdmin)

--- a/app/permissions/TagSpecificPermissions.scala
+++ b/app/permissions/TagSpecificPermissions.scala
@@ -16,6 +16,7 @@ object TagTypePermissionMap {
     tagType match {
       case TagType.Tone.name => Some(Permissions.TagSuperAdmin)
       case TagType.Blog.name => Some(Permissions.TagSuperAdmin) //Blog is to be deprecated
+      case TagType.ContentType.name => Some(Permissions.TagSuperAdmin)
       case TagType.Publication.name => Some(Permissions.TagAdmin)
       case TagType.NewspaperBook.name => Some(Permissions.TagAdmin)
       case TagType.NewspaperBookSection.name => Some(Permissions.TagAdmin)

--- a/public/constants/tagTypes.js
+++ b/public/constants/tagTypes.js
@@ -45,5 +45,5 @@ export const newspaperBookSection = {
 
 export const blog = {
   name: 'Blog',
-  displayName: 'Blog'
+  displayName: 'Blog - DEPRECATED'
 };


### PR DESCRIPTION
Blog Tag is now deprecated (Shows deprecated in tag select) and requires super admin permissions - #91 

ContentType tag is now behind a super admin permission for creation