### PR TITLE
Enable audit streaming to Tools Audit Server

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -42,7 +42,7 @@ object App extends Controller with PanDomainAuthActions {
       }
 
       val clientConfig = ClientConfig(
-        username = s"${req.user.firstName} ${req.user.lastName}",
+        username = req.user.email,
         capiUrl = Config().capiUrl,
         capiPreviewUrl = "/support/previewCapi",
         capiKey = Config().capiKey,

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -101,7 +101,7 @@ object Support extends Controller with PanDomainAuthActions {
 
   def unexpireSectionContent = (APIAuthAction andThen ModifySectionExpiryPermissionsCheck) { req =>
 
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       val sectionId = (json \ "sectionId").as[Long]
 
@@ -118,7 +118,7 @@ object Support extends Controller with PanDomainAuthActions {
 
   def expireSectionContent = (APIAuthAction andThen ModifySectionExpiryPermissionsCheck) { req =>
 
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       val sectionId = (json \ "sectionId").as[Long]
 
@@ -136,7 +136,7 @@ object Support extends Controller with PanDomainAuthActions {
 
   def fixDanglingParents = APIAuthAction { req =>
 
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
 
     val knownTags = TagRepository.loadAllTags
     var danglingParentsCount = 0

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -23,7 +23,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def updateTag(id: Long) = (APIAuthAction andThen UpdateTagPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
 
     req.body.asJson.map { json =>
       try {
@@ -37,7 +37,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def createTag() = (APIAuthAction andThen CreateTagPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       try {
         json.as[CreateTagCommand].process.map{t => Ok(Json.toJson(DenormalisedTag(t))) } getOrElse NotFound
@@ -83,7 +83,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def createSection() = (APIAuthAction andThen CreateSectionPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       try {
         json.as[CreateSectionCommand].process.map{t => Ok(Json.toJson(t)) } getOrElse NotFound
@@ -96,7 +96,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def updateSection(id: Long) = (APIAuthAction andThen UpdateSectionPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       try {
         UpdateSectionCommand(json.as[Section]).process.map{ t => Ok(Json.toJson(t)) } getOrElse NotFound
@@ -109,7 +109,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def addEditionToSection(id: Long) = (APIAuthAction andThen AddEditionToSectionPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       val editionName = (json \ "editionName").as[String]
 
@@ -124,7 +124,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def removeEditionFromSection(id: Long, editionName: String) = (APIAuthAction andThen RemoveEditionFromSectionPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     try {
       RemoveEditionFromSectionCommand(id, editionName.toUpperCase).process.map{ t => Ok(Json.toJson(t)) } getOrElse NotFound
     } catch {
@@ -150,7 +150,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
 
   def batchTag = APIAuthAction { req =>
 
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       try {
         json.as[BatchTagCommand].process.map{t => NoContent } getOrElse NotFound
@@ -163,7 +163,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def mergeTag = (APIAuthAction andThen MergeTagPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       try {
         json.as[MergeTagCommand].process.map{t => NoContent } getOrElse NotFound
@@ -176,7 +176,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def deleteTag(id: Long) = (APIAuthAction andThen DeleteTagPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     try {
       (new DeleteTagCommand(id)).process.map{t => NoContent } getOrElse NotFound
     } catch {
@@ -213,7 +213,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def createSponsorship = (APIAuthAction andThen ManageSponsorshipsPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       try {
         json.as[CreateSponsorshipCommand].process.map{t => Ok(Json.toJson(t)) } getOrElse NotFound
@@ -226,7 +226,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def updateSponsorship(id: Long) = (APIAuthAction andThen ManageSponsorshipsPermissionsCheck) { req =>
-    implicit val username = Option(s"${req.user.firstName} ${req.user.lastName}")
+    implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
       try {
         json.as[UpdateSponsorshipCommand].process.map{s => Ok(Json.toJson(DenormalisedSponsorship(s))) } getOrElse NotFound

--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -1,11 +1,12 @@
 package model
 
 import com.amazonaws.services.dynamodbv2.document.Item
+import com.gu.auditing.model.v1.{App, Notification}
 import com.gu.pandomainauth.model.User
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{Json, JsPath, Format}
+import play.api.libs.json.{Format, JsPath, Json}
 import repositories.SectionRepository
 
 import scala.util.control.NonFatal
@@ -20,6 +21,16 @@ case class SectionAudit(
                      sectionSummary: SectionSummary
                    ) {
   def toItem = Item.fromJSON(Json.toJson(this).toString())
+
+  def asAuditingThrift = Notification(
+    app = App.TagManager,
+    operation = operation,
+    userEmail = s"${user.replace(" ", ".").toLowerCase}@guardian.co.uk",
+    date = date.toString,
+    resourceId = Some(sectionId.toString),
+    message = Some(s"${description}. Section: ${sectionSummary.toString}"),
+    shortMessage = Some(s"${description} Section ID: ${sectionId.toString}")
+  )
 }
 
 object SectionAudit {

--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -29,7 +29,7 @@ case class SectionAudit(
     date = date.toString,
     resourceId = Some(sectionId.toString),
     message = Some(s"${description}. Section: ${sectionSummary.toString}"),
-    shortMessage = Some(s"${description} Section ID: ${sectionId.toString}")
+    shortMessage = Some(description)
   )
 }
 

--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -25,7 +25,7 @@ case class SectionAudit(
   def asAuditingThrift = Notification(
     app = App.TagManager,
     operation = operation,
-    userEmail = s"${user.replace(" ", ".").toLowerCase}@guardian.co.uk",
+    userEmail = user,
     date = date.toString,
     resourceId = Some(sectionId.toString),
     message = Some(s"${description}. Section: ${sectionSummary.toString}"),

--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -1,11 +1,12 @@
 package model
 
 import com.amazonaws.services.dynamodbv2.document.Item
+import com.gu.auditing.model.v1.{App, Notification}
 import com.gu.pandomainauth.model.User
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{Json, JsPath, Format}
+import play.api.libs.json.{Format, JsPath, Json}
 import repositories.SectionRepository
 
 import scala.util.control.NonFatal
@@ -21,6 +22,16 @@ case class TagAudit(
   secondaryTagSummary: Option[TagSummary]
 ) {
   def toItem = Item.fromJSON(Json.toJson(this).toString())
+
+  def asAuditingThrift = Notification(
+    app = App.TagManager,
+    operation = operation,
+    userEmail = s"${user.replace(" ", ".").toLowerCase}@guardian.co.uk",
+    date = date.toString,
+    resourceId = Some(tagId.toString),
+    message = Some(s"${description}. Primary Tag: ${tagSummary.toString}. Secondary Tag: ${secondaryTagSummary.toString}"),
+    shortMessage = Some(s"${description} Tag ID: ${tagId.toString}")
+  )
 }
 
 object TagAudit {

--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -30,7 +30,7 @@ case class TagAudit(
     date = date.toString,
     resourceId = Some(tagId.toString),
     message = Some(s"${description}. Primary Tag: ${tagSummary.toString}. Secondary Tag: ${secondaryTagSummary.toString}"),
-    shortMessage = Some(s"${description} Tag ID: ${tagId.toString}")
+    shortMessage = Some(description)
   )
 }
 

--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -26,7 +26,7 @@ case class TagAudit(
   def asAuditingThrift = Notification(
     app = App.TagManager,
     operation = operation,
-    userEmail = s"${user.replace(" ", ".").toLowerCase}@guardian.co.uk",
+    userEmail = user,
     date = date.toString,
     resourceId = Some(tagId.toString),
     message = Some(s"${description}. Primary Tag: ${tagSummary.toString}. Secondary Tag: ${secondaryTagSummary.toString}"),

--- a/app/repositories/TagAuditRepository.scala
+++ b/app/repositories/TagAuditRepository.scala
@@ -2,8 +2,8 @@ package repositories
 
 import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition
 import model.TagAudit
-import org.joda.time.{Duration, ReadableDuration, DateTime}
-import services.Dynamo
+import org.joda.time.{DateTime, Duration, ReadableDuration}
+import services.{Config, Dynamo, KinesisStreams}
 
 import scala.collection.JavaConversions._
 
@@ -11,6 +11,12 @@ import scala.collection.JavaConversions._
 object TagAuditRepository {
 
   def upsertTagAudit(tagAudit: TagAudit) = {
+
+    //Send onto Auditing Stream
+    if (Config().enableAuditStreaming) {
+      KinesisStreams.auditingEventsStream.publishUpdate("tag-manager-updates", tagAudit.asAuditingThrift)
+    }
+
     try {
       Dynamo.tagAuditTable.putItem(tagAudit.toItem)
       Some(tagAudit)

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -89,6 +89,7 @@ sealed trait Config {
   def taggingOperationsStreamName: String
 
   def commercialExpiryStreamName: String
+  def auditingStreamName: String
 
   def reindexTagsStreamName: String
   def reindexTagsBatchSize: Int
@@ -108,6 +109,8 @@ sealed trait Config {
   def corsableDomains: Seq[String]
 
   def frontendBucketWriteRole: Option[String] = None
+  def auditingKinesisWriteRole: Option[String] = None
+  def enableAuditStreaming: Boolean = true
 }
 
 class DevConfig extends Config {
@@ -127,6 +130,7 @@ class DevConfig extends Config {
   override def sectionUpdateStreamName: String = "section-update-stream-dev"
   override def taggingOperationsStreamName: String = "tagging-operations-stream-dev"
   override def commercialExpiryStreamName: String = "commercial-expiry-stream-DEV-KELVIN"
+  override def auditingStreamName: String = "auditing-CODE"
 
   override def reindexTagsStreamName: String = "tag-reindex-dev"
   override def reindexTagsBatchSize: Int = 500
@@ -144,6 +148,9 @@ class DevConfig extends Config {
 
   override def composerDomain: String = "https://composer.local.dev-gutools.co.uk"
   override def corsableDomains: Seq[String] = Seq(composerDomain)
+
+  //Disables submission of audits to the audit Kinesis server, requires frontCms credentials locally to enable
+  override def enableAuditStreaming: Boolean = false
 }
 
 class CodeConfig extends Config {
@@ -163,6 +170,8 @@ class CodeConfig extends Config {
   override def sectionUpdateStreamName: String = "section-update-stream-CODE"
   override def taggingOperationsStreamName: String = "tagging-operations-stream-CODE"
   override def commercialExpiryStreamName: String = "commercial-expiry-stream-CODE"
+  override def auditingStreamName: String = "auditing-CODE"
+
 
   override def reindexTagsStreamName: String = "tag-reindex-CODE"
   override def reindexTagsBatchSize: Int = 500
@@ -182,6 +191,7 @@ class CodeConfig extends Config {
   override def corsableDomains: Seq[String] = Seq(composerDomain, "https://composer.local.dev-gutools.co.uk")
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
+  override def auditingKinesisWriteRole: Option[String] = Some("arn:aws:iam::163592447864:role/auditing-CrossAccountKinesisAccess-CC5UXEHZNP5M")
 }
 
 class ProdConfig extends Config {
@@ -197,6 +207,7 @@ class ProdConfig extends Config {
   override def tagAuditTableName: String = "tag-manager-tag-audit-PROD"
   override def sectionAuditTableName: String = "tag-manager-section-audit-PROD"
   override def clusterStatusTableName: String = "tag-manager-cluster-status-PROD"
+  override def auditingStreamName: String = "auditing-PROD"
 
   override def tagUpdateStreamName: String = "tag-update-stream-PROD"
   override def sectionUpdateStreamName: String = "section-update-stream-PROD"
@@ -221,4 +232,6 @@ class ProdConfig extends Config {
   override def corsableDomains: Seq[String] = Seq(composerDomain)
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
+  override def auditingKinesisWriteRole: Option[String] = Some("arn:aws:iam::163592447864:role/auditing-CrossAccountKinesisAccess-CC5UXEHZNP5M")
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val dependencies = Seq(
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client" % "7.7",
   "com.gu" %% "tags-thrift-schema" % "0.6.1",
+  "com.gu" %% "auditing-thrift-model" % "0.2",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/cloudformation/tag-manager.json
+++ b/cloudformation/tag-manager.json
@@ -45,6 +45,10 @@
     "CertificateArn": {
       "Description": "ARN of the SSL certificate for this service",
       "Type": "String"
+    },
+    "AuditingRoleToAssume": {
+      "Description": "Auditing to assume for cross account access to auditing account",
+      "Type": "String"
     }
   },
   "Mappings": {
@@ -265,6 +269,22 @@
           ]
         },
         "Roles": [ { "Ref": "TagManagerRole" } ]
+      }
+    },
+
+    "TagManagerCrossAccountPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "TagManagerCrossAccountPolicy",
+        "PolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": { "Ref" : "AuditingRoleToAssume" }
+          }]
+        },
+        "Roles": [{ "Ref": "TagManagerRole" }]
       }
     },
 

--- a/public/components/Header.react.js
+++ b/public/components/Header.react.js
@@ -7,12 +7,6 @@ export default class Header extends React.Component {
         super(props);
     }
 
-    userName () {
-        if (this.props.user) {
-            return this.props.user.firstName + ' ' + this.props.user.lastName;
-        }
-    }
-
     render () {
         return (
             <header className="top-toolbar">


### PR DESCRIPTION
This adds support for @piuccio 's auditing setup. When enabled (All env's apart from DEV) when modifying a Tag or Section, a kinesis message is sent to the stream in the Fronts-CMS account.

cc @steppenwells 