### PR TITLE
Blocking contributors being batch tagged

### DIFF
--- a/public/components/BatchTag/BatchFilters.react.js
+++ b/public/components/BatchTag/BatchFilters.react.js
@@ -12,6 +12,8 @@ momentLocalizer(moment);
 
 const CAPI_DATE_FORMAT = 'YYYY-MM-DD';
 
+const blockedTagTypes = ["Contributor"];
+
 const PREDEFINED_VALUES = {
   today: {
     'from-date': moment().format(CAPI_DATE_FORMAT),
@@ -195,7 +197,7 @@ export default class BatchFilters extends React.Component {
                       </div>
                     );
                   })}
-                  <TagSelect onTagClick={this.addTag.bind(this)} />
+                  <TagSelect blockedTagTypes={blockedTagTypes} onTagClick={this.addTag.bind(this)} />
                 </div>
               </div>
               <div className="batch-filters__filter">
@@ -213,7 +215,7 @@ export default class BatchFilters extends React.Component {
                       </div>
                     );
                   })}
-                  <TagSelect onTagClick={this.addExcludedTag.bind(this)} />
+                  <TagSelect blockedTagTypes={blockedTagTypes} onTagClick={this.addExcludedTag.bind(this)} />
                 </div>
               </div>
               <div className="batch-filters__filter">

--- a/public/components/BatchTagStatus/BatchTagStatus.js
+++ b/public/components/BatchTagStatus/BatchTagStatus.js
@@ -7,6 +7,8 @@ const modes = {
   remove: 'REMOVE_BATCH_MODE'
 };
 
+const blockedTagTypes = ["Contributor"];
+
 export default class BatchTagStatus extends React.Component {
 
     constructor(props) {
@@ -98,7 +100,7 @@ export default class BatchTagStatus extends React.Component {
             <div className="batch-status__info">
               Add Tag
             </div>
-            <TagSelect onTagClick={this.selectTag.bind(this)} showResultsAbove={true} />
+            <TagSelect blockedTagTypes={blockedTagTypes} onTagClick={this.selectTag.bind(this)} showResultsAbove={true} />
             <i className="i-cross" onClick={this.resetMode}></i>
           </div>
       );
@@ -128,7 +130,7 @@ export default class BatchTagStatus extends React.Component {
             <div className="batch-status__info">
               Remove Tag
             </div>
-            <TagSelect onTagClick={this.selectTag.bind(this)} showResultsAbove={true} />
+            <TagSelect blockedTagTypes={blockedTagTypes} onTagClick={this.selectTag.bind(this)} showResultsAbove={true} />
             <i className="i-cross" onClick={this.resetMode}></i>
 
           </div>


### PR DESCRIPTION
Batch tagging contributors 'works' but it doesn't play nicely with Composer so this will block it in the client side as a measure to prevent confusion.

If there's ever a desire for batch tagging to work with contributors then composer will need to be updated, for now just blocking it.