### PR TITLE
add endpoints to hypermedia api to expose sponsorship information.

### DIFF
--- a/app/model/HyperMedia.scala
+++ b/app/model/HyperMedia.scala
@@ -63,5 +63,6 @@ object EmptyResponse { implicit val jsonWrites = Json.writes[EmptyResponse] }
 
 object HyperMediaHelpers {
   def tagUri(id: Long): String = s"https://tagmanager.${conf.pandaDomain}/hyper/tags/${id}"
+  def sponsorshipUri(id: Long): String = s"https://tagmanager.${conf.pandaDomain}/hyper/sponsorships/${id}"
   def fullUri(path: String): String = s"https://tagmanager.${conf.pandaDomain}${path}"
 }

--- a/conf/routes
+++ b/conf/routes
@@ -69,6 +69,8 @@ GET            /reindex/sections                                       controlle
 GET            /hyper                                                  controllers.HyperMediaApi.hyper
 GET            /hyper/tags                                             controllers.HyperMediaApi.tags
 GET            /hyper/tags/:id                                         controllers.HyperMediaApi.tag(id: Long)
+GET            /hyper/tags/:id/sponsorships                            controllers.HyperMediaApi.tagSponsorships(id: Long)
+GET            /hyper/sponsorships/:id                                 controllers.HyperMediaApi.sponsorship(id: Long)
 OPTIONS        /*all                                                   controllers.HyperMediaApi.preflight(all: String)
 
 # Tag export for inCopy


### PR DESCRIPTION
This is used by campaign central to grab real enddates for campaigns (enabling run rate analytics)