### PR TITLE
Sw move paidcontent spons to section

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -112,5 +112,7 @@ GET            /support/fixDanglingParents                             controlle
 # Migration endpoints
 GET            /migration/paidContent                                  controllers.Migration.showPaidContentUploadForm
 POST           /migration/paidContent                                  controllers.Migration.migratePaidContent
-GET           /migration/moveToSections                                  controllers.Migration.movePaidcontentSponsorshipUpToSection
+GET           /migration/moveToSections                                controllers.Migration.movePaidcontentSponsorshipUpToSection
+GET           /migration/flattenSponsoredMicrosite/:sponsId            controllers.Migration.flattenSponsoredMicrosite(sponsId: Long)
+
 


### PR DESCRIPTION
2 things here:

migration endpoint to flatten a sponsored tag to paid content.

updates the update tag command to trigger indexes of tags and sections correctly when the sponsorship updates. This fixes problems propagating changes to sponsorships seen in the wild.