### PR TITLE
Stop old content being included in batch tag operations

### DIFF
--- a/public/components/BatchTag.react.js
+++ b/public/components/BatchTag.react.js
@@ -76,7 +76,7 @@ export class BatchTag extends React.Component {
 
     selectAllContentFromPage(page) {
       this.setState({
-          selectedContent: R.union(this.state.selectedContent, page.map(c => c.id))
+          selectedContent: R.union(this.state.selectedContent, page.filter(c => !!c.fields.internalComposerCode).map(c => c.id))
       });
     }
 

--- a/public/components/BatchTag.react.js
+++ b/public/components/BatchTag.react.js
@@ -81,7 +81,7 @@ export class BatchTag extends React.Component {
     }
 
     deselectAllContentFromPage(page) {
-      var newContent = R.difference(this.state.selectedContent, page.map(c => c.id));
+      var newContent = R.difference(this.state.selectedContent, page.filter(c => !!c.fields.internalComposerCode).map(c => c.id));
 
       this.setState({
               selectedContent: newContent
@@ -90,7 +90,7 @@ export class BatchTag extends React.Component {
 
     toggleAllSelected() {
       const currentPage = this.props.capiSearch.pages[this.props.capiSearch.currentPage];
-      const notSelectedResults = R.difference(currentPage.map((content) => content.id), this.state.selectedContent);
+      const notSelectedResults = R.difference(currentPage.filter(c => !!c.fields.internalComposerCode).map((content) => content.id), this.state.selectedContent);
 
       if (notSelectedResults.length) {
         this.selectAllContentFromPage(currentPage);

--- a/public/components/ContentList/ContentList.js
+++ b/public/components/ContentList/ContentList.js
@@ -18,7 +18,7 @@ export default class ContentList extends React.Component {
           return false;
         }
 
-        const contentIds = this.props.content.map(content => content.id);
+        const contentIds = this.props.content.filter(c => !!c.fields.internalComposerCode).map(content => content.id);
         const unselectedContent = R.difference(contentIds, this.props.selectedContent);
 
         return (

--- a/public/components/ContentList/ContentListItem.js
+++ b/public/components/ContentList/ContentListItem.js
@@ -46,10 +46,7 @@ export default class ContentListItem extends React.Component {
       } else {
         return (
           <div>
-            <input type="checkbox" disabled={true} checked={this.props.isChecked} readOnly={true}/>
-            <div>
-              Content not managed by composer
-            </div>
+            Content not managed by composer
           </div>
         );
       }

--- a/public/components/ContentList/ContentListItem.js
+++ b/public/components/ContentList/ContentListItem.js
@@ -40,11 +40,34 @@ export default class ContentListItem extends React.Component {
       </div>);
     }
 
+    renderCheckBox(content) {
+      if (content.fields.internalComposerCode) {
+        return (<input type="checkbox" checked={this.props.isChecked} readOnly={true}/>);
+      } else {
+        return (
+          <div>
+            <input type="checkbox" disabled={true} checked={this.props.isChecked} readOnly={true}/>
+            <div>
+              Content not managed by composer
+            </div>
+          </div>
+        );
+      }
+    }
+
+    rowClicked() {
+      if (this.props.content.fields.internalComposerCode) {
+        this.props.contentClicked();
+      }
+    }
+
     render() {
+      const rowClass = this.props.content.fields.internalComposerCode ? "taglist__results-item" : "taglist__result-item--disabled";
+
       return (
-          <tr key={this.props.content.id} className="taglist__results-item" onClick={this.props.contentClicked}>
+        <tr key={this.props.content.id} className={rowClass} onClick={this.rowClicked.bind(this)}>
             <td>
-              <input type="checkbox" checked={this.props.isChecked} readOnly={true}/>
+              {this.renderCheckBox(this.props.content)}
             </td>
             <td>{this.props.content.type}</td>
             <td>{this.props.content.webTitle}</td>

--- a/public/style/components/tag-list/_index.scss
+++ b/public/style/components/tag-list/_index.scss
@@ -7,6 +7,10 @@
   text-align: center;
 }
 
+.taglist__result-item--disabled {
+    color: $c-grey-500;
+}
+
 .taglist__results-info {
     cursor: help;
 }

--- a/public/util/capiClient.js
+++ b/public/util/capiClient.js
@@ -56,7 +56,7 @@ export function searchPreviewContent (searchString, params) {
     const searchQueryString = searchString || '';
 
     return Reqwest({
-      url: getCapiPreviewUrl() + '&q=' + searchQueryString.replace(' ', ' AND ')  + '&' + query + '&show-fields=isLive',
+      url: getCapiPreviewUrl() + '&q=' + searchQueryString.replace(' ', ' AND ')  + '&' + query + '&show-fields=isLive,internalComposerCode',
       contentType: 'application/json',
       crossOrigin: true,
       method: 'get'


### PR DESCRIPTION
Grey out and prevent users from selecting content which isn't managed by composer in the batch tagger.

This is required since flex-feeds seemingly can't modify content which isn't managed by composer.

This can be removed in a few weeks when CAPI purges unmanaged content.

![composerbatch](https://cloud.githubusercontent.com/assets/5560113/14205730/6d1d64ea-f805-11e5-863e-c8577ed1585d.jpg)
