### PR TITLE
Batchtag fixes

### DIFF
--- a/public/components/BatchTag/BatchFilters.react.js
+++ b/public/components/BatchTag/BatchFilters.react.js
@@ -89,8 +89,9 @@ export default class BatchFilters extends React.Component {
     }
 
     addTag(tag) {
+      const tagPath = tag.type === "ContentType" ? "type/" + tag.slug : tag.path;
       this.props.updateFilters(Object.assign({}, this.props.filters, {
-        'tag': R.uniq(this.getTagArray().concat([tag.path])).join(',')
+        'tag': R.uniq(this.getTagArray().concat([tagPath])).join(',')
       }));
     }
 

--- a/public/util/capiClient.js
+++ b/public/util/capiClient.js
@@ -38,10 +38,8 @@ export function getByTag (tag, params) {
 export function searchContent (searchString, params) {
     const query = paramsObjectToQuery(params);
 
-    const searchQueryString = searchString || '';
-
     return Reqwest({
-      url: getCapiUrl() + '&q=' + searchQueryString.replace(' ', ' AND ')  + '&' + query,
+      url: getCapiUrl() + '&q=' + searchString.replace(' ', ' AND ')  + '&' + query,
       contentType: 'application/json',
       crossOrigin: true,
       method: 'get'
@@ -51,10 +49,8 @@ export function searchContent (searchString, params) {
 export function searchPreviewContent (searchString, params) {
     const query = paramsObjectToQuery(params);
 
-    const searchQueryString = searchString || '';
-
     return Reqwest({
-      url: getCapiPreviewUrl() + '&q=' + searchQueryString.replace(' ', ' AND ')  + '&' + query + '&show-fields=isLive',
+      url: getCapiPreviewUrl() + '&q=' + searchString.replace(' ', ' AND ')  + '&' + query + '&show-fields=isLive',
       contentType: 'application/json',
       crossOrigin: true,
       method: 'get'

--- a/public/util/capiClient.js
+++ b/public/util/capiClient.js
@@ -38,8 +38,10 @@ export function getByTag (tag, params) {
 export function searchContent (searchString, params) {
     const query = paramsObjectToQuery(params);
 
+    const searchQueryString = searchString || '';
+
     return Reqwest({
-      url: getCapiUrl() + '&q=' + searchString.replace(' ', ' AND ')  + '&' + query,
+      url: getCapiUrl() + '&q=' + searchQueryString.replace(' ', ' AND ')  + '&' + query,
       contentType: 'application/json',
       crossOrigin: true,
       method: 'get'
@@ -49,8 +51,10 @@ export function searchContent (searchString, params) {
 export function searchPreviewContent (searchString, params) {
     const query = paramsObjectToQuery(params);
 
+    const searchQueryString = searchString || '';
+
     return Reqwest({
-      url: getCapiPreviewUrl() + '&q=' + searchString.replace(' ', ' AND ')  + '&' + query + '&show-fields=isLive',
+      url: getCapiPreviewUrl() + '&q=' + searchQueryString.replace(' ', ' AND ')  + '&' + query + '&show-fields=isLive',
       contentType: 'application/json',
       crossOrigin: true,
       method: 'get'

--- a/public/util/capiClient.js
+++ b/public/util/capiClient.js
@@ -27,8 +27,10 @@ function getCapiPreviewUrl() {
 export function getByTag (tag, params) {
     const query = paramsObjectToQuery(params);
 
+    const tagPath = tag.type === 'ContentType' ? 'type/' + tag.slug : tag.path;
+
     return Reqwest({
-      url: getCapiUrl() + '&tag=' + tag.path  + '&' + query,
+      url: getCapiUrl() + '&tag=' + tagPath  + '&' + query,
       contentType: 'application/json',
       crossOrigin: true,
       method: 'get'


### PR DESCRIPTION
 - Can now search without first typing a query (e.g. just based on filter)
 - ContentType path calculations are now done before CAPI request (Content type is an exception where Capi ID is different from our Path)