### PR TITLE
allow sponsorship to target microsite sections

### DIFF
--- a/public/components/SponsorshipEdit/TargetingEdit.react.js
+++ b/public/components/SponsorshipEdit/TargetingEdit.react.js
@@ -13,6 +13,10 @@ export default class TargetingEdit extends React.Component {
 
   constructor(props) {
     super(props);
+
+    this.state = {
+      pickMicrosite: false
+    };
   }
 
   onTagSelected(tag) {
@@ -49,6 +53,10 @@ export default class TargetingEdit extends React.Component {
     }));
   }
 
+  togglePickingMicrosites() {
+    this.setState({pickMicrosite: !this.state.pickMicrosite});
+  }
+
   renderTags(tags) {
     tags = tags || [];
     var selectTagFn = this.onTagSelected.bind(this);
@@ -83,10 +91,11 @@ export default class TargetingEdit extends React.Component {
                 </div>
             );
           })}
+          <input type="checkbox" checked={this.state.pickMicrosite} onChange={this.togglePickingMicrosites.bind(this)} /> Show Microsites
           <SectionSelect
               selectedId=""
               sections={this.props.sections}
-              isMicrosite={false}
+              isMicrosite={this.state.pickMicrosite}
               onChange={selectSectionFn}
           />
         </div>


### PR DESCRIPTION
The rationale for this as supplied by Tim Huges

> We do this from time to time for the online versions of professional supplements, which sometimes have sponsors. Making them as microsites has always seemed the sensible way to proceed, but if you think they should be made as series under editorial sections then that is something we can discuss.
> 
> In the meantime... this front is displaying its logo at 140 x 72 pixels,  and WWF think their panda looks fat. It looks like the logo was sized correctly so it's getting distorted somewhere.

(I left the bit about the fat panda in as it still amuses me hour later).

The control looks very similar to those elsewhere:

<img width="486" alt="screen shot 2016-09-22 at 14 53 34" src="https://cloud.githubusercontent.com/assets/145254/18750838/b6e5013e-80d4-11e6-818a-b8aa6f33df1c.png">
