### PR TITLE
include paid content tag's sponsorship in hypermedia api response

### DIFF
--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -91,7 +91,10 @@ object HyperMediaApi extends Controller with PanDomainAuthActions {
   def tagSponsorships(id: Long) = CORSable(conf.corsableDomains: _*) {
     Action {
       TagRepository.getTag(id).map { tag =>
-        val sponsorships = tag.activeSponsorships.flatMap{sid => SponsorshipRepository.getSponsorship(sid)}
+        val activeSponsorships = tag.activeSponsorships.flatMap{sid => SponsorshipRepository.getSponsorship(sid)}
+        val paidSponsorship = tag.sponsorship.flatMap(SponsorshipRepository.getSponsorship(_))
+
+        val sponsorships = (activeSponsorships ::: paidSponsorship.toList).distinct
 
         Ok(Json.toJson(CollectionResponse(
           offset = 0,


### PR DESCRIPTION
even if it has expired.

This endpoint is used by campaign central