### PR TITLE
Feature/169 improve tag audit summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.13.1",
     "react-hot-loader": "^1.3.0",
+    "react-tooltip": "^1.1.2",
     "webpack-dev-server": "^1.12.1"
   }
 }

--- a/public/components/Audit.react.js
+++ b/public/components/Audit.react.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {allowedAuditReports} from '../constants/allowedAuditReports';
 import tagManagerApi from '../util/tagManagerApi';
 import moment from 'moment';
+import ReactTooltip from 'react-tooltip';
 
 const reportSubjects = ['tag', 'section'];
 
@@ -35,6 +36,7 @@ export default class Audit extends React.Component {
 
     renderListItem(logItem) {
       const date = moment.unix(logItem.date).format('ddd DD MMM HH:mm')
+      const summary = Object.keys(logItem.tagSummary).map(k => `${k}: ${logItem.tagSummary[k]}`).join('<br />')
 
       return (
         <tr key={logItem.operation + logItem.date} className="taglist__results-item">
@@ -42,6 +44,7 @@ export default class Audit extends React.Component {
           <td>{logItem.operation}</td>
           <td>{logItem.description}</td>
           <td>{logItem.user}</td>
+          <td className="taglist__results-info" data-tip={summary}><i className="i-info-grey" /></td>
         </tr>
       );
     }
@@ -81,6 +84,7 @@ export default class Audit extends React.Component {
               <th>Operation</th>
               <th>Desciption</th>
               <th>User</th>
+              <th></th>
             </tr>
           </thead>
           <tbody className="audit__results">
@@ -116,6 +120,7 @@ export default class Audit extends React.Component {
             }, this)}
           </div>
           {this.renderTable()}
+          <ReactTooltip multiline={true} place="right" effect="solid"/>
         </div>
 
       );

--- a/public/components/Audit.react.js
+++ b/public/components/Audit.react.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {allowedAuditReports} from '../constants/allowedAuditReports';
 import tagManagerApi from '../util/tagManagerApi';
+import moment from 'moment';
 
 const reportSubjects = ['tag', 'section'];
 
@@ -33,9 +34,11 @@ export default class Audit extends React.Component {
     }
 
     renderListItem(logItem) {
+      const date = moment.unix(logItem.date).format('ddd DD MMM HH:mm')
+
       return (
         <tr key={logItem.operation + logItem.date} className="taglist__results-item">
-          <td>{logItem.date}</td>
+          <td>{date}</td>
           <td>{logItem.operation}</td>
           <td>{logItem.description}</td>
           <td>{logItem.user}</td>

--- a/public/style/components/tag-list/_index.scss
+++ b/public/style/components/tag-list/_index.scss
@@ -6,3 +6,7 @@
   background-color: $c-grey-150;
   text-align: center;
 }
+
+.taglist__results-info {
+    cursor: help;
+}


### PR DESCRIPTION
Fixes #169

* Dates are formatted
* Summary visible in tooltip

![tagsummary](https://cloud.githubusercontent.com/assets/2061333/13074894/6650ed1e-d49f-11e5-9fec-170c5a38f2ca.gif)
