### PR TITLE
Increasing contrast of save bar

### DIFF
--- a/public/style/components/save/_index.scss
+++ b/public/style/components/save/_index.scss
@@ -8,8 +8,8 @@
 
   display: block;
 
-  background-color: $c-grey-200;
-  border-top: 1px solid $c-grey-300;
+  background-color: $c-alt-green;
+  border-top: 1px solid $c-grey-400;
   width: 100%;
 
   text-align: left;


### PR DESCRIPTION
If this isn't adequate please add a comment :smile: 

Previously:

<img width="1280" alt="previous" src="https://cloud.githubusercontent.com/assets/5560113/12724419/cfe9ed5c-c905-11e5-8604-2e94ef5e35b5.png">

New:

<img width="1280" alt="current" src="https://cloud.githubusercontent.com/assets/5560113/12724426/d59ff480-c905-11e5-95f3-70e1d9a98e51.png">