### PR TITLE
Do not break apart quoted strings when searching CAPI

### DIFF
--- a/public/util/capiClient.js
+++ b/public/util/capiClient.js
@@ -24,6 +24,47 @@ function getCapiPreviewUrl() {
   return store.getState().config.capiPreviewUrl + '/search?api-key=' + store.getState().config.capiKey;
 }
 
+// Ensure quoted strings are not split up into separate search tokens. For example:
+//   buildSearch('') === '';
+//   buildSearch('abc') === 'abc';
+//   buildSearch('abc def xyz') === 'abc AND def AND xyz';
+//   buildSearch('abc   def') === 'abc AND def';
+//   buildSearch('"abc def" xyz') === '"abc def" AND xyz';
+//   buildSearch('"abc def" xyz "beep   beep" bloop') === '"abc def" AND xyz AND "beep   beep" AND bloop';
+
+function buildSearch(searchString) {
+    const tokens = [];
+
+    let token = '';
+    let withinQuote = false;
+
+    for(const char of searchString) {
+        if(char === '"') {
+            withinQuote = !withinQuote;
+        }
+
+        if(withinQuote) {
+            token += char;
+        } else {
+            if(char === ' ') {
+                if(token != '') {
+                    tokens.push(token);
+                    token = '';
+                }
+            } else {
+                token += char;
+            }
+        }
+    }
+
+    // grab the last one
+    if(token != '') {
+        tokens.push(token);
+    }
+
+    return tokens.join(' AND ');
+}
+
 export function getByTag (tag, params) {
     const query = paramsObjectToQuery(params);
 
@@ -43,7 +84,7 @@ export function searchContent (searchString, params) {
     const searchQueryString = searchString || '';
 
     return Reqwest({
-      url: getCapiUrl() + '&q=' + searchQueryString.replace(' ', ' AND ')  + '&' + query,
+      url: getCapiUrl() + '&q=' + buildSearch(searchQueryString) + '&' + query,
       contentType: 'application/json',
       crossOrigin: true,
       method: 'get'
@@ -56,7 +97,7 @@ export function searchPreviewContent (searchString, params) {
     const searchQueryString = searchString || '';
 
     return Reqwest({
-      url: getCapiPreviewUrl() + '&q=' + searchQueryString.replace(' ', ' AND ')  + '&' + query + '&show-fields=isLive,internalComposerCode&order-by=newest',
+      url: getCapiPreviewUrl() + '&q=' + buildSearch(searchQueryString) + '&' + query + '&show-fields=isLive,internalComposerCode&order-by=newest',
       contentType: 'application/json',
       crossOrigin: true,
       method: 'get'


### PR DESCRIPTION
Fixes a problem where the name search in the Bulk Tag editor couldn't properly search for names (*forename* *surname* etc). All the spaces in the search were converted to CAPI `AND` filters whilst the user really wanted to search for the whole name.

After the fix, search strings in double quotes are not broken apart but sent to CAPI verbatim. For example:

**Before**: `"Zhang Yimou"` -> `search?q=%22Zhang%20AND%20Yimou%22`
**After**: `"Zhang Yimou"` -> `search?q=%22Zhang%20Yimou%22`