### PR TITLE
Fixing up a CAPI query size limitation

### DIFF
--- a/app/repositories/ContentAPI.scala
+++ b/app/repositories/ContentAPI.scala
@@ -22,19 +22,43 @@ object ContentAPI {
   private val apiClient = new LiveContentApiClass(Config().capiKey, Config().capiUrl)
   private val previewApiClient = new DraftContentApiClass(Config().capiKey, Config().capiPreviewUrl)
 
-  def countOccurencesOfTagInContents(contentIds: List[String], apiTagId: String): Int= {
+  def countOccurencesOfTagInContents(contentIds: List[String], apiTagId: String): Int = {
+    val builder = StringBuilder.newBuilder
+    var pageSize = 0
+
+    var total = 0
+
+    for (id <- contentIds) {
+      // ~2048 chars is the max sensible amount for a URL.
+      // Rather than faff about subtracting our URL + query string junk from 2048 we'll just stay well below the max (1500)
+      // Also, CAPI maxes out at 50 items per query
+      if (pageSize >= 50 || builder.length + id.length > 1500) {
+        total += countTags(builder.toString, pageSize, apiTagId)
+        builder.setLength(0)
+        pageSize = 0
+      }
+
+      if (builder.length > 0) {
+        builder.append(',')
+      }
+      builder.append(id)
+      pageSize += 1
+    }
+    total += countTags(builder.toString, pageSize, apiTagId)
+
+    total
+  }
+
+  private def countTags(ids: String, pageSize: Int, apiTagId: String): Int = {
     val response = apiClient.getResponse(new SearchQuery()
-      .ids(contentIds mkString(","))
-      .pageSize(contentIds.length)
+      .ids(ids)
+      .pageSize(pageSize)
       .showTags("all")
     )
-
     val contentWithTag = response.map(_.results.filter{ c => c.tags.exists(_.id == apiTagId)})
-
     val contentWithTagCount = contentWithTag.map(_.length)
 
-    val count = Await.result(contentWithTagCount, 5 seconds)
-    count
+    Await.result(contentWithTagCount, 5 seconds)
   }
 
   def getTag(apiTagId: String) = {


### PR DESCRIPTION
When a tag had a lot of associated content we failed to split up the content into small enough chunks leading to either the URL being too long or overrunning the max amount of content you can check at any one time.

This fix incrementally builds the tag count query and flushes the request if we overrun the limitations.