### PR TITLE
Sponsor logo styling fix

### DIFF
--- a/public/components/SponsorshipEdit/SponsorLogo.react.js
+++ b/public/components/SponsorshipEdit/SponsorLogo.react.js
@@ -60,7 +60,7 @@ export default class SponsorEdit extends React.Component {
     const imageAsset = this.props.logo.assets[0];
 
     return (
-      <div className="tag-edit__field">
+      <div className="tag-edit__field tag-edit__field-logo">
         <img src={imageAsset.imageUrl} className="tag-edit__field__image"/>
         <div className="tag-edit__image__info">
           <div>Width: {imageAsset.width}px</div>

--- a/public/components/SponsorshipEdit/SponsorLogo.react.js
+++ b/public/components/SponsorshipEdit/SponsorLogo.react.js
@@ -60,7 +60,7 @@ export default class SponsorEdit extends React.Component {
     const imageAsset = this.props.logo.assets[0];
 
     return (
-      <div className="tag-edit__field tag-edit__field--logo">
+      <div className="tag-edit__field--logo">
         <img src={imageAsset.imageUrl} className="tag-edit__field__image"/>
         <div className="tag-edit__image__info">
           <div>Width: {imageAsset.width}px</div>

--- a/public/components/SponsorshipEdit/SponsorLogo.react.js
+++ b/public/components/SponsorshipEdit/SponsorLogo.react.js
@@ -60,7 +60,7 @@ export default class SponsorEdit extends React.Component {
     const imageAsset = this.props.logo.assets[0];
 
     return (
-      <div className="tag-edit__field tag-edit__field-logo">
+      <div className="tag-edit__field tag-edit__field--logo">
         <img src={imageAsset.imageUrl} className="tag-edit__field__image"/>
         <div className="tag-edit__image__info">
           <div>Width: {imageAsset.width}px</div>

--- a/public/style/components/tag-edit/_index.scss
+++ b/public/style/components/tag-edit/_index.scss
@@ -46,13 +46,18 @@ $tag-edit-padding: $standard-padding/2;
   -moz-columns: 2;
 }
 
-.tag-edit__field {
+%tag-edit__field {
   position: relative;
   margin: $standard-padding/2 0;
 }
 
-.tag-edit__field-logo {
-  min-height: 100px;
+.tag-edit__field {
+  @extend %tag-edit__field;
+}
+
+.tag-edit__field--logo {
+  @extend %tag-edit__field;
+  min-height: 60px;
 }
 
 .tag-edit__field__image {

--- a/public/style/components/tag-edit/_index.scss
+++ b/public/style/components/tag-edit/_index.scss
@@ -51,6 +51,10 @@ $tag-edit-padding: $standard-padding/2;
   margin: $standard-padding/2 0;
 }
 
+.tag-edit__field-logo {
+  min-height: 100px;
+}
+
 .tag-edit__field__image {
   display: inline-block;
   width: 100px;


### PR DESCRIPTION
A small styling fix to correctly show the images' dimensions.

Before:
![screen shot 2016-04-26 at 15 18 14](https://cloud.githubusercontent.com/assets/489567/14821306/2479f944-0bc2-11e6-96ca-e8fbcc59c894.png)

After:
![screen shot 2016-04-26 at 15 18 20](https://cloud.githubusercontent.com/assets/489567/14821310/291a0c46-0bc2-11e6-9107-c5dfc585df60.png)
