### PR TITLE
Adds podcast category support

### DIFF
--- a/app/model/Section.scala
+++ b/app/model/Section.scala
@@ -58,7 +58,7 @@ case class Section(
 
 object Section {
 
-  implicit val sectionFormat = Jsonx.formatCaseClassUseDefaults[Section]
+  implicit val sectionFormat: Format[Section] = Jsonx.formatCaseClassUseDefaults[Section]
 
   def fromItem(item: Item) = try{
     Json.parse(item.toJSON).as[Section]

--- a/app/model/Sponsorship.scala
+++ b/app/model/Sponsorship.scala
@@ -21,7 +21,7 @@ case class SponsorshipTargeting(publishedSince: Option[DateTime], validEditions:
 }
 
 object SponsorshipTargeting {
-  implicit val sponsorshipTargettingFormat = Jsonx.formatCaseClass[SponsorshipTargeting]
+  implicit val sponsorshipTargetingFormat: Format[SponsorshipTargeting]  = Jsonx.formatCaseClass[SponsorshipTargeting]
 }
 
 case class Sponsorship (
@@ -52,7 +52,7 @@ case class Sponsorship (
 
 object Sponsorship {
 
-  implicit val sponsorshipFormat = Jsonx.formatCaseClass[Sponsorship]
+  implicit val sponsorshipFormat: Format[Sponsorship] = Jsonx.formatCaseClass[Sponsorship]
 
   def fromJson(json: JsValue) = json.as[Sponsorship]
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,10 +6,12 @@ name := "tag-manager"
 
 version := "1.0"
 
+resolvers += "Guardian Bintray" at "https://dl.bintray.com/guardian/editorial-tools"
+
 lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.10.33",
   "com.amazonaws" % "amazon-kinesis-client" % "1.6.1",
-  "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.8",
+  "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.13",
   "com.gu" %% "editorial-permissions-client" % "0.2",
   ws, // for panda
   "org.cvogt" %% "play-json-extensions" % "0.6.0",
@@ -18,7 +20,7 @@ lazy val dependencies = Seq(
   "com.twitter" %% "scrooge-core" % "4.1.0",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client" % "7.7",
-  "com.gu" %% "tags-thrift-schema" % "0.6.0",
+  "com.gu" %% "tags-thrift-schema" % "0.6.1",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/public/components/TagEdit/formComponents/series/PodcastCategorySelect.js
+++ b/public/components/TagEdit/formComponents/series/PodcastCategorySelect.js
@@ -10,6 +10,19 @@ export default class PodcastCategorySelect extends React.Component {
   }
 
   updateMainPodcastCategory(e) {
+
+    const newMainCat = e.target.value;
+
+    console.log(R.omit('categories', this.props.tag.podcastMetadata))
+
+    if (!newMainCat) {
+      this.props.updateTag(R.merge(this.props.tag, {
+        podcastMetadata: R.omit(['categories'], this.props.tag.podcastMetadata)
+      }));
+
+      return;
+    }
+
     this.props.updateTag(R.merge(this.props.tag, {
       podcastMetadata: R.merge(this.props.tag.podcastMetadata, {
         categories: {
@@ -50,7 +63,7 @@ export default class PodcastCategorySelect extends React.Component {
       <div className="tag-edit__field">
         <label className="tag-edit__label">Sub Category</label>
         <select value={categories.sub} onChange={this.updateSecondaryPodcastCategory.bind(this)}>
-          {!categories.sub ? <option value={false}></option> : false}
+          <option value=""></option>
           {activeCategory.subCategories.map(function(cat) {
             return (
               <option value={cat} key={cat}>{cat}</option>
@@ -74,7 +87,7 @@ export default class PodcastCategorySelect extends React.Component {
         <div className="tag-edit__field">
           <label className="tag-edit__label">Main Category</label>
           <select value={categories.main} onChange={this.updateMainPodcastCategory.bind(this)}>
-            {!categories.main ? <option value={false}></option> : false}
+            <option value=""></option>
             {podcastCategories.map(function(cat) {
               return (
                 <option value={cat.category} key={cat.category}>{cat.category}</option>

--- a/public/components/TagEdit/formComponents/series/PodcastCategorySelect.js
+++ b/public/components/TagEdit/formComponents/series/PodcastCategorySelect.js
@@ -13,8 +13,6 @@ export default class PodcastCategorySelect extends React.Component {
 
     const newMainCat = e.target.value;
 
-    console.log(R.omit('categories', this.props.tag.podcastMetadata))
-
     if (!newMainCat) {
       this.props.updateTag(R.merge(this.props.tag, {
         podcastMetadata: R.omit(['categories'], this.props.tag.podcastMetadata)

--- a/public/components/TagEdit/formComponents/series/PodcastCategorySelect.js
+++ b/public/components/TagEdit/formComponents/series/PodcastCategorySelect.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import R from 'ramda';
+
+import {podcastCategories} from '../../../../constants/podcastCategories';
+
+export default class PodcastCategorySelect extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  updateMainPodcastCategory(e) {
+    this.props.updateTag(R.merge(this.props.tag, {
+      podcastMetadata: R.merge(this.props.tag.podcastMetadata, {
+        categories: {
+          main: e.target.value
+        }
+      })
+    }));
+  }
+
+  updateSecondaryPodcastCategory(e) {
+    this.props.updateTag(R.merge(this.props.tag, {
+      podcastMetadata: R.merge(this.props.tag.podcastMetadata, {
+        categories: R.merge(this.props.tag.podcastMetadata.categories, {
+          sub: e.target.value
+        })
+      })
+    }));
+  }
+
+  tagHasPodcast() {
+    return !!this.props.tag.podcastMetadata;
+  }
+
+  renderSubCategory() {
+    const categories = this.props.tag.podcastMetadata.categories || {};
+
+    if (!categories.main) {
+      return false;
+    }
+
+    const activeCategory = podcastCategories.filter((cat) => cat.category === categories.main)[0];
+
+    if (!activeCategory || !activeCategory.subCategories) {
+      return false;
+    }
+
+    return (
+      <div className="tag-edit__field">
+        <label className="tag-edit__label">Sub Category</label>
+        <select value={categories.sub} onChange={this.updateSecondaryPodcastCategory.bind(this)}>
+          {!categories.sub ? <option value={false}></option> : false}
+          {activeCategory.subCategories.map(function(cat) {
+            return (
+              <option value={cat} key={cat}>{cat}</option>
+            );
+          })}
+        </select>
+      </div>
+    );
+  }
+
+  render () {
+
+    if (!this.tagHasPodcast) {
+      return false;
+    }
+
+    const categories = this.props.tag.podcastMetadata.categories || {};
+
+    return (
+      <div>
+        <div className="tag-edit__field">
+          <label className="tag-edit__label">Main Category</label>
+          <select value={categories.main} onChange={this.updateMainPodcastCategory.bind(this)}>
+            {!categories.main ? <option value={false}></option> : false}
+            {podcastCategories.map(function(cat) {
+              return (
+                <option value={cat.category} key={cat.category}>{cat.category}</option>
+              );
+            })}
+          </select>
+        </div>
+        {this.renderSubCategory()}
+      </div>
+    );
+  }
+}

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -2,6 +2,7 @@ import React from 'react';
 import R from 'ramda';
 
 import TagImageEdit from '../TagImageEdit.react';
+import PodcastCategorySelect from './PodcastCategorySelect.js';
 
 export default class PodcastMetadata extends React.Component {
 
@@ -132,6 +133,9 @@ export default class PodcastMetadata extends React.Component {
           label="Podcast Image"
           onChange={this.updateImage.bind(this)}
           tagEditable={this.props.tagEditable}/>
+        <PodcastCategorySelect
+          tag={this.props.tag}
+          updateTag={this.props.updateTag}/>
       </div>
     );
   }

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -75,6 +75,9 @@ export default class PodcastMetadata extends React.Component {
 
     return (
       <div>
+        <PodcastCategorySelect
+          tag={this.props.tag}
+          updateTag={this.props.updateTag}/>
         <div className="tag-edit__field">
           <label className="tag-edit__label">Link URL</label>
           <input type="text"
@@ -133,9 +136,6 @@ export default class PodcastMetadata extends React.Component {
           label="Podcast Image"
           onChange={this.updateImage.bind(this)}
           tagEditable={this.props.tagEditable}/>
-        <PodcastCategorySelect
-          tag={this.props.tag}
-          updateTag={this.props.updateTag}/>
       </div>
     );
   }

--- a/public/constants/podcastCategories.js
+++ b/public/constants/podcastCategories.js
@@ -1,0 +1,123 @@
+export const podcastCategories = [
+  {
+    category: 'Arts',
+    subCategories: [
+      'Design',
+      'Fashion & Beauty',
+      'Food',
+      'Literature',
+      'Performing Arts',
+      'Visual Arts'
+    ]
+  },
+  {
+    category: 'Business',
+    subCategories: [
+      'Business News',
+      'Careers',
+      'Investing',
+      'Management & Marketing',
+      'Shopping'
+    ]
+  },
+  {
+    category: 'Comedy'
+  },
+  {
+    category: 'Education',
+    subCategories: [
+      'Educational Technology',
+      'Higher Education',
+      'K-12',
+      'Language Courses',
+      'Training'
+    ]
+  },
+  {
+    category: 'Games & Hobbies',
+    subCategories: [
+      'Automotive',
+      'Aviation',
+      'Hobbies',
+      'Other Games',
+      'Video Games'
+    ]
+  },
+  {
+    category: 'Government & Organizations',
+    subCategories: [
+      'Local',
+      'National',
+      'Non-Profit',
+      'Regional'
+    ]
+  },
+  {
+    category: 'Health',
+    subCategories: [
+      'Alternative Health',
+      'Fitness & Nutrition',
+      'Self-Help',
+      'Sexuality'
+    ]
+  },
+  {
+    category: 'Kids & Family'
+  },
+  {
+    category: 'Music'
+  },
+  {
+    category: 'News & Politics'
+  },
+  {
+    category: 'Religion & Spirituality',
+    subCategories: [
+      'Buddhism',
+      'Christianity',
+      'Hinduism',
+      'Islam',
+      'Judaism',
+      'Other',
+      'Spirituality'
+    ]
+  },
+  {
+    category: 'Science & Medicine',
+    subCategories: [
+      'Medicine',
+      'Natural Sciences',
+      'Social Sciences'
+    ]
+  },
+  {
+    category: 'Society & Culture',
+    subCategories: [
+      'History',
+      'Personal Journals',
+      'Philosophy',
+      'Places & Travel'
+    ]
+  },
+  {
+    category: 'Sports & Recreation',
+    subCategories: [
+      'Amateur',
+      'College & High School',
+      'Outdoor',
+      'Professional'
+    ]
+  },
+  {
+    category: 'Technology',
+    subCategories: [
+      'Gadgets',
+      'Tech News',
+      'Podcasting',
+      'Software How-To'
+    ]
+  },
+  {
+    category: 'TV & Film'
+  }
+];


### PR DESCRIPTION
Adds podcast categories,

Note: these are represented in the thrift definition as a list, but only a single main and sub category is applicable in TagManager. Hence the List creation in asThrift method

Tested on CODE and confirmed appears correctly in CAPI
