### PR TITLE
Fixing section audit username reporting

### DIFF
--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -42,20 +42,20 @@ object SectionAudit {
     }
   }
 
-  def created(section: Section)(implicit user: Option[User] = None): SectionAudit = {
-    SectionAudit(section.id, "created", new DateTime(), user.map(_.email).getOrElse("default user"), s"section '${section.name}' created", SectionSummary(section))
+  def created(section: Section)(implicit user: Option[String] = None): SectionAudit = {
+    SectionAudit(section.id, "created", new DateTime(), user.getOrElse("default user"), s"section '${section.name}' created", SectionSummary(section))
   }
 
-  def updated(section: Section)(implicit user: Option[User] = None): SectionAudit = {
-    SectionAudit(section.id, "updated", new DateTime(), user.map(_.email).getOrElse("default user"), s"section '${section.name}' updated", SectionSummary(section))
+  def updated(section: Section)(implicit user: Option[String] = None): SectionAudit = {
+    SectionAudit(section.id, "updated", new DateTime(), user.getOrElse("default user"), s"section '${section.name}' updated", SectionSummary(section))
   }
 
-  def addedEdition(section: Section, editionName: String)(implicit user: Option[User] = None): SectionAudit = {
-    SectionAudit(section.id, "added edition", new DateTime(), user.map(_.email).getOrElse("default user"), s"added ${editionName} edition to section '${section.name}", SectionSummary(section))
+  def addedEdition(section: Section, editionName: String)(implicit user: Option[String] = None): SectionAudit = {
+    SectionAudit(section.id, "added edition", new DateTime(), user.getOrElse("default user"), s"added ${editionName} edition to section '${section.name}", SectionSummary(section))
   }
 
-  def removedEdition(section: Section, editionName: String)(implicit user: Option[User] = None): SectionAudit = {
-    SectionAudit(section.id, "removed edition", new DateTime(), user.map(_.email).getOrElse("default user"), s"removed ${editionName} edition from section '${section.name}", SectionSummary(section))
+  def removedEdition(section: Section, editionName: String)(implicit user: Option[String] = None): SectionAudit = {
+    SectionAudit(section.id, "removed edition", new DateTime(), user.getOrElse("default user"), s"removed ${editionName} edition from section '${section.name}", SectionSummary(section))
   }
 
 }


### PR DESCRIPTION
The issue was we had an implicit parameter `Option[User]` which defaulted to `None`. At some point in the past users stopped being passed around as `User` objects and were passed around as a `Option[String]`. This silently broke the audit creation since the lack of an implicit `Option[User]` caused the function to simply default to `None`.

Here's a screenshot of the new behaviour: 
<img width="798" alt="sectionupdate" src="https://cloud.githubusercontent.com/assets/5560113/13118743/949c6316-d59d-11e5-9a79-eeb70bb3bba5.png">

I've checked through and all the places where audits are constructed have `Some(username)`