### PR TITLE
Adding more valid image extensions

### DIFF
--- a/public/util/validateImage.js
+++ b/public/util/validateImage.js
@@ -1,4 +1,4 @@
-const URL_REGEX = /^https:\/\/(static.guim.co.uk\/sys-images\/Guardian|uploads.guim.co.uk)\/.*\.(png|jpg)$/;
+const URL_REGEX = /^https:\/\/(static.guim.co.uk\/sys-images\/Guardian|uploads.guim.co.uk)\/.*\.(png|jpg|jpeg|PNG|JPG|JPEG)$/;
 
 export function validateImageUrl(url) {
   return !!url && !!url.match(URL_REGEX);


### PR DESCRIPTION
S3 uploader doesn't change the extension file name so we've got to handle most common cases.

Added the very common `jpeg` and also the far less common `PNG`, `JPG` and `JPEG` I've seen some cameras give use.

Thanks to Akash for pointing this out in #181 