### PR TITLE
Add capiType support to references picker

### DIFF
--- a/app/model/ExternalReferenceType.scala
+++ b/app/model/ExternalReferenceType.scala
@@ -11,7 +11,8 @@ import scala.util.control.NonFatal
 case class ExternalReferenceType (
                     typeName: String,
                     displayName: String,
-                    path: String
+                    path: String,
+                    capiType: Option[String]
                   )
 
 object ExternalReferenceType {
@@ -19,7 +20,8 @@ object ExternalReferenceType {
   implicit val sectionFormat: Format[ExternalReferenceType] = (
     (JsPath \ "typeName").format[String] and
       (JsPath \ "displayName").format[String] and
-      (JsPath \ "path").format[String]
+      (JsPath \ "path").format[String] and
+      (JsPath \ "capiType").formatNullable[String]
     )(ExternalReferenceType.apply, unlift(ExternalReferenceType.unapply))
 
   def fromItem(item: Item) = try{

--- a/app/model/Reference.scala
+++ b/app/model/Reference.scala
@@ -5,8 +5,8 @@ import play.api.libs.functional.syntax._
 import com.gu.tagmanagement.{Reference => ThriftReference}
 import helpers.XmlHelpers._
 
-case class Reference(`type`: String, value: String) {
-  def asThrift = ThriftReference(`type`, value)
+case class Reference(`type`: String, value: String, capiType: Option[String]) {
+  def asThrift = ThriftReference(`type`, value, capiType)
 
 
   def asExportedXml = {
@@ -25,9 +25,11 @@ object Reference {
 
   implicit val referenceFormat: Format[Reference] = (
       (JsPath \ "type").format[String] and
-      (JsPath \ "value").format[String]
+      (JsPath \ "value").format[String] and
+        (JsPath \ "capiType").formatNullable[String]
+
     )(Reference.apply, unlift(Reference.unapply))
 
-  def apply(thriftReference: ThriftReference): Reference = Reference(thriftReference.`type`, thriftReference.value)
+  def apply(thriftReference: ThriftReference): Reference = Reference(thriftReference.`type`, thriftReference.value, thriftReference.capiType)
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val dependencies = Seq(
   "com.twitter" %% "scrooge-core" % "4.1.0",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client" % "7.7",
-  "com.gu" %% "tags-thrift-schema" % "0.3.7",
+  "com.gu" %% "tags-thrift-schema" % "0.3.8",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/public/components/TagContext/TagReferences/AddReference.react.js
+++ b/public/components/TagContext/TagReferences/AddReference.react.js
@@ -47,8 +47,11 @@ export default class AddReference extends React.Component {
         return;
       }
 
+      const refType = this.props.referenceTypes.filter((r) => r.typeName === this.state.newType)[0];
+
       this.props.onAddReference({
-        type: this.state.newType,
+        type: refType.typeName,
+        capiType: refType.capiType,
         value: this.state.newValue
       });
 


### PR DESCRIPTION
This adds capiType support (old API indexer logic moved to tagmanager)