### PR TITLE
fire clash validation on all updates to sponsorship

### DIFF
--- a/public/components/Sponsorship/Display.js
+++ b/public/components/Sponsorship/Display.js
@@ -71,7 +71,7 @@ class SponsorshipDisplay extends React.Component {
       return (
         <div className="sponsorship-edit">
           <div className="sponsorship-edit__column--sidebar">
-            <SponsorEdit sponsorship={this.props.sponsorship} updateSponsorship={this.props.sponsorshipActions.updateSponsorship}/>
+            <SponsorEdit sponsorship={this.props.sponsorship} updateSponsorship={this.updateSponsorshipAndCheckClashes.bind(this)}/>
           </div>
           <div className="sponsorship-edit__column">
             <div className="tag-edit__input-group">


### PR DESCRIPTION
not just targeting changes.

This means that a sponsorship can be valid after changes to sponsor name etc. This change is not applied to create which will always need targeting configured.