### PR TITLE
Clicking elements in a list no longer replaces the current history

### DIFF
--- a/public/components/SectionList/SectionList.react.js
+++ b/public/components/SectionList/SectionList.react.js
@@ -10,7 +10,7 @@ class SectionList extends React.Component {
 
     onSectionClick(section) {
       const path = this.props.route.isMicrositeView ? '/microsite/' + section.id : '/section/' + section.id;
-      history.replaceState(null, path);
+      history.pushState(null, path);
     }
 
     componentWillMount() {

--- a/public/components/TagList/TagList.react.js
+++ b/public/components/TagList/TagList.react.js
@@ -39,7 +39,7 @@ export default class TagList extends React.Component {
     }
 
     onTagClick(tag) {
-      history.replaceState(null, '/tag/' + tag.id);
+      history.pushState(null, '/tag/' + tag.id);
     }
 
     render () {


### PR DESCRIPTION
Preventing the Tag and Section lists from writing over history, which lead to some perhaps surprising behaviour.

The create tag/section actions still replace the current history. It seems to make sense since you're not undoing the creation action when pressing back.