### PR TITLE
Changing how Cloud Formation is auto scaling is done

### DIFF
--- a/cloudformation/tag-manager.json
+++ b/cloudformation/tag-manager.json
@@ -1,6 +1,22 @@
 {
   "AWSTemplateFormatVersion":"2010-09-09",
   "Description":"tag-manager",
+  "Mappings":{
+    "Config":{
+      "CODE":{
+        "MinSize": 1,
+        "MaxSize": 2,
+        "DesiredCapacity": 1,
+        "InstanceType": "t2.small"
+      },
+      "PROD":{
+        "MinSize": 2,
+        "MaxSize": 4,
+        "DesiredCapacity": 2,
+        "InstanceType": "t2.small"
+      }
+    }
+  },
   "Parameters":{
     "KeyName":{
       "Description":"The EC2 Key Pair to allow SSH access to the instance",
@@ -365,8 +381,8 @@
         "AvailabilityZones": { "Fn::GetAZs": "" },
         "VPCZoneIdentifier": { "Ref": "PrivateVpcSubnets" },
         "LaunchConfigurationName":{ "Ref":"TagManagerLaunchConfig" },
-        "MinSize":"1",
-        "MaxSize":"2",
+        "MinSize":{ "Fn::FindInMap": [ "Config", { "Ref": "Stage" }, "MinSize" ] },
+        "MaxSize":{ "Fn::FindInMap": [ "Config", { "Ref": "Stage" }, "MaxSize" ] },
         "DesiredCapacity": "1",
         "HealthCheckType" : "ELB",
         "HealthCheckGracePeriod": 300,
@@ -402,8 +418,7 @@
           { "Ref": "AppServerSecurityGroup" },
           { "Ref": "SSHSecurityGroup" }
         ],
-        "InstanceType": "t2.medium",
-        "IamInstanceProfile": {"Ref": "TagManagerInstanceProfile"},
+        "IamInstanceProfile":{ "Fn::FindInMap": [ "Config", { "Ref": "Stage" }, "InstanceType" ] },
         "UserData":{
           "Fn::Base64":{
             "Fn::Join":["", [

--- a/cloudformation/tag-manager.json
+++ b/cloudformation/tag-manager.json
@@ -418,7 +418,8 @@
           { "Ref": "AppServerSecurityGroup" },
           { "Ref": "SSHSecurityGroup" }
         ],
-        "IamInstanceProfile":{ "Fn::FindInMap": [ "Config", { "Ref": "Stage" }, "InstanceType" ] },
+        "InstanceType":{ "Fn::FindInMap": [ "Config", { "Ref": "Stage" }, "InstanceType" ] },
+        "IamInstanceProfile": {"Ref": "TagManagerInstanceProfile"},
         "UserData":{
           "Fn::Base64":{
             "Fn::Join":["", [


### PR DESCRIPTION
CODE and PROD now have different sizes, defined by a mapping.