### PR TITLE
Added paging to batchtagging

### DIFF
--- a/public/actions/CapiActions/searchCapi.js
+++ b/public/actions/CapiActions/searchCapi.js
@@ -1,10 +1,18 @@
 import debounce from 'lodash.debounce';
 import {searchContent} from '../../util/capiClient';
 
+export const CAPI_CLEAR_PAGES = 'CAPI_CLEAR_PAGES';
 export const CAPI_SEARCH_REQUEST = 'CAPI_SEARCH_REQUEST';
 export const CAPI_SEARCH_RECEIVE = 'CAPI_SEARCH_RECEIVE';
 export const CAPI_SEARCH_ERROR = 'CAPI_SEARCH_ERROR';
 export const CAPI_FILTERS_UPDATE = 'CAPI_FILTERS_UPDATE';
+
+function capiClearPages() {
+    return {
+        type:               CAPI_CLEAR_PAGES,
+        receivedAt:         Date.now()
+    }
+}
 
 function requestCapiSearch(searchTerm) {
     return {
@@ -19,6 +27,7 @@ function recieveCapiSearch(res, searchTerm) {
         type:               CAPI_SEARCH_RECEIVE,
         results:            res.response.results,
         resultsCount:       res.response.total,
+        page:               res.response.currentPage,
         searchTerm:         searchTerm,
         receivedAt:         Date.now()
     };
@@ -45,6 +54,12 @@ export function searchCapi(searchString, params) {
     return dispatch => {
         dispatch(requestCapiSearch(searchString));
         return _debouncedSearch(dispatch, searchString, params);
+    };
+}
+
+export function clearPages() {
+    return dispatch => {
+        dispatch(capiClearPages())
     };
 }
 

--- a/public/actions/CapiActions/searchCapi.js
+++ b/public/actions/CapiActions/searchCapi.js
@@ -2,6 +2,7 @@ import debounce from 'lodash.debounce';
 import {searchContent} from '../../util/capiClient';
 
 export const CAPI_CLEAR_PAGES = 'CAPI_CLEAR_PAGES';
+export const CAPI_SWITCH_PAGE = 'CAPI_SWITCH_PAGE';
 export const CAPI_SEARCH_REQUEST = 'CAPI_SEARCH_REQUEST';
 export const CAPI_SEARCH_RECEIVE = 'CAPI_SEARCH_RECEIVE';
 export const CAPI_SEARCH_ERROR = 'CAPI_SEARCH_ERROR';
@@ -12,6 +13,14 @@ function capiClearPages() {
         type:               CAPI_CLEAR_PAGES,
         receivedAt:         Date.now()
     }
+}
+
+function switchCapiPage(page) {
+    return {
+        type: CAPI_SWITCH_PAGE,
+        page: page
+    }
+
 }
 
 function requestCapiSearch(searchTerm) {
@@ -55,6 +64,12 @@ export function searchCapi(searchString, params) {
         dispatch(requestCapiSearch(searchString));
         return _debouncedSearch(dispatch, searchString, params);
     };
+}
+
+export function switchPage(page) {
+    return dispatch => {
+        dispatch(switchCapiPage(page));
+    }
 }
 
 export function clearPages() {

--- a/public/components/BatchTag.react.js
+++ b/public/components/BatchTag.react.js
@@ -147,7 +147,12 @@ export class BatchTag extends React.Component {
         'page': page
       });
 
-      this.props.capiActions.searchCapi(this.props.capiSearch.searchTerm, params);
+      if (this.props.capiSearch.pages[page]) {
+        // If we already have the page just used the cached version
+        this.props.capiActions.switchPage(page);
+      } else {
+        this.props.capiActions.searchCapi(this.props.capiSearch.searchTerm, params);
+      }
     }
 
     renderPageNavigator() {

--- a/public/components/utils/PageNavigator.react.js
+++ b/public/components/utils/PageNavigator.react.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+export default class PageNavigator extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    renderPageButton(number) {
+        if (number == this.props.currentPage) {
+            return (<span key={"page_" + number} className="page-navigator__selected">{number}</span>);
+        }
+        return (<span key={"page_" + number} className="page-navigator__page" onClick={this.props.pageSelectCallback.bind(this, number)}>{number}</span>);
+    }
+
+    renderStartElipsis(firstDisplayedPage, lastPage) {
+        if (firstDisplayedPage > 2 && firstDisplayedPage < lastPage) {
+            return (<span>...</span>);
+        }
+        return false;
+    }
+
+    renderEndElipsis(lastDisplayedPage, lastPage) {
+        if (lastDisplayedPage < lastPage) {
+            return (<span> ... </span>);
+        }
+        return false;
+    }
+
+    renderPageSpan(firstDisplayedPage, lastDisplayedPage) {
+        var spans = [];
+        for (var i = firstDisplayedPage; i <= lastDisplayedPage; i++) {
+            spans.push(this.renderPageButton(i));
+        }
+        return spans;
+    }
+
+    render() {
+        var firstDisplayedPage = Math.max(2, this.props.currentPage - this.props.pageSpan);
+        var lastDisplayedPage = Math.min(this.props.lastPage, firstDisplayedPage + this.props.pageSpan * 2);
+        return (<div className="page-navigator">
+                    {this.renderPageButton(1)}
+
+                    {this.renderStartElipsis(firstDisplayedPage, this.props.lastPage)}
+
+                    {this.renderPageSpan(firstDisplayedPage, lastDisplayedPage)}
+
+                    {this.renderEndElipsis(lastDisplayedPage, this.props.lastPage)}
+                </div>);
+    }
+}

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -10,7 +10,7 @@ import {SECTION_SAVE_REQUEST, SECTION_SAVE_RECEIVE, SECTION_SAVE_ERROR} from '..
 import {REFERENCE_TYPES_GET_REQUEST, REFERENCE_TYPES_GET_RECEIVE, REFERENCE_TYPES_GET_ERROR} from '../actions/ReferenceTypeActions/getReferenceTypes';
 import {TAG_POPULATE_BLANK} from '../actions/TagActions/createTag';
 import {SECTION_POPULATE_BLANK} from '../actions/SectionsActions/createSection';
-import {CAPI_CLEAR_PAGES, CAPI_SEARCH_RECEIVE, CAPI_SEARCH_REQUEST, CAPI_FILTERS_UPDATE} from '../actions/CapiActions/searchCapi';
+import {CAPI_CLEAR_PAGES, CAPI_SWITCH_PAGE, CAPI_SEARCH_RECEIVE, CAPI_SEARCH_REQUEST, CAPI_FILTERS_UPDATE} from '../actions/CapiActions/searchCapi';
 import {CLEAR_ERROR} from '../actions/UIActions/clearError';
 import {SHOW_ERROR} from '../actions/UIActions/showError';
 
@@ -210,6 +210,13 @@ export default function tag(state = {
           count: 0,
           pageRequestCount: 0
       })
+    });
+
+  case CAPI_SWITCH_PAGE:
+    return Object.assign({}, state, {
+        capiSearch: Object.assign({}, state.capiSearch, {
+            currentPage: action.page
+        })
     });
 
   case CAPI_SEARCH_REQUEST:

--- a/public/reducers/rootReducer.js
+++ b/public/reducers/rootReducer.js
@@ -10,7 +10,7 @@ import {SECTION_SAVE_REQUEST, SECTION_SAVE_RECEIVE, SECTION_SAVE_ERROR} from '..
 import {REFERENCE_TYPES_GET_REQUEST, REFERENCE_TYPES_GET_RECEIVE, REFERENCE_TYPES_GET_ERROR} from '../actions/ReferenceTypeActions/getReferenceTypes';
 import {TAG_POPULATE_BLANK} from '../actions/TagActions/createTag';
 import {SECTION_POPULATE_BLANK} from '../actions/SectionsActions/createSection';
-import {CAPI_SEARCH_RECEIVE, CAPI_SEARCH_REQUEST, CAPI_FILTERS_UPDATE} from '../actions/CapiActions/searchCapi';
+import {CAPI_CLEAR_PAGES, CAPI_SEARCH_RECEIVE, CAPI_SEARCH_REQUEST, CAPI_FILTERS_UPDATE} from '../actions/CapiActions/searchCapi';
 import {CLEAR_ERROR} from '../actions/UIActions/clearError';
 import {SHOW_ERROR} from '../actions/UIActions/showError';
 
@@ -19,11 +19,6 @@ export const saveState = {
   clean: 'SAVE_STATE_CLEAN',
   inprogress: 'SAVE_STATE_INPROGRESS',
   error: 'SAVE_STATE_ERROR'
-};
-
-const fetchState = {
-  dirty: 'FETCH_STATE_DIRTY',
-  clean: 'FETCH_STATE_CLEAN'
 };
 
 export default function tag(state = {
@@ -208,22 +203,38 @@ export default function tag(state = {
 
   //CAPI SEARCH
 
+  case CAPI_CLEAR_PAGES:
+    return Object.assign({}, state, {
+      capiSearch: Object.assign({}, state.capiSearch, {
+          pages: {},
+          count: 0,
+          pageRequestCount: 0
+      })
+    });
+
   case CAPI_SEARCH_REQUEST:
     return Object.assign({}, state, {
       capiSearch: Object.assign({}, state.capiSearch, {
         searchTerm: action.searchTerm,
-        fetchState: fetchState.dirty
+        pageRequestCount: state.capiSearch.pageRequestCount + 1
       })
     });
 
   case CAPI_SEARCH_RECEIVE:
-    return Object.assign({}, state, {
+    var newState = Object.assign({}, state, {
       capiSearch: Object.assign({}, state.capiSearch, {
-        results: action.results,
-        count: action.resultsCount,
-        fetchState: fetchState.clean //Add logic to ensure this is results for current search Term;
-      })
+          pages: Object.assign({}, state.capiSearch.pages),
+          count: action.resultsCount,
+          currentPage: action.page
+        }),
     });
+
+    var newPage = action.results;
+
+    newState.capiSearch.pages[action.page] = newPage;
+    newState.capiSearch.pageRequestCount -= 1;
+
+    return newState;
 
   case CAPI_FILTERS_UPDATE:
     return Object.assign({}, state, {

--- a/public/style/components/page-navigator/_index.scss
+++ b/public/style/components/page-navigator/_index.scss
@@ -1,0 +1,18 @@
+.page-navigator {
+    margin: 10px;
+    text-align: center;
+}
+
+.page-navigator__page,
+.page-navigator__selected {
+    margin-right: 2px;
+    margin-left: 2px;
+
+    padding: 5px;
+    background-color: $c-grey-100;
+    border: 1px solid $c-grey-300;
+}
+
+.page-navigator__selected {
+    background-color: $c-grey-400;
+}

--- a/public/style/main.scss
+++ b/public/style/main.scss
@@ -33,3 +33,4 @@
 @import "components/status/index";
 @import "components/merge-tag/index";
 @import "components/progress-spinner/index";
+@import "components/page-navigator/index";


### PR DESCRIPTION
# :book: Batch Tag Paging :book: 

Added pagination to batch tagging!

<img width="1280" alt="pagination" src="https://cloud.githubusercontent.com/assets/5560113/12816992/811fc6bc-cb47-11e5-8a69-0831458d769c.png">

## Current status
* Pages are currently 50 content items long, this can be changed trivially but 50 seems like a reasonable number and prevents React.js from slowing down too much.
* Pages are loaded lazily then cached.
* When a user selects a tag and changes page, their tag is still selected. Their content item will still be selected when they navigate back to the original page.
* The PageNavigator component is not coupled to tagmanager at all. It can be reused fairly easily.
* Currently shows 5 pages to the left and to the right of the current page, in addition to the first page so the user can easily jump back.