### PR TITLE
Sw hosted content paths

### DIFF
--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -140,9 +140,9 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     Ok(Json.toJson(ExternalReferencesTypeRepository.loadAllReferenceTypes))
   }
 
-  def checkPathInUse(`type`: String, slug: String, section: Option[Long], trackingTagType: Option[String]) = APIAuthAction { req =>
+  def checkPathInUse(tagType: String, slug: String, section: Option[Long], tagSubType: Option[String]) = APIAuthAction { req =>
     try {
-      new PathUsageCheck(`type`, slug, section, trackingTagType).process.map{ t => Ok(Json.toJson(t)) } getOrElse BadRequest
+      new PathUsageCheck(tagType, slug, section, tagSubType).process.map{ t => Ok(Json.toJson(t)) } getOrElse BadRequest
     } catch {
       commandErrorAsResult
     }

--- a/app/model/command/PathUsageCheck.scala
+++ b/app/model/command/PathUsageCheck.scala
@@ -4,12 +4,12 @@ import model.command.logic.TagPathCalculator
 import repositories.PathManager
 
 
-class PathUsageCheck(`type`: String, slug: String, sectionId: Option[Long], trackingTagType: Option[String]) extends Command {
+class PathUsageCheck(tagType: String, slug: String, sectionId: Option[Long], tagSubType: Option[String]) extends Command {
 
   type T = Map[String, Boolean]
 
   override def process()(implicit username: Option[String] = None): Option[Map[String, Boolean]] = {
-    val calculatedPath = TagPathCalculator calculatePath(`type`, slug, sectionId, trackingTagType)
+    val calculatedPath = TagPathCalculator calculatePath(tagType, slug, sectionId, tagSubType)
 
     val inUse = PathManager isPathInUse(calculatedPath)
 

--- a/app/model/command/logic/TagPathCalculator.scala
+++ b/app/model/command/logic/TagPathCalculator.scala
@@ -6,14 +6,14 @@ import repositories.SectionRepository
 
 object TagPathCalculator {
 
-  def calculatePath(`type`: String, slug: String, sectionId: Option[Long], trackingTagType: Option[String]) = {
+  def calculatePath(tagType: String, slug: String, sectionId: Option[Long], tagSubType: Option[String]) = {
 
     val loadedSection = sectionId.map(SectionRepository.getSection(_).getOrElse(SectionNotFound))
 
     val sectionPathPrefix = loadedSection.map(_.wordsForUrl + "/").getOrElse("")
-    val trackingTagName = trackingTagType.getOrElse("")
+    val trackingTagName = tagSubType.getOrElse("")
 
-    `type`.toLowerCase match {
+    tagType.toLowerCase match {
       case "contenttype" => s"$slug"
       case "tone" => s"tone/$slug"
       case "contributor" => s"profile/$slug"

--- a/app/model/command/logic/TagPathCalculator.scala
+++ b/app/model/command/logic/TagPathCalculator.scala
@@ -11,16 +11,16 @@ object TagPathCalculator {
     val loadedSection = sectionId.map(SectionRepository.getSection(_).getOrElse(SectionNotFound))
 
     val sectionPathPrefix = loadedSection.map(_.wordsForUrl + "/").getOrElse("")
-    val trackingTagName = tagSubType.getOrElse("")
 
-    tagType.toLowerCase match {
-      case "contenttype" => s"$slug"
-      case "tone" => s"tone/$slug"
-      case "contributor" => s"profile/$slug"
-      case "publication" => s"$slug/all"
-      case "series" => s"${sectionPathPrefix}series/$slug"
-      case "tracking" => s"tracking/${trackingTagName}/$slug"
-      case _ => sectionPathPrefix + slug
+    (tagType.toLowerCase, tagSubType.map(_.toLowerCase)) match {
+      case ("contenttype", _) => s"$slug"
+      case ("tone", _) => s"tone/$slug"
+      case ("contributor", _) => s"profile/$slug"
+      case ("publication", _) => s"$slug/all"
+      case ("series", _) => s"${sectionPathPrefix}series/$slug"
+      case ("tracking", trackingType) => s"tracking/${trackingType.getOrElse("")}/$slug"
+      case ("paidcontent", Some("hostedcontent")) => s"advertiser-content/$slug"
+      case (_, _) => sectionPathPrefix + slug
     }
   }
 

--- a/conf/routes
+++ b/conf/routes
@@ -41,7 +41,7 @@ GET            /api/clashingSponsorships                               controlle
 
 GET            /api/referenceTypes                                     controllers.TagManagementApi.listReferenceTypes
 
-GET            /api/checkPathInUse                                     controllers.TagManagementApi.checkPathInUse(type: String, slug: String, section: Option[Long], trackingTagType: Option[String])
+GET            /api/checkPathInUse                                     controllers.TagManagementApi.checkPathInUse(tagType: String, slug: String, section: Option[Long], tagSubType: Option[String])
 POST           /api/batchTag                                           controllers.TagManagementApi.batchTag
 POST           /api/mergeTag                                           controllers.TagManagementApi.mergeTag
 

--- a/public/components/Tag/Create.react.js
+++ b/public/components/Tag/Create.react.js
@@ -70,7 +70,16 @@ class TagCreate extends React.Component {
     }
 
     checkPathInUse(tag) {
-      tagManagerApi.checkPathInUse(tag.type, tag.slug, tag.section, tag.trackingInformation ? tag.trackingInformation : undefined)
+      var subtype;
+      if (tag.trackingInformation && tag.trackingInformation.trackingType) {
+        subtype = tag.trackingInformation.trackingType;
+      }
+
+      if (tag.paidContentInformation && tag.paidContentInformation.paidContentType) {
+        subtype = tag.paidContentInformation.paidContentType;
+      }
+
+      tagManagerApi.checkPathInUse(tag.type, tag.slug, tag.section, subtype)
         .then(res => this.setState({pathInUse: res.inUse}))
         .fail((error) => {
           console.log(error);

--- a/public/components/TagEdit/formComponents/TagName.react.js
+++ b/public/components/TagEdit/formComponents/TagName.react.js
@@ -118,6 +118,16 @@ export default class TagNameEdit extends React.Component {
       return 'tracking/' + trackingTypeName + '/';
     }
 
+    // Paid content with sub type of hosted exception
+
+    if (this.props.tag.type === tagTypes.paidContent.name
+      && this.props.tag.paidContentInformation
+      && this.props.tag.paidContentInformation.paidContentType
+      && this.props.tag.paidContentInformation.paidContentType === 'HostedContent') {
+
+      return 'advertiser-content/';
+    }
+
     //Infer from Tag Type
 
     const tagTypeKey = Object.keys(tagTypes).filter((tagTypeKey) => {

--- a/public/components/TagEdit/formComponents/TagName.react.js
+++ b/public/components/TagEdit/formComponents/TagName.react.js
@@ -122,7 +122,6 @@ export default class TagNameEdit extends React.Component {
 
     if (this.props.tag.type === tagTypes.paidContent.name
       && this.props.tag.paidContentInformation
-      && this.props.tag.paidContentInformation.paidContentType
       && this.props.tag.paidContentInformation.paidContentType === 'HostedContent') {
 
       return 'advertiser-content/';

--- a/public/components/TagEdit/formComponents/paidcontent/PaidContentInfoEdit.react.js
+++ b/public/components/TagEdit/formComponents/paidcontent/PaidContentInfoEdit.react.js
@@ -25,9 +25,22 @@ export default class PaidContentInfoEdit extends React.Component {
   }
 
   updatePaidContentType(e) {
-    this.updatePaidContentInformation(Object.assign({}, this.props.tag.paidContentInformation, {
-        paidContentType: e.target.value
-    }));
+    const subtype = e.target.value;
+    
+    if(subtype === 'HostedContent') {
+      this.props.updateTag(Object.assign({}, this.props.tag, {
+        createMicrosite: true,
+        section: undefined,
+        capiSectionId: undefined,
+        paidContentInformation: Object.assign({}, this.props.tag.paidContentInformation, {
+          paidContentType: subtype
+        })
+      }));
+    } else {
+      this.updatePaidContentInformation(Object.assign({}, this.props.tag.paidContentInformation, {
+        paidContentType: subtype
+      }));
+    }
   }
 
   onUpdateCreateMicrosite(e) {
@@ -64,7 +77,9 @@ export default class PaidContentInfoEdit extends React.Component {
 
     return (
       <div>
-        <input type="checkbox" checked={this.props.tag.createMicrosite} onChange={this.onUpdateCreateMicrosite.bind(this)}/>
+        <input type="checkbox" checked={this.props.tag.createMicrosite}
+               onChange={this.onUpdateCreateMicrosite.bind(this)}
+               disabled={this.props.tag.paidContentInformation && this.props.tag.paidContentInformation.paidContentType === 'HostedContent'}/>
         <label className="tag-edit__label">create microsite for this tag</label>
       </div>
     );

--- a/public/util/tagManagerApi.js
+++ b/public/util/tagManagerApi.js
@@ -197,15 +197,16 @@ export default {
     });
   },
 
-  checkPathInUse: (type, slug, section, trackingTagType) => {
-      const query = {type: type, slug: slug};
+  checkPathInUse: (tagType, slug, section, tagSubType) => {
+    console.log('in path usage check', tagSubType);
+      const query = {tagType: tagType, slug: slug};
 
       if (section) {
           query.section = section;
       }
 
-      if (trackingTagType) {
-        query.trackingTagType = trackingTagType
+      if (tagSubType) {
+        query.tagSubType = tagSubType
       }
 
       return PandaReqwest({

--- a/public/util/tagManagerApi.js
+++ b/public/util/tagManagerApi.js
@@ -198,7 +198,6 @@ export default {
   },
 
   checkPathInUse: (tagType, slug, section, tagSubType) => {
-    console.log('in path usage check', tagSubType);
       const query = {tagType: tagType, slug: slug};
 
       if (section) {


### PR DESCRIPTION
Ensures that all hosted content campaign tags are created wit an "advertiser-content/" path prefix.

Also ensures that microsites are always created for hosted content tags.

also makes path check for tracking tags work correctly.