### PR TITLE
Parents: better UX

### DIFF
--- a/public/components/TagContext/TagReferences/AddReference.react.js
+++ b/public/components/TagContext/TagReferences/AddReference.react.js
@@ -62,14 +62,14 @@ export default class AddReference extends React.Component {
 
       if (!this.state.expanded) {
         return (
-          <div className="tag-reference__add" onClick={this.expand.bind(this)}>
+          <div onClick={this.expand.bind(this)}>
             <i className="i-plus" /> Add Reference
           </div>
         );
       }
 
       return (
-        <div className="tag-reference__add">
+        <div>
           <form onSubmit={this.addReference.bind(this)}>
             <ReferenceTypeSelect referenceTypes={this.props.referenceTypes} onChange={this.onTypeChange.bind(this)} selectedType={this.state.newType} />
             <input type="text" placeholder="Value" onChange={this.onValueChange.bind(this)} value={this.state.newValue}/>

--- a/public/components/TagContext/TagRelationship/AddRelationship.react.js
+++ b/public/components/TagContext/TagRelationship/AddRelationship.react.js
@@ -11,9 +11,9 @@ export default class AddRelationship extends React.Component {
         };
     }
 
-    expand() {
+    toggle() {
       this.setState({
-        expanded: true
+        expanded: !this.state.expanded
       });
     }
 
@@ -28,21 +28,29 @@ export default class AddRelationship extends React.Component {
       this.minimise();
     }
 
-    render () {
-
-      if (!this.state.expanded) {
+    renderTagSelect() {
+      if(this.state.expanded) {
         return (
-          <div className="tag-relationship__add" onClick={this.expand.bind(this)}>
-            <i className="i-plus" />
-          </div>
-        );
-      }
-
-      return (
-        <div className="tag-relationship__add--expanded">
+          <div className="tag-relationship__add--expanded">
           <TagSelect onTagClick={this.onAddTag.bind(this)} disabled={!this.props.tagEditable}/>
           <i className="i-cross" onClick={this.minimise.bind(this)}></i>
-        </div>
+          </div>
+        )
+      } else {
+        return (
+          <span></span>
+        )
+      }
+    }
+
+    render () {
+      return (
+        <span>
+          <div className="tag-relationship__add" onClick={this.toggle.bind(this)}>
+            <i className="i-plus" /> Add parent
+          </div>
+          {this.renderTagSelect()}
+        </span>
       );
     }
-}
+  }

--- a/public/components/TagContext/TagRelationship/TagRelationship.react.js
+++ b/public/components/TagContext/TagRelationship/TagRelationship.react.js
@@ -92,7 +92,6 @@ export default class TagRelationship extends React.Component {
       if (this.props.tagEditable) {
         return <AddTagToContext onAddTag={this.addParentTag.bind(this)} tagEditable={this.props.tagEditable}/>
       }
-      return false;
     }
 
     render () {
@@ -105,19 +104,13 @@ export default class TagRelationship extends React.Component {
         return false;
       }
 
-      if (!this.props.tag.parents) {
-        return (
-          <div className="tag-context__item">
-            No parent tags found
-          </div>
-        );
-      }
-
       return (
         <div className="tag-context__item">
           <div className="tag-context__header">Parents</div>
           <div className="tag-relationship">
-              {this.props.tag.parents.map(this.renderTag)}
+              <div className="tag-relationship__tags">
+                {this.props.tag.parents.map(this.renderTag)}
+              </div>
               {this.renderAddTagToContext()}
           </div>
         </div>

--- a/public/components/TagContext/TagRelationship/TagRelationship.react.js
+++ b/public/components/TagContext/TagRelationship/TagRelationship.react.js
@@ -75,16 +75,19 @@ export default class TagRelationship extends React.Component {
       const tag = this.state.cachedTags[tagId];
 
       if (!tag) {
-        return 'Fetching: ' + tagId;
+          return (
+            <tr>
+              <td colspan="3">Fetching tag #{tagId}</td>
+            </tr>
+        )
       }
 
       return (
-        <div key={tag.id} className="tag-relationship__tag">
-          <Link to={`/tag/${tag.id}`}>{tag.internalName}</Link>
-          <div className="tag-relationship__tag__remove" onClick={this.removeParentTag.bind(this, tag)}>
-            <i className="i-delete" />
-          </div>
-        </div>
+         <tr>
+           <td><Link to={`/tag/${tag.id}`}>{tag.internalName}</Link></td>
+           <td>{tag.type}</td>
+           <td onClick={this.removeParentTag.bind(this, tag)}><i className="i-delete" /></td>
+         </tr>
       );
     }
 
@@ -103,17 +106,31 @@ export default class TagRelationship extends React.Component {
       if (this.props.tag.type !== tagTypes.topic.name) {
         return false;
       }
-
       return (
-        <div className="tag-context__item">
-          <div className="tag-context__header">Parents</div>
-          <div className="tag-relationship">
-              <div className="tag-relationship__tags">
+          <div className="tag-context__item">
+            <div className="tag-context__header">Parents</div>
+            <table className="tag-references">
+              <thead className="tag-references__header">
+                <tr>
+                  <th>
+                    Tag
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody className="tag-references__references">
                 {this.props.tag.parents.map(this.renderTag)}
-              </div>
-              {this.renderAddTagToContext()}
+                <tr>
+                  <td colSpan="3" className="tag-references__addrow">
+                    {this.renderAddTagToContext()}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
-        </div>
-      );
+      )
     }
 }

--- a/public/style/components/context-display/_index.scss
+++ b/public/style/components/context-display/_index.scss
@@ -21,7 +21,6 @@
 .tag-relationship {
   border: 1px solid $c-grey-300;
   padding: $standard-padding;
-  min-height: 100px;
 }
 
 .tag-relationship__tag {
@@ -61,23 +60,19 @@
 
 %context__add {
   display: inline-block;
-
   position: relative;
-
-  margin-left: $standard-padding;
 }
 
 .tag-relationship__add {
   @extend %context__add;
   line-height: 35px;
-
+  cursor: pointer;
 }
 
 .tag-relationship__add--expanded {
   @extend %context__add;
-
   width: 300px;
-
+  margin-left: $standard-padding;
 }
 
 .tag-references__header {


### PR DESCRIPTION
Re #146 

* Add parent opens / closes add widget
* Add widget displayed next to add button, not over it
* Parent tag list presented in a table view
* Tag list above add button

![parents](https://cloud.githubusercontent.com/assets/2061333/13107763/233e5250-d567-11e5-84c8-2b77e9281f3b.gif)
