### PR TITLE
Add local composer to CORS-able domains in code

### DIFF
--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -133,8 +133,6 @@ class DevConfig extends Config {
 
   override def composerDomain: String = "https://composer.local.dev-gutools.co.uk"
   override def corsableDomains: Seq[String] = Seq(composerDomain)
-
-
 }
 
 class CodeConfig extends Config {
@@ -166,9 +164,7 @@ class CodeConfig extends Config {
   override def pandaAuthCallback: String = "https://tagmanager.code.dev-gutools.co.uk/oauthCallback"
 
   override def composerDomain: String = "https://composer.code.dev-gutools.co.uk"
-  override def corsableDomains: Seq[String] = Seq(composerDomain)
-
-
+  override def corsableDomains: Seq[String] = Seq(composerDomain, "https://composer.local.dev-gutools.co.uk")
 }
 
 class ProdConfig extends Config {


### PR DESCRIPTION
Local composer should use code tagmanager (so people don't need to run tagmanager locally), this adds local composer as a "cors"able domain in CODE tagmanager