### PR TITLE
Adding limitations to merge tagging to prevent bad combos

### DIFF
--- a/app/model/command/CommandErrors.scala
+++ b/app/model/command/CommandErrors.scala
@@ -13,6 +13,9 @@ object CommandError extends Results {
   def PathInUse = throw new CommandError("path in use", 400)
   def PathNotFound = throw new CommandError("could not remove path from pathmanager", 400)
   def CouldNotCreateSectionTag = throw new CommandError("could not create section tag", 400)
+  def IllegalMergeTagType = throw new CommandError("illegal merge tag type", 400)
+  def AttemptedSelfMergeTag = throw new CommandError("attempted to merge a tag with itself", 400)
+  def MergeTagTypesDontMatch = throw new CommandError("merge tag types don't match", 400)
 
   def InvalidSectionEditionRegion = throw new CommandError("Invalid region supplied", 400)
 

--- a/public/components/MergeTag.react.js
+++ b/public/components/MergeTag.react.js
@@ -59,16 +59,16 @@ export default class MergeTag extends React.Component {
 
       if (blockedTagTypes.indexOf(this.state.fromTag.type) !== -1) {
           // This should never happen since the TagSelect component should prevent it
-          return (<div className="merge__warning">
-                    <div>The 'from' tag type ({this.state.fromTag.type}) is not a mergable tag type.</div>
-                  </div>);
+        return (<div className="merge__warning">
+                  <div>The 'from' tag type ({this.state.fromTag.type}) is not a mergable tag type.</div>
+                </div>);
       }
 
       if (blockedTagTypes.indexOf(this.state.toTag.type) !== -1) {
           // This should never happen since the TagSelect component should prevent it
-          return (<div className="merge__warning">
-                    <div>The 'to' tag type ({this.state.fromTag.type}) is not a mergable tag type.</div>
-                  </div>);
+        return (<div className="merge__warning">
+                  <div>The 'to' tag type ({this.state.fromTag.type}) is not a mergable tag type.</div>
+                </div>);
       }
 
       return (
@@ -81,7 +81,7 @@ export default class MergeTag extends React.Component {
 
     renderTag(tag, setTagFn) {
       if (!tag) {
-          return <TagSelect onTagClick={setTagFn} blockedTagTypes={blockedTagTypes} />;
+        return <TagSelect onTagClick={setTagFn} blockedTagTypes={blockedTagTypes} />;
       }
 
       return (

--- a/public/components/MergeTag.react.js
+++ b/public/components/MergeTag.react.js
@@ -1,13 +1,16 @@
 import React from 'react';
+import R from 'ramda';
 import TagSelect from './utils/TagSelect.js';
 import CapiStats from './CapiStats/CapiStats.react';
 import ConfirmButton from './utils/ConfirmButton.react';
 import tagManagerApi from '../util/tagManagerApi';
 import history from '../routes/history';
 import showError from '../actions/UIActions/showError';
+import * as tagTypes from '../constants/tagTypes';
+
+const blockedTagTypes = ["Publication", "NewspaperBook", "NewspaperBookSection", "Tracking", "ContentType", "Contributor"];
 
 export default class MergeTag extends React.Component {
-
     constructor(props) {
         super(props);
 
@@ -44,6 +47,31 @@ export default class MergeTag extends React.Component {
         return false;
       }
 
+      if (this.state.fromTag.id === this.state.toTag.id) {
+        return (<div> className="merge__warning">
+                  <div>Cannot merge a tag into itself.</div>
+                </div>);
+      }
+
+      if (this.state.fromTag.type !== this.state.toTag.type) {
+        return (<div className="merge__warning">
+                  <div>Cannot merge tags of differing types.</div>
+                </div>);
+      }
+
+      if (blockedTagTypes.indexOf(this.state.fromTag.type) !== -1) {
+          // This should never happen since the TagSelect function should block
+          return (<div className="merge__warning">
+                    <div>The 'from' tag type ({this.state.fromTag.type}) is not a mergable tag type.</div>
+                  </div>);
+      }
+
+      if (blockedTagTypes.indexOf(this.state.toTag.type) !== -1) {
+          return (<div className="merge__warning">
+                    <div>The 'to' tag type ({this.state.fromTag.type}) is not a mergable tag type.</div>
+                  </div>);
+      }
+
       return (
         <div className="merge__confirmation">
           <div>This operation will DELETE all instances of the tag "{this.state.fromTag.internalName}" and replace them with the "{this.state.toTag.internalName}" tag. This operation is not reversible.</div>
@@ -54,7 +82,9 @@ export default class MergeTag extends React.Component {
 
     renderTag(tag, setTagFn) {
       if (!tag) {
-        return <TagSelect onTagClick={setTagFn} />;
+          return <TagSelect
+            onTagClick={setTagFn}
+            blockedTagTypes={blockedTagTypes} />;
       }
 
       return (

--- a/public/components/MergeTag.react.js
+++ b/public/components/MergeTag.react.js
@@ -6,7 +6,7 @@ import tagManagerApi from '../util/tagManagerApi';
 import history from '../routes/history';
 import showError from '../actions/UIActions/showError';
 
-const blockedTagTypes = ["Publication", "NewspaperBook", "NewspaperBookSection", "Tracking", "ContentType", "Contributor"];
+const blockedTagTypes = ["Publication", "NewspaperBook", "NewspaperBookSection", "ContentType", "Contributor"];
 
 export default class MergeTag extends React.Component {
     constructor(props) {

--- a/public/components/MergeTag.react.js
+++ b/public/components/MergeTag.react.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import R from 'ramda';
 import TagSelect from './utils/TagSelect.js';
 import CapiStats from './CapiStats/CapiStats.react';
 import ConfirmButton from './utils/ConfirmButton.react';
 import tagManagerApi from '../util/tagManagerApi';
 import history from '../routes/history';
 import showError from '../actions/UIActions/showError';
-import * as tagTypes from '../constants/tagTypes';
 
 const blockedTagTypes = ["Publication", "NewspaperBook", "NewspaperBookSection", "Tracking", "ContentType", "Contributor"];
 
@@ -60,13 +58,14 @@ export default class MergeTag extends React.Component {
       }
 
       if (blockedTagTypes.indexOf(this.state.fromTag.type) !== -1) {
-          // This should never happen since the TagSelect function should block
+          // This should never happen since the TagSelect component should prevent it
           return (<div className="merge__warning">
                     <div>The 'from' tag type ({this.state.fromTag.type}) is not a mergable tag type.</div>
                   </div>);
       }
 
       if (blockedTagTypes.indexOf(this.state.toTag.type) !== -1) {
+          // This should never happen since the TagSelect component should prevent it
           return (<div className="merge__warning">
                     <div>The 'to' tag type ({this.state.fromTag.type}) is not a mergable tag type.</div>
                   </div>);
@@ -82,9 +81,7 @@ export default class MergeTag extends React.Component {
 
     renderTag(tag, setTagFn) {
       if (!tag) {
-          return <TagSelect
-            onTagClick={setTagFn}
-            blockedTagTypes={blockedTagTypes} />;
+          return <TagSelect onTagClick={setTagFn} blockedTagTypes={blockedTagTypes} />;
       }
 
       return (

--- a/public/components/MergeTag.react.js
+++ b/public/components/MergeTag.react.js
@@ -35,7 +35,7 @@ export default class MergeTag extends React.Component {
       .then((res) => {
         history.pushState(null, '/status');
       })
-      .error((error) => {
+      .fail((error) => {
         showError(error);
       });
     }

--- a/public/components/utils/TagSelect.js
+++ b/public/components/utils/TagSelect.js
@@ -50,6 +50,13 @@ export default class TagSelect extends React.Component {
         });
     }
 
+    isAllowedTagType(tagType) {
+      if (this.props.blockedTagTypes) {
+        return this.props.blockedTagTypes.indexOf(tagType) === -1;
+      }
+      return true;
+    }
+
     renderSuggestions() {
       if (!this.state.suggestions.length) {
         return false;
@@ -58,8 +65,7 @@ export default class TagSelect extends React.Component {
       return (
         <div className="tag-select__suggestions">
           <ul>
-            {this.state.suggestions.map(tag => {
-
+            {this.state.suggestions.filter(tag => this.isAllowedTagType(tag.type)).map(tag => {
               const tagTypeKey = Object.keys(tagTypes).filter((tagTypeKey) => {
                 return tagTypes[tagTypeKey].name === tag.type;
               })[0];

--- a/public/style/components/merge-tag/_index.scss
+++ b/public/style/components/merge-tag/_index.scss
@@ -29,7 +29,12 @@
   font-weight: bold;
 }
 
+.merge__warning,
 .merge__confirmation {
   color: $c-red;
   font-weight: bold;
+}
+
+.merge__warning {
+    color: $c-orange;
 }


### PR DESCRIPTION
Current checks:
* To and From tag ids are different
* To and From tag types are the same
* To and From tag types are not on the list of unmergable tag types*

* Unmergable tags are: Publication, NewspaperBook, NewspaperBookSection, Tracking, ContentType, Contributor