### PR TITLE
Sw dedupe active spons

### DIFF
--- a/app/repositories/SponsorshipOperations.scala
+++ b/app/repositories/SponsorshipOperations.scala
@@ -10,7 +10,7 @@ object SponsorshipOperations {
   def addSponsorshipToTag(sponsorshipId: Long, tagId: Long)(implicit username: Option[String]): Unit = {
     Logger.info(s"adding sponsorship $sponsorshipId to tag $tagId")
     TagRepository.getTag(tagId).foreach { t =>
-      val sponsoredTag = t.copy(activeSponsorships = sponsorshipId :: t.activeSponsorships )
+      val sponsoredTag = t.copy(activeSponsorships = (sponsorshipId :: t.activeSponsorships).distinct )
       val result = TagRepository.upsertTag(sponsoredTag)
 
       KinesisStreams.tagUpdateStream.publishUpdate(sponsoredTag.id.toString, TagEvent(EventType.Update, sponsoredTag.id, Some(sponsoredTag.asThrift)))

--- a/conf/routes
+++ b/conf/routes
@@ -116,8 +116,9 @@ GET            /support/fixDanglingParents                             controlle
 # Migration endpoints
 GET            /migration/paidContent                                  controllers.Migration.showPaidContentUploadForm
 POST           /migration/paidContent                                  controllers.Migration.migratePaidContent
-GET           /migration/moveToSections                                controllers.Migration.movePaidcontentSponsorshipUpToSection
-GET           /migration/flattenSponsoredMicrosite/:sponsId            controllers.Migration.flattenSponsoredMicrosite(sponsId: Long)
-GET           /migration/addMissingPaidContentTypes                    controllers.Migration.addMissingPaidContentTypes
+GET            /migration/moveToSections                               controllers.Migration.movePaidcontentSponsorshipUpToSection
+GET            /migration/flattenSponsoredMicrosite/:sponsId           controllers.Migration.flattenSponsoredMicrosite(sponsId: Long)
+GET            /migration/addMissingPaidContentTypes                   controllers.Migration.addMissingPaidContentTypes
+GET            /migration/dudupeActiveSponsorships                     controllers.Migration.dudupeActiveSponsorships
 
 


### PR DESCRIPTION
There are some tags which have the same sponsorship references twice in the active sponsorship list. This looks like it was caused by 2 sponsorship launchers running at the same time:

<img width="501" alt="screen shot 2017-02-08 at 14 25 12" src="https://cloud.githubusercontent.com/assets/145254/22743897/84e1ca58-ee13-11e6-9b48-ca457390c37b.png">

This will be a rare occurrence (I suspect it only ever happened when we did the initial migration of all sponsorships) but this guards against it happening again.

There is also a migration to fix existing tags.

The equivalent section operation already had dedupe support

cc @kelvin-chappell 