### PR TITLE
remove code in denormalised tag normalisation process to update spons…

### DIFF
--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -194,15 +194,6 @@ case class DenormalisedTag (
 
   def normalise(): (Tag, Option[Sponsorship]) = {
 
-    val updatedSponsorship: Option[Sponsorship] = sponsorship.map { s => s.copy(status = SponsorshipStatusCalculator.calculateStatus(s.validFrom, s.validTo)) }
-
-    val updatedActiveSponsorships = if (`type` == "PaidContent") {
-      // only paid content tags control the active sponsorships on update
-      updatedSponsorship.toList.filter(_.status == "active").map(_.id)
-    } else {
-      activeSponsorships
-    }
-
     val tag = Tag(
       id = id,
       path = path,
@@ -226,12 +217,12 @@ case class DenormalisedTag (
       isMicrosite = isMicrosite,
       capiSectionId = capiSectionId,
       trackingInformation = trackingInformation,
-      activeSponsorships = updatedActiveSponsorships,
-      sponsorship = updatedSponsorship.map(_.id), // for paid content tags, they have an associated sponsorship but it may not be active
-      paidContentInformation = paidContentInformation, // for paid content tags, they have an associated sponsorship but it may not be active
-      expired = updatedSponsorship.map(_.status == "expired").getOrElse(false)
+      activeSponsorships = activeSponsorships,
+      sponsorship = sponsorship.map(_.id), // for paid content tags, they have an associated sponsorship but it may not be active
+      paidContentInformation = paidContentInformation,
+      expired = expired
     )
-    (tag, updatedSponsorship)
+    (tag, sponsorship)
   }
 }
 

--- a/app/repositories/SponsorshipOperations.scala
+++ b/app/repositories/SponsorshipOperations.scala
@@ -51,7 +51,7 @@ object SponsorshipOperations {
   def removeSponsorshipFromSection(sponsorshipId: Long, sectionId: Long)(implicit username: Option[String]): Unit = {
     Logger.info(s"removing sponsorship $sponsorshipId from section $sectionId")
     SectionRepository.getSection(sectionId).foreach { s =>
-      val sponsoredSection = s.copy(activeSponsorships =  s.activeSponsorships.filterNot(_ == sponsorshipId) )
+      val sponsoredSection = s.copy(activeSponsorships = s.activeSponsorships.filterNot(_ == sponsorshipId) )
       val result = SectionRepository.updateSection(sponsoredSection)
 
       KinesisStreams.sectionUpdateStream.publishUpdate(sponsoredSection.id.toString, SectionEvent(EventType.Update, sponsoredSection.id, Some(sponsoredSection.asThrift)))


### PR DESCRIPTION
…orship state

The code was updating the sponsorship state and the tag's active sponsorships but was not performing the section update or content expires. The code has been removed to let the sponsorship expiry and launch jobs handle paid content sponsorship state changes, thus there is only one place this happens and the confusing incomplete launch by side effect is removed.