### PR TITLE
restrict tag types that can be sponsored to topic and series.

### DIFF
--- a/public/components/SponsorshipEdit/TargetingEdit.react.js
+++ b/public/components/SponsorshipEdit/TargetingEdit.react.js
@@ -64,7 +64,7 @@ export default class TargetingEdit extends React.Component {
               </div>
             )
           })}
-          <TagSelect onTagClick={selectTagFn}/>
+          <TagSelect onTagClick={selectTagFn} tagType="topic,series" />
         </div>
     );
   }


### PR DESCRIPTION
This will prevent people sponsoring content types etc.

<img width="211" alt="screen shot 2016-09-22 at 11 43 58" src="https://cloud.githubusercontent.com/assets/145254/18745400/e54033fc-80b9-11e6-835e-ee008d6b8593.png">
