### PR TITLE
remove guard preventing paid content migration happening when type is…

### DIFF
--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -65,13 +65,12 @@ object Migration extends Controller with PanDomainAuthActions {
 
   def flattenSponsoredMicrosite(sponsorshipId: Long) =  (APIAuthAction andThen TriggerMigrationPermissionsCheck) {
     implicit val username = Some("sponsorship Migration")
-    
+
     val spons = SponsorshipRepository.getSponsorship(sponsorshipId)
 
     var count = 0
     spons.foreach { s =>
       PaidContentMigrator.migrate(s)
-
       for (
         tags <- s.tags;
         tagId <- tags;
@@ -80,9 +79,11 @@ object Migration extends Controller with PanDomainAuthActions {
         val section = tag.section.flatMap { sid => SectionRepository.getSection(sid) }
         section foreach { s =>
           if (s.sectionTagId == tag.id) {
+
             val sponsorship = tag.sponsorship.flatMap { sid => SponsorshipRepository.getSponsorship(sid) }
 
             val targetedSponsorship = sponsorship map { spon =>
+
               val targetSections = spon.sections.getOrElse(Nil)
               val updatedSponsorship = spon.copy(sections = Some((s.id :: targetSections).distinct))
 

--- a/app/services/migration/PaidContentMigrator.scala
+++ b/app/services/migration/PaidContentMigrator.scala
@@ -22,16 +22,17 @@ object PaidContentMigrator {
       try {
         Logger.info(s"migrating tag ${t.internalName} to paid content type")
 
-        if (sponsorship.sponsorshipType != "paidContent") {
-          Logger.info(s"sponsorship provided is not a paid content type, aborting")
-          throw new AbortItemMigrationException
-        }
+//        if (sponsorship.sponsorshipType != "paidContent") {
+//          Logger.info(s"sponsorship provided is not a paid content type, aborting")
+//          throw new AbortItemMigrationException
+//        }
 
         val status = SponsorshipStatusCalculator.calculateStatus(sponsorship.validFrom, sponsorship.validTo)
         val sponsorshipWithStatus = sponsorship.copy(
           status = status,
           tags = Some(tagIds),
-          sections = None
+          sections = None,
+          sponsorshipType = "paidContent"
         )
 
         val paidContentTag = t.copy(


### PR DESCRIPTION
… not paid content.

this is how we're fixing missed stuff so it's no longer relevant