### PR TITLE
Allowed images to be sent from s3-uploader

### DIFF
--- a/public/components/TagEdit/formComponents/TagImageEdit.react.js
+++ b/public/components/TagEdit/formComponents/TagImageEdit.react.js
@@ -38,7 +38,7 @@ export default class TagImageEdit extends React.Component {
   }
 
   updateInputUrl(e) {
-    const url = e.target.value.replace('http://static.guim.co.uk', 'https://static.guim.co.uk')
+    const url = e.target.value.replace('http://', 'https://')
 
     this.setState({
       inputUrl: url,
@@ -105,7 +105,7 @@ export default class TagImageEdit extends React.Component {
       return (
         <div className="tag-edit__image__add--error">
           <i className="i-cross-red" />
-          Url Not Valid. The image should be located on https://static.guim.co.uk
+          Url Not Valid. The image should be located on https://static.guim.co.uk or https://uploads.guim.co.uk
         </div>
       );
     }

--- a/public/components/TagEdit/formComponents/TagImageEdit.react.js
+++ b/public/components/TagEdit/formComponents/TagImageEdit.react.js
@@ -105,7 +105,7 @@ export default class TagImageEdit extends React.Component {
       return (
         <div className="tag-edit__image__add--error">
           <i className="i-cross-red" />
-          Url Not Valid. The image should be located on https://static.guim.co.uk or https://uploads.guim.co.uk
+          Invalid image URL. Upload your image with the <a href="https://s3-uploader.gutools.co.uk/">image uploader</a> and use the URL it provides.
         </div>
       );
     }

--- a/public/components/TagEdit/formComponents/TagImageEdit.react.js
+++ b/public/components/TagEdit/formComponents/TagImageEdit.react.js
@@ -143,7 +143,7 @@ export default class TagImageEdit extends React.Component {
           <div>Width: {imageAsset.width}px</div>
           <div>Height: {imageAsset.height}px</div>
           <div className="tag-edit__image__remove" onClick={this.removeImage.bind(this)}>
-            <i className="i-cross-red" />Remove image
+            <i className="i-delete" />Remove image
           </div>
         </div>
       </div>

--- a/public/util/validateImage.js
+++ b/public/util/validateImage.js
@@ -1,4 +1,4 @@
-const URL_REGEX = /^https:\/\/static.guim.co.uk\/sys-images\/Guardian\/.*\.(png|jpg)$/;
+const URL_REGEX = /^https:\/\/(static.guim.co.uk\/sys-images\/Guardian|uploads.guim.co.uk)\/.*\.(png|jpg)$/;
 
 export function validateImageUrl(url) {
   return !!url && !!url.match(URL_REGEX);


### PR DESCRIPTION
Images can now be added from S3 uploader:

A valid image:
<img width="384" alt="imageupload" src="https://cloud.githubusercontent.com/assets/5560113/13112228/d391f02a-d581-11e5-8bdd-bc2c3420c8a0.png">

A "valid" URL which does no have an image at the end:
<img width="385" alt="imageupload_notreal" src="https://cloud.githubusercontent.com/assets/5560113/13112247/e276077a-d581-11e5-84d5-a6016efe6216.png">
