### PR TITLE
Updated Path Calculation for publication and content type

### DIFF
--- a/app/model/command/logic/TagPathCalculator.scala
+++ b/app/model/command/logic/TagPathCalculator.scala
@@ -13,10 +13,10 @@ object TagPathCalculator {
     val sectionPathPrefix = loadedSection.map(_.wordsForUrl + "/").getOrElse("")
 
     `type`.toLowerCase match {
-      case "contenttype" => s"type/$slug"
+      case "contenttype" => s"$slug"
       case "tone" => s"tone/$slug"
       case "contributor" => s"profile/$slug"
-      case "publication" => s"publication/$slug"
+      case "publication" => s"$slug/all"
       case "series" => s"${sectionPathPrefix}series/$slug"
       case _ => sectionPathPrefix + slug
     }

--- a/public/constants/tagTypes.js
+++ b/public/constants/tagTypes.js
@@ -23,14 +23,12 @@ export const tone = {
 
 export const contentType = {
   name: 'ContentType',
-  displayName: 'Content Type',
-  pathPrefix: 'type'
+  displayName: 'Content Type'
 };
 
 export const publication = {
   name: 'Publication',
-  displayName: 'Publication',
-  pathPrefix: 'publication'
+  displayName: 'Publication'
 };
 
 export const newspaperBook = {


### PR DESCRIPTION
This updates the path calculation for publication and content type tags, previously we were calculating the capi id, but these tag types the id differs from the path, this calculates the correct path