### PR TITLE
Adding es dump diffing script

### DIFF
--- a/scripts/diff-elasticsearch-dumps.js
+++ b/scripts/diff-elasticsearch-dumps.js
@@ -1,0 +1,118 @@
+// This tool compares an array of elasticsearch records to another array of elasticsearch records
+// Finds:
+// * record level differences old to new and new to old
+// * records missing from old in new and new in old
+//
+// Note: Requires ramda!
+//
+// Run like so: `node sourceDiff.js > differences.json`
+
+var R = require("ramda");
+var oldTags = require("./tag.json");
+var newTags = require("./tagmanagerTag.json");
+
+function diffArray(a, b, fieldName, differingFields) {
+    var same = 0;
+    a[fieldName].forEach(function (e) {
+        same += R.contains(e, b[fieldName])
+    });
+    if (same !== a[fieldName].length) {
+        differingFields.push(fieldName);
+    }
+}
+
+function diffObject(a, b, fieldName, differingFields) {
+    var aSubfields = Object.keys(a[fieldName]);
+
+    var shouldContinue = true;
+    aSubfields.forEach(function(subfield) {
+        if (shouldContinue) {
+            return;
+        }
+        if (!compare(a[fieldName][subfield], b[fieldName[subfield]])) {
+            differingFields.push(fieldName);
+            shouldContinue = false;
+        }
+    });
+}
+
+function compare(a, b) {
+    if (a && typeof a === 'string' && b) {
+        var aClean = a.replace("http://", "https://");
+        var bClean = b.replace("http://", "https://");
+        return aClean === bClean;
+    }
+
+    return a === b;
+}
+
+function getDifferentSources(a, b) {
+    var differingFields = [];
+
+    var aFields = Object.keys(a);
+
+    aFields.forEach(function (f) {
+        if (Array.isArray(a[f])) {
+            diffArray(a, b, f, differingFields);
+        } else if ((typeof a[f] === "object") && (a[f] !== null)) {
+            diffObject(a, b, f, differingFields);
+
+        } else {
+            if (!compare(a[f], b[f])) {
+                differingFields.push(f);
+            }
+        }
+    });
+
+    return differingFields;
+}
+
+function testAToB(A, B) {
+    var bAsMap = {};
+    B.forEach(function (b) {
+        var bSource = b._source;
+        bAsMap[bSource.id] = bSource;
+    });
+
+    var problems = {
+        missing: [],
+        different: []
+    };
+
+    A.forEach(function (a) {
+        var aSource = a._source;
+        var bSource = bAsMap[aSource.id];
+
+        if (bSource) {
+            var differentFields = getDifferentSources(aSource, bSource);
+            if (differentFields.length > 0) {
+                var badTag = {
+                    "id": aSource.id,
+                    "fields": {}
+                };
+                differentFields.forEach(function (d) {
+                    if (Array.isArray(aSource[d])) {
+                        aSource[d].sort();
+                        bSource[d].sort();
+                    }
+                    badTag.fields[d] = {
+                        "a": aSource[d],
+                        "b": bSource[d]
+                    }
+                });
+                problems.different.push(badTag);
+            }
+        } else {
+            problems.missing.push(aSource);
+        }
+    })
+    return problems;
+}
+
+var all = {
+    "newDiffOld" : testAToB(newTags, oldTags),
+    "oldDiffNew" : testAToB(oldTags, newTags)
+}
+
+console.log(JSON.stringify(all, undefined, 4));
+


### PR DESCRIPTION
Adding a cheeky wee diffing script that outputs some JSON with tags which are missing and also tags where some fields don't match.

Looks like this:
```
{
    "newDiffOld": {
        "missing": [
            {
                "id": "culture/apple2066test",
                "alternateIds": [
                    "internal-code/tag/73574",
                    "culture/apple2066test"
                ],
                "sectionId": "culture",
                "webTitle": "Apple2066Test",
                "references": [],
                "type": "keyword",
                "description": "<p><br></p>",
                "path": "culture/apple2066test"
            },
            {
                "id": "childrens-books-site",
                "alternateIds": [
                    "internal-code/tag/43119",
                    "childrens-books-site"
                ],
                "sectionId": "childrens-books-site",
                "webTitle": "Children's books",
                "references": [],
                "type": "blog",
                "path": "childrens-books-site"
            },
            {
                "id": "cardiff",
                "alternateIds": [
                    "internal-code/tag/35783",
                    "cardiff"
                ],
                "sectionId": "cardiff",
                "webTitle": "Cardiff",
                "references": [],
                "type": "blog",
                "path": "cardiff"
            },
            {
                "id": "commentisfree",
                "alternateIds": [
                    "internal-code/tag/10528",
                    "commentisfree"
                ],
                "sectionId": "commentisfree",
                "webTitle": "Opinion",
                "references": [],
                "type": "blog",
                "path": "commentisfree"
            },
            {
                "id": "edinburgh",
                "alternateIds": [
                    "internal-code/tag/35784",
                    "edinburgh"
                ],
                "sectionId": "edinburgh",
                "webTitle": "Edinburgh",
                "references": [],
                "type": "blog",
                "path": "edinburgh"
            },
            {
                "id": "leeds",
                "alternateIds": [
                    "internal-code/tag/35782",
                    "leeds"
                ],
                "sectionId": "leeds",
                "webTitle": "Leeds",
                "references": [],
                "type": "blog",
                "path": "leeds"
            },
            {
                "id": "test-microsite/test-microsite",
                "alternateIds": [
                    "internal-code/tag/73572",
                    "test-microsite/test-microsite"
                ],
                "webTitle": "Test Microsite",
                "references": [],
                "type": "keyword",
                "path": "test-microsite/test-microsite"
            }
        ],
        "different": [
            {
                "id": "profile/mariot-chauvin",
                "fields": {
                    "sectionId": {
                        "a": "/Public"
                    }
                }
            },
            {
                "id": "publication/theguardian",
                "fields": {
                    "description": {
                        "a": "All the latest from the world's leading liberal voice."
                    }
                }
            },
            {
                "id": "publication/theobserver",
                "fields": {
                    "description": {
                        "a": "From the Observer, the Sunday newspaper and sister publication of the Guardian."
                    }
                }
            }
        ]
    },
    "oldDiffNew": {
        "missing": [
            {
                "alternateIds": [
                    "adam-smith-institute/adam-smith-institute",
                    "internal-code/tag/54010"
                ],
                "id": "adam-smith-institute/adam-smith-institute",
                "path": "adam-smith-institute/adam-smith-institute",
                "webTitle": "Adam Smith Institute",
                "references": [],
                "type": "keyword",
                "sectionId": "global-development-professionals-network/adam-smith-institute"
            },
            {
                "alternateIds": [
                    "cardiff/cardiff",
                    "internal-code/tag/35783"
                ],
                "id": "cardiff/cardiff",
                "path": "cardiff/cardiff",
                "webTitle": "Cardiff",
                "references": [],
                "type": "blog",
                "sectionId": "cardiff"
            },
            {
                "alternateIds": [
                    "chester-zoo-islands/chester-zoo-islands",
                    "internal-code/tag/70461"
                ],
                "id": "chester-zoo-islands/chester-zoo-islands",
                "path": "chester-zoo-islands/chester-zoo-islands",
                "webTitle": "Chester Zoo Islands",
                "references": [],
                "type": "keyword",
                "sectionId": "chester-zoo-islands"
            },
            {
                "alternateIds": [
                    "childrens-books-site/childrens-books-site",
                    "internal-code/tag/43119"
                ],
                "id": "childrens-books-site/childrens-books-site",
                "path": "childrens-books-site/childrens-books-site",
                "webTitle": "Children's books",
                "references": [],
                "type": "blog",
                "sectionId": "childrens-books-site"
            },
            {
                "alternateIds": [
                    "commentisfree/commentisfree",
                    "internal-code/tag/10528"
                ],
                "id": "commentisfree/commentisfree",
                "path": "commentisfree/commentisfree",
                "webTitle": "Opinion",
                "references": [],
                "type": "blog",
                "sectionId": "commentisfree"
            },
            {
                "alternateIds": [
                    "crisis-at-christmas/crisis-at-christmas",
                    "internal-code/tag/67414"
                ],
                "id": "crisis-at-christmas/crisis-at-christmas",
                "path": "crisis-at-christmas/crisis-at-christmas",
                "webTitle": "Crisis at Christmas",
                "references": [],
                "type": "keyword",
                "sectionId": "crisis-at-christmas"
            },
            {
                "alternateIds": [
                    "discover-woodland-trust/discover-woodland-trust",
                    "internal-code/tag/70844"
                ],
                "id": "discover-woodland-trust/discover-woodland-trust",
                "path": "discover-woodland-trust/discover-woodland-trust",
                "webTitle": "Discover Woodland Trust",
                "references": [],
                "type": "keyword",
                "sectionId": "discover-woodland-trust"
            },
            {
                "alternateIds": [
                    "edinburgh/edinburgh",
                    "internal-code/tag/35784"
                ],
                "id": "edinburgh/edinburgh",
                "path": "edinburgh/edinburgh",
                "webTitle": "Edinburgh",
                "references": [],
                "type": "blog",
                "sectionId": "edinburgh"
            },
            {
                "alternateIds": [
                    "experience-more-with-kia/experience-more-with-kia",
                    "internal-code/tag/70579"
                ],
                "id": "experience-more-with-kia/experience-more-with-kia",
                "path": "experience-more-with-kia/experience-more-with-kia",
                "webTitle": "Experience more with Kia",
                "references": [],
                "type": "keyword",
                "sectionId": "experience-more-with-kia"
            },
            {
                "alternateIds": [
                    "football/series/briefing",
                    "internal-code/tag/72178"
                ],
                "id": "football/series/briefing",
                "path": "football/series/briefing",
                "webTitle": "Briefing",
                "references": [],
                "type": "series",
                "sectionId": "football"
            },
            {
                "alternateIds": [
                    "gap-empowering-girls/gap-empowering-girls",
                    "internal-code/tag/71199"
                ],
                "id": "gap-empowering-girls/gap-empowering-girls",
                "path": "gap-empowering-girls/gap-empowering-girls",
                "webTitle": "Gap empowering girls",
                "references": [],
                "type": "keyword",
                "sectionId": "gap-empowering-girls"
            },
            {
                "alternateIds": [
                    "grundig-design/grundig-design",
                    "internal-code/tag/70638"
                ],
                "id": "grundig-design/grundig-design",
                "path": "grundig-design/grundig-design",
                "webTitle": "Grundig design",
                "references": [],
                "type": "keyword",
                "sectionId": "grundig-design"
            },
            {
                "alternateIds": [
                    "heineken-rugby/heineken-rugby",
                    "internal-code/tag/71274"
                ],
                "id": "heineken-rugby/heineken-rugby",
                "path": "heineken-rugby/heineken-rugby",
                "webTitle": "Rugby World Cup 2015 with Heineken",
                "references": [],
                "type": "keyword",
                "sectionId": "heineken-rugby"
            },
            {
                "alternateIds": [
                    "hifx-money-transfers/hifx-money-transfers",
                    "internal-code/tag/49604"
                ],
                "id": "hifx-money-transfers/hifx-money-transfers",
                "path": "hifx-money-transfers/hifx-money-transfers",
                "webTitle": "HiFX International Money Transfers",
                "references": [],
                "type": "keyword",
                "sectionId": "hifx-money-transfers"
            },
            {
                "alternateIds": [
                    "hilton-weekends/hilton-weekends",
                    "internal-code/tag/63428"
                ],
                "id": "hilton-weekends/hilton-weekends",
                "path": "hilton-weekends/hilton-weekends",
                "webTitle": "Hilton Weekends",
                "references": [],
                "type": "keyword",
                "sectionId": "hilton-weekends"
            },
            {
                "alternateIds": [
                    "jekyll-and-hyde-itv/jekyll-and-hyde-itv",
                    "internal-code/tag/72082"
                ],
                "id": "jekyll-and-hyde-itv/jekyll-and-hyde-itv",
                "path": "jekyll-and-hyde-itv/jekyll-and-hyde-itv",
                "webTitle": "Jekyll and Hyde ITV",
                "references": [],
                "type": "keyword",
                "sectionId": "jekyll-and-hyde-itv"
            },
            {
                "alternateIds": [
                    "justgiving-crowdfunding/justgiving-crowdfunding",
                    "internal-code/tag/71501"
                ],
                "id": "justgiving-crowdfunding/justgiving-crowdfunding",
                "path": "justgiving-crowdfunding/justgiving-crowdfunding",
                "webTitle": "JustGiving Crowdfunding",
                "references": [],
                "type": "keyword",
                "sectionId": "justgiving-crowdfunding"
            },
            {
                "alternateIds": [
                    "leeds/leeds",
                    "internal-code/tag/35782"
                ],
                "id": "leeds/leeds",
                "path": "leeds/leeds",
                "webTitle": "Leeds",
                "references": [],
                "type": "blog",
                "sectionId": "leeds"
            },
            {
                "alternateIds": [
                    "lexus-create-amazing/lexus-create-amazing",
                    "internal-code/tag/71417"
                ],
                "id": "lexus-create-amazing/lexus-create-amazing",
                "path": "lexus-create-amazing/lexus-create-amazing",
                "webTitle": "Lexus create amazing",
                "references": [],
                "type": "keyword",
                "sectionId": "lexus-create-amazing"
            },
            {
                "alternateIds": [
                    "oatly-eat-mindfully/oatly-eat-mindfully",
                    "internal-code/tag/71737"
                ],
                "id": "oatly-eat-mindfully/oatly-eat-mindfully",
                "path": "oatly-eat-mindfully/oatly-eat-mindfully",
                "webTitle": "Oatly eat mindfully",
                "references": [],
                "type": "keyword",
                "sectionId": "oatly-eat-mindfully"
            },
            {
                "alternateIds": [
                    "old-el-paso-restaurante/old-el-paso-restaurante",
                    "internal-code/tag/71449"
                ],
                "id": "old-el-paso-restaurante/old-el-paso-restaurante",
                "path": "old-el-paso-restaurante/old-el-paso-restaurante",
                "webTitle": "Old El Paso Restaurante",
                "description": "Cook like a local with Old El Paso. Watch expert cookery videos and discover Mexican recipes to try tonight. Plus, tips for entertaining from Eat Like A Girl food blogger, Niamh Shields",
                "references": [],
                "type": "keyword",
                "sectionId": "old-el-paso-restaurante"
            },
            {
                "alternateIds": [
                    "profile/the-b-team",
                    "internal-code/tag/60764"
                ],
                "id": "profile/the-b-team",
                "path": "profile/the-b-team",
                "webTitle": "The B Team",
                "r2ContributorId": "60764",
                "firstName": "team",
                "lastName": "b",
                "references": [],
                "type": "contributor",
                "bio": "<p><a href=\"http://bteam.org/about/vision/\" title=\"\">The B Team</a> is a not-for-profit initiative to create a future where the purpose of business is to be a driving force for social, environmental and economic benefit. It includes: Shari Arison, Sir Richard Branson, Kathy Calvin, Arianna Huffington, Mo Ibrahim, Guilherme Leal, Strive Masiyiwa, Blake Mycoskie, Dr. Ngozi Okonjo-Iweala, François-Henri Pinault, Paul Polman, Ratan Tata, Zhang Yue, Professor Muhammad Yunus and Jochen Zeitz.</p>"
            },
            {
                "alternateIds": [
                    "rowse-bee-a-beefarmer/rowse-bee-a-beefarmer",
                    "internal-code/tag/71311"
                ],
                "id": "rowse-bee-a-beefarmer/rowse-bee-a-beefarmer",
                "path": "rowse-bee-a-beefarmer/rowse-bee-a-beefarmer",
                "webTitle": "Rowse bee a beefarmer",
                "references": [],
                "type": "keyword",
                "sectionId": "rowse-bee-a-beefarmer"
            },
            {
                "alternateIds": [
                    "sainsburys-bank-future-families/sainsburys-bank-future-families",
                    "internal-code/tag/68891"
                ],
                "id": "sainsburys-bank-future-families/sainsburys-bank-future-families",
                "path": "sainsburys-bank-future-families/sainsburys-bank-future-families",
                "webTitle": "Sainsbury's Bank future families",
                "references": [],
                "type": "keyword",
                "sectionId": "sainsburys-bank-future-families"
            },
            {
                "alternateIds": [
                    "see-sicario/see-sicario",
                    "internal-code/tag/71434"
                ],
                "id": "see-sicario/see-sicario",
                "path": "see-sicario/see-sicario",
                "webTitle": "See Sicario",
                "description": "The inside story of the Mexican war on drugs",
                "references": [],
                "type": "keyword",
                "sectionId": "see-sicario"
            },
            {
                "alternateIds": [
                    "shelf-improvement-offers/shelf-improvement-offers",
                    "internal-code/tag/59924"
                ],
                "id": "shelf-improvement-offers/shelf-improvement-offers",
                "path": "shelf-improvement-offers/shelf-improvement-offers",
                "webTitle": "Shelf Improvement offer",
                "references": [],
                "type": "keyword",
                "sectionId": "shelf-improvement-offers"
            },
            {
                "alternateIds": [
                    "symonds-founders-reserve/symonds-founders-reserve",
                    "internal-code/tag/71456"
                ],
                "id": "symonds-founders-reserve/symonds-founders-reserve",
                "path": "symonds-founders-reserve/symonds-founders-reserve",
                "webTitle": "Symonds Founder's Reserve - more than your usual",
                "description": "All about apples, tastings and cider-making.",
                "references": [],
                "type": "keyword",
                "sectionId": "symonds-founders-reserve"
            },
            {
                "alternateIds": [
                    "valspar-colour/valspar-colour",
                    "internal-code/tag/68610"
                ],
                "id": "valspar-colour/valspar-colour",
                "path": "valspar-colour/valspar-colour",
                "webTitle": "Valspar colour",
                "references": [],
                "type": "keyword",
                "sectionId": "valspar-colour"
            },
            {
                "alternateIds": [
                    "visit-west-sweden/visit-west-sweden",
                    "internal-code/tag/64272"
                ],
                "id": "visit-west-sweden/visit-west-sweden",
                "path": "visit-west-sweden/visit-west-sweden",
                "webTitle": "Visit Gothenburg & West Sweden",
                "references": [],
                "type": "keyword",
                "sectionId": "visit-west-sweden"
            },
            {
                "alternateIds": [
                    "vodafone-roam-europe/vodafone-roam-europe",
                    "internal-code/tag/70641"
                ],
                "id": "vodafone-roam-europe/vodafone-roam-europe",
                "path": "vodafone-roam-europe/vodafone-roam-europe",
                "webTitle": "Roam around Europe",
                "references": [],
                "type": "keyword",
                "sectionId": "vodafone-roam-europe"
            },
            {
                "alternateIds": [
                    "welcome-to-brussels-and-wallonia/welcome-to-brussels-and-wallonia",
                    "internal-code/tag/70504"
                ],
                "id": "welcome-to-brussels-and-wallonia/welcome-to-brussels-and-wallonia",
                "path": "welcome-to-brussels-and-wallonia/welcome-to-brussels-and-wallonia",
                "webTitle": "Welcome to Brussels and Wallonia",
                "references": [],
                "type": "keyword",
                "sectionId": "welcome-to-brussels-and-wallonia"
            }
        ],
        "different": [
            {
                "id": "music/vampire-weekend",
                "fields": {
                    "references": {
                        "a": [
                            {
                                "type": "musicbrainz",
                                "id": "musicbrainz/af37c51c-0790-4a29-b995-456f98a6b8c9"
                            }
                        ],
                        "b": []
                    }
                }
            },
            {
                "id": "us-news/series/the-campaign-minute-2016",
                "fields": {
                    "alternateIds": {
                        "a": [
                            "internal-code/tag/72158",
                            "us-news/series/the-campaign-minute-2016"
                        ],
                        "b": [
                            "internal-code/tag/73268",
                            "us-news/series/the-campaign-minute-2016"
                        ]
                    },
                    "webTitle": {
                        "a": "the campaign minute 2016",
                        "b": "The campaign minute 2016"
                    }
                }
            }
        ]
    }
}

```