### PR TITLE
Adding step failure causing job failure

### DIFF
--- a/app/model/jobs/Job.scala
+++ b/app/model/jobs/Job.scala
@@ -33,6 +33,7 @@ case class Job(
       step.stepStatus match {
         case StepStatus.ready => processStep(step)
         case StepStatus.processed => checkStep(step)
+        case StepStatus.failed => failJob(step)
         case _ => {}
       }
 
@@ -57,6 +58,12 @@ case class Job(
       case NonFatal(e) => {
         jobStatus = JobStatus.failed
       }
+    }
+  }
+
+  def failJob(step: Step) = {
+    if (jobStatus != JobStatus.failed) {
+      jobStatus = JobStatus.failed
     }
   }
 

--- a/app/model/jobs/Job.scala
+++ b/app/model/jobs/Job.scala
@@ -62,9 +62,7 @@ case class Job(
   }
 
   def failJob(step: Step) = {
-    if (jobStatus != JobStatus.failed) {
-      jobStatus = JobStatus.failed
-    }
+    jobStatus = JobStatus.failed
   }
 
   def checkIfComplete() = {


### PR DESCRIPTION
This should fix an issue where steps run out of retries but the outer job does *NOT* fail. This causes the job to block the entire job queue.

It's really hard to know what causes the step failures to not trigger the job failures but this change should allow the jobs to recover and set the correct state.