### PR TITLE
Sw make paid content type mandatory

### DIFF
--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -115,7 +115,7 @@ object Migration extends Controller with PanDomainAuthActions {
 
     val missingSubType = paidContentTags.filter{t =>
       t.paidContentInformation.isEmpty ||
-        t.paidContentInformation.get.paidContentType.trim == null ||
+        t.paidContentInformation.get.paidContentType == null ||
         t.paidContentInformation.get.paidContentType.trim == ""
     }
 

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -1,10 +1,13 @@
 package controllers
 
-import model.{Sponsorship, Tag}
+import com.gu.tagmanagement.{EventType, TagEvent}
+import model.command.FlexTagReindexCommand
+import model.{PaidContentInformation, Sponsorship, Tag, TagAudit}
 import permissions.TriggerMigrationPermissionsCheck
 import play.api.libs.json.Json
 import play.api.mvc.Controller
 import repositories._
+import services.KinesisStreams
 import services.migration.PaidContentMigrator
 
 import scala.io.Source
@@ -101,6 +104,37 @@ object Migration extends Controller with PanDomainAuthActions {
     }
 
     Ok(s"updated $count partner zones")
+  }
+
+  def addMissingPaidContentTypes() = (APIAuthAction andThen TriggerMigrationPermissionsCheck) {
+    implicit val username = Some("sponsorship Migration")
+
+    val paidContentTags = TagLookupCache.search(
+      TagSearchCriteria(types = Some(List("PaidContent")))
+    )
+
+    val missingSubType = paidContentTags.filter{t =>
+      t.paidContentInformation.isEmpty ||
+        t.paidContentInformation.get.paidContentType.trim == null ||
+        t.paidContentInformation.get.paidContentType.trim == ""
+    }
+
+    missingSubType foreach{ t =>
+      val paidContentInformation = t.paidContentInformation match {
+        case Some(pc) => pc.copy(paidContentType = "Topic")
+        case None => PaidContentInformation(paidContentType = "Topic", campaignColour = None)
+      }
+      val withSubType = t.copy(paidContentInformation = Some(paidContentInformation))
+
+      TagRepository.upsertTag(withSubType) foreach { updatedTag =>
+        KinesisStreams.tagUpdateStream.publishUpdate(updatedTag.id.toString, TagEvent(EventType.Update, updatedTag.id, Some(updatedTag.asThrift)))
+        TagAuditRepository.upsertTagAudit(TagAudit.updated(updatedTag))
+        FlexTagReindexCommand(updatedTag).process()
+      }
+
+    }
+
+    Ok(missingSubType.map{t => t.externalName}.mkString("\n"))
   }
 
 }

--- a/conf/routes
+++ b/conf/routes
@@ -118,5 +118,6 @@ GET            /migration/paidContent                                  controlle
 POST           /migration/paidContent                                  controllers.Migration.migratePaidContent
 GET           /migration/moveToSections                                controllers.Migration.movePaidcontentSponsorshipUpToSection
 GET           /migration/flattenSponsoredMicrosite/:sponsId            controllers.Migration.flattenSponsoredMicrosite(sponsId: Long)
+GET           /migration/addMissingPaidContentTypes                    controllers.Migration.addMissingPaidContentTypes
 
 

--- a/public/util/validateTag.js
+++ b/public/util/validateTag.js
@@ -45,6 +45,8 @@ function validatePodcast(tag) {
 
 function validatePaidContent(tag) {
 
+  let paidContentErrors = [];
+
   if (!tag.sponsorship) {
     return [{
       fieldName: 'sponsorship',
@@ -52,6 +54,12 @@ function validatePaidContent(tag) {
     }];
   }
 
+  if (!tag.paidContentInformation || !tag.paidContentInformation.paidContentType) {
+    paidContentErrors.push({
+      fieldName: 'paidContentType',
+      message: "Mandatory field 'paid content type' is empty"
+    });
+  }
 
   if (tag.paidContentInformation && tag.paidContentInformation.paidContentType === 'HostedContent') {
 
@@ -59,16 +67,16 @@ function validatePaidContent(tag) {
     const hexCodeRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
 
     if (!tag.paidContentInformation.campaignColour || !tag.paidContentInformation.campaignColour.match(hexCodeRegex)) {
-      return [{
+      paidContentErrors.push({
         fieldName: 'campaignColour',
         message: 'Mandatory campaignColour information is missing or is invalid'
-      }];
+      });
     }
   }
 
   const mandatoryPaidContentFields = ['sponsorName', 'sponsorLogo', 'sponsorLink'];
 
-  return validateMandatoryFields(mandatoryPaidContentFields, tag.sponsorship);
+  return paidContentErrors.concat(validateMandatoryFields(mandatoryPaidContentFields, tag.sponsorship));
 }
 
 function validateTrackingTag(tag) {


### PR DESCRIPTION
2 bits: the frontend validations now ensure the subtype is populated, and a migration endpoint to fix existing problematic paid content tags.