### PR TITLE
split reindexes into new taggingOperationsReIndexStream

### DIFF
--- a/app/model/command/FlexTagReindexCommand.scala
+++ b/app/model/command/FlexTagReindexCommand.scala
@@ -24,7 +24,7 @@ case class FlexTagReindexCommand(tag: Tag) extends Command {
           contentPath = contentPath
         )
         Logger.info(s"raising flex reindex for content $contentPath")
-        KinesisStreams.taggingOperationsStream.publishUpdate(contentPath.take(200), taggingOperation)
+        KinesisStreams.taggingOperationsReIndexStream.publishUpdate(contentPath.take(200), taggingOperation)
       }
     }
 

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -103,6 +103,7 @@ object KinesisStreams {
   lazy val reindexTagsStream = new KinesisStreamProducer(streamName = Config().reindexTagsStreamName, requireCompressionByte = true)
   lazy val reindexSectionsStream = new KinesisStreamProducer(streamName = Config().reindexSectionsStreamName, requireCompressionByte = true)
   lazy val taggingOperationsStream = new KinesisStreamProducer(streamName = Config().taggingOperationsStreamName)
+  lazy val taggingOperationsReIndexStream = new KinesisStreamProducer(streamName = Config().taggingOperationsReIndexStreamName)
   lazy val commercialExpiryStream = new KinesisStreamProducer(streamName = Config().commercialExpiryStreamName)
   lazy val auditingEventsStream = new KinesisStreamProducer(streamName = Config().auditingStreamName, requireCompressionByte = true, isAuditing = true)
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -87,6 +87,7 @@ sealed trait Config {
   def tagUpdateStreamName: String
   def sectionUpdateStreamName: String
   def taggingOperationsStreamName: String
+  def taggingOperationsReIndexStreamName: String
 
   def commercialExpiryStreamName: String
   def auditingStreamName: String
@@ -129,6 +130,7 @@ class DevConfig extends Config {
   override def tagUpdateStreamName: String = "tag-update-stream-dev"
   override def sectionUpdateStreamName: String = "section-update-stream-dev"
   override def taggingOperationsStreamName: String = "tagging-operations-stream-dev"
+  override def taggingOperationsReIndexStreamName: String = "tagging-reindex-operations-stream-dev"
   override def commercialExpiryStreamName: String = "commercial-expiry-stream-DEV-KELVIN"
   override def auditingStreamName: String = "auditing-CODE"
 
@@ -173,6 +175,7 @@ class CodeConfig extends Config {
   override def tagUpdateStreamName: String = "tag-update-stream-CODE"
   override def sectionUpdateStreamName: String = "section-update-stream-CODE"
   override def taggingOperationsStreamName: String = "tagging-operations-stream-CODE"
+  override def taggingOperationsReIndexStreamName: String = "tagging-reindex-operations-stream-CODE"
   override def commercialExpiryStreamName: String = "commercial-expiry-stream-CODE"
   override def auditingStreamName: String = "auditing-CODE"
 
@@ -223,6 +226,7 @@ class ProdConfig extends Config {
   override def tagUpdateStreamName: String = "tag-update-stream-PROD"
   override def sectionUpdateStreamName: String = "section-update-stream-PROD"
   override def taggingOperationsStreamName: String = "tagging-operations-stream-PROD"
+  override def taggingOperationsReIndexStreamName: String = "tagging-reindex-operations-stream-PROD"
   override def commercialExpiryStreamName: String = "commercial-expiry-stream-PROD"
 
   override def reindexTagsStreamName: String = "tag-reindex-PROD"


### PR DESCRIPTION
flex feeds will consume the new stream, in addition to the original taggingOperationsStream, to stop the bottleneck caused by changes to External References