### PR TITLE
Improve thread pool handling

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -6,10 +6,10 @@ import play.api.mvc.{Action, Controller}
 import repositories.{TagSearchCriteria, TagRepository}
 import play.api.Logger
 import services.Config
-import com.gu.tagmanagement.{TagType}
+import com.gu.tagmanagement.TagType
 import permissions._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits._
 import scala.collection.mutable.ListBuffer
 
 object App extends Controller with PanDomainAuthActions {

--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -1,14 +1,13 @@
 package controllers
 
-import model.{Tag, EntityResponse, EmptyResponse, CollectionResponse, EmbeddedEntity, TagEntity, HyperMediaHelpers}
+import model._
 import play.api.libs.json._
-import play.api.mvc.Result
 import play.api.mvc.{Action, Controller, Request, Result}
 import repositories._
-import scala.concurrent.Future
 import services.Config.conf
-import scala.concurrent.ExecutionContext.Implicits.global
 
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits._
 
 case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
   def apply(request: Request[A]): Future[Result] = {

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -2,7 +2,7 @@ package controllers
 
 import play.api.mvc._
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits._
 
 object Login extends Controller with PanDomainAuthActions {
 

--- a/app/controllers/ReadOnly.scala
+++ b/app/controllers/ReadOnly.scala
@@ -1,10 +1,8 @@
 package controllers
 
 import helpers.XmlHelpers._
+import model.{Create, Delete, Merge, Section}
 import play.api.mvc.{Action, Controller}
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
-import model.{Tag, Section, Delete, Merge, Create}
 import repositories._
 
 import scala.xml.Node
@@ -103,6 +101,7 @@ object ReadOnlyApi extends Controller {
 
   def modifiedAsXml(since: Long) = Action {
     import helpers.XmlHelpers._
+
     import scala.xml.Node
 
     val audits = TagAuditRepository.getAuditsOfTagOperationsSince("updated", since).sortBy(_.date.getMillis)

--- a/app/helpers/XmlHelpers.scala
+++ b/app/helpers/XmlHelpers.scala
@@ -11,11 +11,13 @@ object XmlHelpers {
 
   def addChild(n: Node, newChild: Node): Node = n match {
     case Elem(prefix, label, attribs, scope, child @ _*) =>
-      Elem(prefix, label, attribs, scope, child ++ newChild : _*)
-    case _ => error("Can only add children to elements!")
+      val nodes = child ++ newChild
+      Elem.apply(prefix, label, attribs, scope, nodes.isEmpty, nodes : _*)
+    case _ => sys.error("Can only add children to elements!")
   }
 
   def createElem(name: String): Elem = {
-    Elem(null, name, Null, TopScope, Text(""))
+    val text = Text("")
+    Elem.apply(null, name, Null, TopScope, text.isEmpty, text)
   }
 }

--- a/app/model/command/AddEditionToSectionCommand.scala
+++ b/app/model/command/AddEditionToSectionCommand.scala
@@ -1,21 +1,22 @@
 package model.command
 
-import com.gu.pandomainauth.model.User
 import com.gu.tagmanagement.{EventType, SectionEvent}
 import model.command.CommandError._
 import model.command.logic.SectionEditionPathCalculator
-import model.{Section, SectionAudit, EditionalisedPage}
+import model.{EditionalisedPage, Section, SectionAudit}
 import play.api.Logger
-import repositories.{PathRegistrationFailed, PathManager, SectionAuditRepository, SectionRepository}
-import services.KinesisStreams
+import repositories.{PathManager, PathRegistrationFailed, SectionAuditRepository, SectionRepository}
+import services.{Contexts, KinesisStreams}
+
+import scala.concurrent.Future
 
 
 case class AddEditionToSectionCommand(sectionId: Long, editionName: String) extends Command {
 
   type T = Section
 
-  override def process()(implicit username: Option[String] = None): Option[Section] = {
-    Logger.info(s"add ${editionName} to section ${sectionId}")
+  override def process()(implicit username: Option[String] = None): Future[Option[Section]] = Future{
+    Logger.info(s"add $editionName to section $sectionId")
 
     val section = SectionRepository.getSection(sectionId).getOrElse(SectionNotFound)
 
@@ -40,5 +41,5 @@ case class AddEditionToSectionCommand(sectionId: Long, editionName: String) exte
     SectionAuditRepository.upsertSectionAudit(SectionAudit.addedEdition(updatedSection, editionName))
 
     result
-  }
+  }(Contexts.tagOperationContext)
 }

--- a/app/model/command/BatchTagCommand.scala
+++ b/app/model/command/BatchTagCommand.scala
@@ -1,20 +1,18 @@
 package model.command
 
-import com.gu.tagmanagement.{TagWithSection, OperationType, TaggingOperation}
-import model.TagAudit
+import model.command.CommandError._
 import model.jobs.JobHelper
-import org.joda.time.DateTime
-import play.api.Logger
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, Format}
+import play.api.libs.json.{Format, JsPath}
 import repositories._
-import CommandError._
-import services.{SQS, KinesisStreams}
+import services.Contexts
+
+import scala.concurrent.Future
 
 case class BatchTagCommand(contentIds: List[String], tagId: Long, operation: String) extends Command {
   type T = Unit
 
-  override def process()(implicit username: Option[String] = None): Option[Unit] = {
+  override def process()(implicit username: Option[String] = None): Future[Option[Unit]] = Future{
     val tag = TagRepository.getTag(tagId) getOrElse(TagNotFound)
 
     operation match {
@@ -23,7 +21,7 @@ case class BatchTagCommand(contentIds: List[String], tagId: Long, operation: Str
     }
 
     Some(())
-  }
+  }(Contexts.tagOperationContext)
 }
 
 object BatchTagCommand {

--- a/app/model/command/ClashingSponsorshipsFetch.scala
+++ b/app/model/command/ClashingSponsorshipsFetch.scala
@@ -1,20 +1,23 @@
 package model.command
 
 import model.Sponsorship
-import org.joda.time.{Interval, DateTime}
-import repositories.{SponsorshipSearchCriteria, SponsorshipRepository}
+import org.joda.time.{DateTime, Interval}
+import repositories.{SponsorshipRepository, SponsorshipSearchCriteria}
+import services.Contexts
+
+import scala.concurrent.Future
 
 
 class ClashingSponsorshipsFetch(id: Option[Long], tagIds: Option[List[Long]], sectionIds: Option[List[Long]], validFrom: Option[DateTime], validTo: Option[DateTime], editions: Option[List[String]]) extends Command {
 
   type T = List[Sponsorship]
 
-  override def process()(implicit username: Option[String] = None): Option[List[Sponsorship]] = {
+  override def process()(implicit username: Option[String] = None): Future[Option[List[Sponsorship]]] = Future{
 
     val targetedSponsorships = (tagIds.map{ tids =>
-      tids.flatMap{ tagId => SponsorshipRepository.searchSponsorships(new SponsorshipSearchCriteria(tagId = Some(tagId)))}
+      tids.flatMap{ tagId => SponsorshipRepository.searchSponsorships(SponsorshipSearchCriteria(tagId = Some(tagId)))}
     }.getOrElse(Nil) ++ sectionIds.map{ sids =>
-      sids.flatMap(sectionId => SponsorshipRepository.searchSponsorships(new SponsorshipSearchCriteria(sectionId = Some(sectionId))))
+      sids.flatMap(sectionId => SponsorshipRepository.searchSponsorships(SponsorshipSearchCriteria(sectionId = Some(sectionId))))
     }.getOrElse(Nil)).distinct
 
     val checkInterval = new Interval(validFrom.getOrElse(new DateTime().minusYears(500)), validTo.getOrElse(new DateTime().plusYears(500)))
@@ -22,14 +25,14 @@ class ClashingSponsorshipsFetch(id: Option[Long], tagIds: Option[List[Long]], se
     Some(targetedSponsorships.filter{ s =>
       lazy val timesOverlap = checkInterval overlaps interval(s.validFrom, s.validTo)
       lazy val editionsOverlap = (editions, s.targeting.flatMap(_.validEditions)) match {
-        case(Some(eds1), Some(eds2)) => !eds1.intersect(eds2).isEmpty
+        case(Some(eds1), Some(eds2)) => eds1.intersect(eds2).nonEmpty
         case _ => true // one or other sponsorship targets all editions
       }
 
       timesOverlap && editionsOverlap
 
-    }.filterNot{s => Some(s.id) == id})
-  }
+    }.filterNot{s => id.contains(s.id)})
+  }(Contexts.tagOperationContext)
 
   private def interval(from: Option[DateTime], to: Option[DateTime]) = new Interval(from.getOrElse(new DateTime().minusYears(500)), to.getOrElse(new DateTime().plusYears(500)))
 }

--- a/app/model/command/Command.scala
+++ b/app/model/command/Command.scala
@@ -1,11 +1,9 @@
 package model.command
 
-import play.api.Logger
-import play.api.libs.json._
-import play.api.libs.functional.syntax._
+import scala.concurrent.Future
 
 trait Command {
   type T
 
-  def process()(implicit username: Option[String] = None): Option[T]
+  def process()(implicit username: Option[String] = None): Future[Option[T]]
 }

--- a/app/model/command/CreateSponsorshipCommand.scala
+++ b/app/model/command/CreateSponsorshipCommand.scala
@@ -1,15 +1,16 @@
 package model.command
 
-import com.gu.tagmanagement.{SectionEvent, EventType, TagEvent}
 import model._
 import model.command.logic.SponsorshipStatusCalculator
 import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, Format}
+import play.api.libs.json.{Format, JsPath}
 import repositories.SponsorshipOperations._
-import repositories.{SponsorshipRepository, Sequences}
-import services.KinesisStreams
+import repositories.{Sequences, SponsorshipRepository}
+import services.Contexts
+
+import scala.concurrent.Future
 
 case class CreateSponsorshipCommand(
   validFrom: Option[DateTime],
@@ -27,7 +28,7 @@ case class CreateSponsorshipCommand(
 
   override type T = Sponsorship
 
-  override def process()(implicit username: Option[String]): Option[T] = {
+  override def process()(implicit username: Option[String]): Future[Option[T]] = Future{
 
     val status = SponsorshipStatusCalculator.calculateStatus(validFrom, validTo)
 
@@ -66,7 +67,7 @@ case class CreateSponsorshipCommand(
       createdSponsorship
     }
 
-  }
+  }(Contexts.tagOperationContext)
 }
 
 object CreateSponsorshipCommand{

--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -1,6 +1,6 @@
 package model.command
 
-import com.gu.tagmanagement.{SectionEvent, EventType, TagEvent}
+import com.gu.tagmanagement.{EventType, SectionEvent, TagEvent}
 import model.command.logic.{SponsorshipStatusCalculator, TagPathCalculator}
 import model._
 import org.apache.commons.lang3.StringUtils
@@ -8,10 +8,12 @@ import org.cvogt.play.json.Jsonx
 import org.cvogt.play.json.implicits.optionWithNull
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, Format}
+import play.api.libs.json.{Format, JsPath}
 import repositories._
 import CommandError._
-import services.KinesisStreams
+import services.{Contexts, KinesisStreams}
+
+import scala.concurrent.Future
 
 case class InlinePaidContentSponsorshipCommand(
                          validFrom: Option[DateTime],
@@ -78,7 +80,7 @@ case class CreateTagCommand(
 
   type T = Tag
 
-  def process()(implicit username: Option[String] = None): Option[Tag] = {
+  def process()(implicit username: Option[String] = None): Future[Option[Tag]] = Future {
 
     val tagId = Sequences.tagId.getNextId
 
@@ -176,7 +178,7 @@ case class CreateTagCommand(
     }
 
     result
-  }
+  }(Contexts.tagOperationContext)
 }
 
 object CreateTagCommand {

--- a/app/model/command/DeleteTagCommand.scala
+++ b/app/model/command/DeleteTagCommand.scala
@@ -1,27 +1,21 @@
 package model.command
 
-import com.gu.tagmanagement.{TagWithSection, OperationType, TaggingOperation}
 import model.command.CommandError._
 import model.jobs.JobHelper
-import org.joda.time.DateTime
-import play.api.Logger
-import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, Format}
 import repositories._
-import services.{SQS, KinesisStreams}
+import services.Contexts
 
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 
 case class DeleteTagCommand(removingTagId: Long) extends Command {
   override type T = Unit
 
-  override def process()(implicit username: Option[String] = None): Option[T] = {
+  override def process()(implicit username: Option[String] = None): Future[Option[T]] = Future{
     val removingTag = TagRepository.getTag(removingTagId) getOrElse(TagNotFound)
 
     JobHelper.beginTagDeletion(removingTag)
 
     Some(())
-  }
+  }(Contexts.tagOperationContext)
 }

--- a/app/model/command/ExpireSectionContentCommand.scala
+++ b/app/model/command/ExpireSectionContentCommand.scala
@@ -3,15 +3,17 @@ package model.command
 import model.Section
 import play.api.Logger
 import repositories._
-import services.KinesisStreams
+import services.{Contexts, KinesisStreams}
+
+import scala.concurrent.Future
 
 
 case class ExpireSectionContentCommand(sectionId: Long) extends Command {
 
   type T = Section
 
-  override def process()(implicit username: Option[String] = None): Option[Section] = {
-    Logger.info(s"Expiring Content for Section: ${sectionId}")
+  override def process()(implicit username: Option[String] = None): Future[Option[Section]] = Future{
+    Logger.info(s"Expiring Content for Section: $sectionId")
 
     SectionRepository.getSection(sectionId).map(section => {
 
@@ -24,5 +26,5 @@ case class ExpireSectionContentCommand(sectionId: Long) extends Command {
 
       section
     })
-  }
+  }(Contexts.tagOperationContext)
 }

--- a/app/model/command/MergeTagCommand.scala
+++ b/app/model/command/MergeTagCommand.scala
@@ -1,23 +1,19 @@
 package model.command
 
-import com.gu.tagmanagement.{TagWithSection, OperationType, TaggingOperation}
 import model.command.CommandError._
 import model.jobs.JobHelper
-import org.joda.time.DateTime
-import play.api.Logger
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, Format}
+import play.api.libs.json.{Format, JsPath}
 import repositories._
-import services.{SQS, KinesisStreams}
+import services.Contexts
 
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 
 case class MergeTagCommand(removingTagId: Long, replacementTagId: Long) extends Command {
   override type T = Unit
 
-  override def process()(implicit username: Option[String] = None): Option[T] = {
+  override def process()(implicit username: Option[String] = None): Future[Option[T]] = Future{
     if (removingTagId == replacementTagId) {
       AttemptedSelfMergeTag
     }
@@ -36,7 +32,7 @@ case class MergeTagCommand(removingTagId: Long, replacementTagId: Long) extends 
 
     JobHelper.beginMergeTag(removingTag, replacementTag)
     Some(())
-  }
+  }(Contexts.tagOperationContext)
 }
 
 object MergeTagCommand {

--- a/app/model/command/PathUsageCheck.scala
+++ b/app/model/command/PathUsageCheck.scala
@@ -2,17 +2,20 @@ package model.command
 
 import model.command.logic.TagPathCalculator
 import repositories.PathManager
+import services.Contexts
+
+import scala.concurrent.Future
 
 
 class PathUsageCheck(tagType: String, slug: String, sectionId: Option[Long], tagSubType: Option[String]) extends Command {
 
   type T = Map[String, Boolean]
 
-  override def process()(implicit username: Option[String] = None): Option[Map[String, Boolean]] = {
+  override def process()(implicit username: Option[String] = None): Future[Some[Map[String, Boolean]]] = Future{
     val calculatedPath = TagPathCalculator calculatePath(tagType, slug, sectionId, tagSubType)
 
     val inUse = PathManager isPathInUse(calculatedPath)
 
     Some(Map("inUse" -> inUse))
-  }
+  }(Contexts.tagOperationContext)
 }

--- a/app/model/command/ReindexSectionsCommand.scala
+++ b/app/model/command/ReindexSectionsCommand.scala
@@ -1,19 +1,15 @@
 package model.command
 
-import model.AppAudit;
 import model.jobs.JobHelper
-import services.SQS
-import org.cvogt.play.json.Jsonx
-import org.joda.time.DateTime
-import play.api.libs.json._
-import play.api.Logger
-import repositories._
+import services.Contexts
+
+import scala.concurrent.Future
 
 case class ReindexSectionsCommand() extends Command {
   override type T = Unit
 
-  override def process()(implicit username: Option[String] = None): Option[T] = {
+  override def process()(implicit username: Option[String] = None): Future[Option[T]] = Future{
     JobHelper.beginSectionReindex
     Some(())
-  }
+  }(Contexts.tagOperationContext)
 }

--- a/app/model/command/ReindexTagsCommand.scala
+++ b/app/model/command/ReindexTagsCommand.scala
@@ -1,21 +1,16 @@
 package model.command
 
-import model.AppAudit;
 import model.jobs.JobHelper
-import services.SQS
-import org.cvogt.play.json.Jsonx
-import org.joda.time.DateTime
-import play.api.libs.functional.syntax._
-import play.api.libs.json._
-import play.api.Logger
-import repositories._
+import services.Contexts
+
+import scala.concurrent.Future
 
 case class ReindexTagsCommand() extends Command {
   override type T = Unit
 
-  override def process()(implicit username: Option[String] = None): Option[T] = {
+  override def process()(implicit username: Option[String] = None): Future[Option[T]] = Future{
     JobHelper.beginTagReindex
     Some(())
-  }
+  }(Contexts.tagOperationContext)
 }
 

--- a/app/model/command/UnexpireSectionContentCommand.scala
+++ b/app/model/command/UnexpireSectionContentCommand.scala
@@ -1,23 +1,19 @@
 package model.command
 
-import java.nio.ByteBuffer
-
-import com.gu.tagmanagement._
-import com.squareup.okhttp.{Credentials, Request}
-import model.{Tag, TagAudit, Section}
-import org.joda.time.{DateTime, DateTimeZone}
+import model.Section
 import play.api.Logger
 import repositories._
-import com.amazonaws.services.kinesis.model.{PutRecordRequest, PutRecordResult}
-import services.{KinesisStreams, Config}
+import services.{Contexts, KinesisStreams}
+
+import scala.concurrent.Future
 
 
 case class UnexpireSectionContentCommand(sectionId: Long) extends Command {
 
   type T = Section
 
-  override def process()(implicit username: Option[String] = None): Option[Section] = {
-    Logger.info(s"Unexpiring Content for Section: ${sectionId}")
+  override def process()(implicit username: Option[String] = None): Future[Option[Section]] = Future{
+    Logger.info(s"Unexpiring Content for Section: $sectionId")
 
     SectionRepository.getSection(sectionId).map(section => {
 
@@ -31,5 +27,5 @@ case class UnexpireSectionContentCommand(sectionId: Long) extends Command {
 
       section
     })
-  }
+  }(Contexts.tagOperationContext)
 }

--- a/app/model/command/UpdateSectionCommand.scala
+++ b/app/model/command/UpdateSectionCommand.scala
@@ -1,18 +1,19 @@
 package model.command
 
-import com.gu.pandomainauth.model.User
 import com.gu.tagmanagement.{EventType, SectionEvent}
 import model.{Section, SectionAudit}
 import play.api.Logger
 import repositories.{SectionAuditRepository, SectionRepository}
-import services.KinesisStreams
+import services.{Contexts, KinesisStreams}
+
+import scala.concurrent.Future
 
 
 case class UpdateSectionCommand(section: Section) extends Command {
 
   type T = Section
 
-  override def process()(implicit username: Option[String] = None): Option[Section] = {
+  override def process()(implicit username: Option[String] = None): Future[Option[Section]] = Future{
     Logger.info(s"updating section ${section.id}")
 
     val result = SectionRepository.updateSection(section)
@@ -22,5 +23,5 @@ case class UpdateSectionCommand(section: Section) extends Command {
     SectionAuditRepository.upsertSectionAudit(SectionAudit.updated(section))
 
     result
-  }
+  }(Contexts.tagOperationContext)
 }

--- a/app/model/command/UpdateSponsorshipCommand.scala
+++ b/app/model/command/UpdateSponsorshipCommand.scala
@@ -5,9 +5,12 @@ import model.command.logic.SponsorshipStatusCalculator
 import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, Format}
+import play.api.libs.json.{Format, JsPath}
 import repositories.SponsorshipOperations._
 import repositories.SponsorshipRepository
+import services.Contexts
+
+import scala.concurrent.Future
 
 case class UpdateSponsorshipCommand(
   id: Long,
@@ -26,7 +29,7 @@ case class UpdateSponsorshipCommand(
 
   override type T = Sponsorship
 
-  override def process()(implicit username: Option[String]): Option[T] = {
+  override def process()(implicit username: Option[String]): Future[Option[T]] = Future{
 
     val status = SponsorshipStatusCalculator.calculateStatus(validFrom, validTo)
 
@@ -77,7 +80,7 @@ case class UpdateSponsorshipCommand(
 
       updatedSponsorship
     }
-  }
+  }(Contexts.tagOperationContext)
 
   private def getActiveTags(s: Sponsorship): List[Long] = {
     s.status match {

--- a/app/model/command/UpdateTagCommand.scala
+++ b/app/model/command/UpdateTagCommand.scala
@@ -2,18 +2,19 @@ package model.command
 
 import com.gu.tagmanagement._
 import model.{DenormalisedTag, SectionAudit, Tag, TagAudit}
+import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
 import repositories._
-import services.KinesisStreams
-import org.joda.time.{DateTime, DateTimeZone}
-import model.command._
+import services.{Contexts, KinesisStreams}
+
+import scala.concurrent.Future
 
 
 case class UpdateTagCommand(denormalisedTag: DenormalisedTag) extends Command {
 
   type T = Tag
 
-  override def process()(implicit username: Option[String] = None): Option[Tag] = {
+  override def process()(implicit username: Option[String] = None): Future[Option[Tag]] = Future{
     val (tag, sponsorship) = denormalisedTag.normalise()
 
     Logger.info(s"updating tag ${tag.id}")
@@ -67,5 +68,5 @@ case class UpdateTagCommand(denormalisedTag: DenormalisedTag) extends Command {
     TagAuditRepository.upsertTagAudit(TagAudit.updated(tag))
 
     result
-  }
+  }(Contexts.tagOperationContext)
 }

--- a/app/model/jobs/steps/MergeTagForContent.scala
+++ b/app/model/jobs/steps/MergeTagForContent.scala
@@ -1,13 +1,15 @@
 package model.jobs.steps
 
-import com.gu.tagmanagement.{TagWithSection, OperationType, TaggingOperation}
+import com.gu.tagmanagement.{OperationType, TagWithSection, TaggingOperation}
 import model.{Section, Tag, TagAudit}
+
 import scala.concurrent.duration._
 import model.jobs.{Step, StepStatus}
 import play.api.Logger
 import services.KinesisStreams
 import repositories._
-import java.lang.UnsupportedOperationException
+
+import scala.language.postfixOps
 
 case class MergeTagForContent(from: Tag, to: Tag, fromSection: Option[Section], toSection: Option[Section], username: Option[String], var contentCount: Int = -1,
   `type`: String = MergeTagForContent.`type`, var stepStatus: String = StepStatus.ready, var stepMessage: String = "Waiting", var attempts: Int = 0) extends Step {
@@ -38,7 +40,7 @@ case class MergeTagForContent(from: Tag, to: Tag, fromSection: Option[Section], 
     val fromCount = ContentAPI.countContentWithTag(from.path)
     val toCount = ContentAPI.countContentWithTag(to.path)
 
-    Logger.info(s"Checking merge tag CAPI counts. From tag: '${from.path}' remains on ${fromCount} pieces of content. To tag: '${to.path}' on to ${toCount} pieces of content, ${contentCount - toCount} left to add.")
+    Logger.info(s"Checking merge tag CAPI counts. From tag: '${from.path}' remains on $fromCount pieces of content. To tag: '${to.path}' on to $toCount pieces of content, ${contentCount - toCount} left to add.")
     if (fromCount == 0 && toCount == contentCount) {
       true
     } else {

--- a/app/model/jobs/steps/RemoveTagFromCapi.scala
+++ b/app/model/jobs/steps/RemoveTagFromCapi.scala
@@ -1,12 +1,15 @@
 package model.jobs.steps
 
-import com.gu.tagmanagement.{TagEvent, EventType}
+import com.gu.tagmanagement.{EventType, TagEvent}
 import model.Tag
 import repositories.ContentAPI
 import services.KinesisStreams
+
 import scala.concurrent.duration._
 import model.jobs.{Step, StepStatus}
 import play.api.Logger
+
+import scala.language.postfixOps
 
 case class RemoveTagFromCapi(tag: Tag,
   `type`: String = RemoveTagFromCapi.`type`, var stepStatus: String = StepStatus.ready, var stepMessage: String = "Waiting", var attempts: Int = 0) extends Step {
@@ -23,12 +26,8 @@ case class RemoveTagFromCapi(tag: Tag,
 
   override def check: Boolean = {
     ContentAPI.getTag(tag.path) match {
-      case Some(tag) => {
-        false
-      }
-      case None => {
-        true
-      }
+      case Some(_) => false
+      case None => true
     }
   }
 

--- a/app/model/jobs/steps/RemoveTagFromContent.scala
+++ b/app/model/jobs/steps/RemoveTagFromContent.scala
@@ -1,12 +1,15 @@
 package model.jobs.steps
 
-import com.gu.tagmanagement.{TagWithSection, OperationType, TaggingOperation}
+import com.gu.tagmanagement.{OperationType, TagWithSection, TaggingOperation}
 import model.{Section, Tag, TagAudit}
+
 import scala.concurrent.duration._
 import model.jobs.{Step, StepStatus}
 import play.api.Logger
 import services.KinesisStreams
 import repositories.{ContentAPI, TagAuditRepository}
+
+import scala.language.postfixOps
 
 case class RemoveTagFromContent(tag: Tag, section: Option[Section], contentIds: List[String],
   `type`: String = RemoveTagFromContent.`type`, var stepStatus: String = StepStatus.ready, var stepMessage: String = "Waiting", var attempts: Int = 0) extends Step {
@@ -18,7 +21,7 @@ case class RemoveTagFromContent(tag: Tag, section: Option[Section], contentIds: 
         tag = Some(TagWithSection(tag.asThrift, section.map(_.asThrift)))
       )
       KinesisStreams.taggingOperationsStream.publishUpdate(contentPath.take(200), taggingOperation)
-      Logger.info(s"raising ${OperationType.Remove} for ${tag.id} on ${contentPath} operation")
+      Logger.info(s"raising ${OperationType.Remove} for ${tag.id} on $contentPath operation")
     }
 
     TagAuditRepository.upsertTagAudit(TagAudit.batchTag(tag, "remove", contentIds.length))
@@ -30,7 +33,7 @@ case class RemoveTagFromContent(tag: Tag, section: Option[Section], contentIds: 
 
   override def check: Boolean = {
     val count = ContentAPI.countOccurencesOfTagInContents(contentIds, tag.path)
-    Logger.info(s"Checking tags removed from content. Expected=0 Actual=${count}")
+    Logger.info(s"Checking tags removed from content. Expected=0 Actual=$count")
     if (count == 0) {
       true
     } else {

--- a/app/modules/sponsorshiplifecycle/SponsorshipLifecycleModule.scala
+++ b/app/modules/sponsorshiplifecycle/SponsorshipLifecycleModule.scala
@@ -2,15 +2,17 @@ package modules.sponsorshiplifecycle
 
 import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
+
 import com.google.common.util.concurrent.AbstractScheduledService.Scheduler
 import com.google.common.util.concurrent.{AbstractScheduledService, ServiceManager}
 import com.google.inject.AbstractModule
 import model.Sponsorship
 import play.api.Logger
 import play.api.inject.ApplicationLifecycle
+import play.api.libs.concurrent.Execution.Implicits._
 import repositories.SponsorshipOperations._
 import repositories.SponsorshipRepository
-import scala.concurrent.ExecutionContext.Implicits.global
+
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 

--- a/app/permissions/PermissionActionCheck.scala
+++ b/app/permissions/PermissionActionCheck.scala
@@ -1,12 +1,12 @@
 package permissions
 
+import com.gu.editorial.permissions.client.{PermissionAuthorisation, PermissionDenied, PermissionGranted}
 import com.gu.pandomainauth.action.UserRequest
-import com.gu.editorial.permissions.client.{Permission, PermissionAuthorisation, PermissionDenied, PermissionGranted}
-import com.gu.tagmanagement.TagType
-import play.api.mvc.{ActionFilter, Results}
 import play.api.Logger
-import scala.concurrent.{Future}
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.mvc.{ActionFilter, Results}
+
+import play.api.libs.concurrent.Execution.Implicits._
+import scala.concurrent.Future
 
 trait PermissionActionFilter extends ActionFilter[UserRequest] {
   val testAccess: String => Future[PermissionAuthorisation]

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -2,7 +2,8 @@ package permissions
 
 import com.gu.editorial.permissions.client._
 import services.Config
-import scala.concurrent.{Future, ExecutionContext}
+
+import scala.concurrent.Future
 
 object Permissions extends PermissionsProvider {
 

--- a/app/repositories/ContentAPI.scala
+++ b/app/repositories/ContentAPI.scala
@@ -7,7 +7,7 @@ import com.gu.contentapi.client.model._
 import com.squareup.okhttp.Credentials
 import dispatch.FunctionHandler
 import play.api.Logger
-import services.Config
+import services.{Config, Contexts}
 
 import scala.annotation.tailrec
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -17,8 +17,7 @@ import scala.language.postfixOps
 
 object ContentAPI {
 
-  private val executorService = Executors.newFixedThreadPool(25)
-  private implicit val executionContext = ExecutionContext.fromExecutor(executorService)
+  private implicit val executionContext = Contexts.capiContext
 
   private val previewApiClient = new DraftContentApiClass(Config().capiKey, Config().capiPreviewUrl)
 
@@ -116,8 +115,6 @@ object ContentAPI {
 
   def shutdown(): Unit = {
     previewApiClient.shutdown()
-
-    executorService.shutdown()
   }
 
 }

--- a/app/repositories/ReindexProgressRepository.scala
+++ b/app/repositories/ReindexProgressRepository.scala
@@ -1,7 +1,10 @@
 package repositories;
 
 import model.ReindexProgress
-import services.Dynamo
+import services.{Contexts, Dynamo}
+
+import scala.concurrent.Future
+import services.Contexts.tagOperationContext
 
 object ReindexProgressRepository {
   // Write
@@ -38,21 +41,29 @@ object ReindexProgressRepository {
   }
 
   // Read
-  def getTagReindexProgress(): Option[ReindexProgress] = {
-    Option(Dynamo.reindexProgressTable.getItem("type", ReindexProgress.TagTypeName))
-      .map(ReindexProgress.fromItem(_))
+  def getTagReindexProgress: Future[Option[ReindexProgress]] = {
+    Future{
+      Option(Dynamo.reindexProgressTable.getItem("type", ReindexProgress.TagTypeName))
+        .map(ReindexProgress.fromItem)
+    }
   }
 
-  def getSectionReindexProgress(): Option[ReindexProgress] = {
-    Option(Dynamo.reindexProgressTable.getItem("type", ReindexProgress.SectionTypeName))
-      .map(ReindexProgress.fromItem(_))
+  def getSectionReindexProgress: Future[Option[ReindexProgress]] = {
+    Future{
+      Option(Dynamo.reindexProgressTable.getItem("type", ReindexProgress.SectionTypeName))
+        .map(ReindexProgress.fromItem)
+    }
   }
 
-  def isTagReindexInProgress(): Boolean = {
-    getTagReindexProgress.map(_.status == ReindexProgress.InProgress).getOrElse(false)
+  def isTagReindexInProgress: Future[Boolean] = {
+    getTagReindexProgress.map { result =>
+      result.exists(_.status == ReindexProgress.InProgress)
+    }
   }
 
-  def isSectionReindexInProgress(): Boolean = {
-    getSectionReindexProgress.map(_.status == ReindexProgress.InProgress).getOrElse(false)
+  def isSectionReindexInProgress: Future[Boolean] = {
+    getSectionReindexProgress.map { result =>
+      result.exists(_.status == ReindexProgress.InProgress)
+    }
   }
 }

--- a/app/services/Contexts.scala
+++ b/app/services/Contexts.scala
@@ -1,0 +1,11 @@
+package services
+
+import play.api.libs.concurrent.Akka
+
+import scala.concurrent.ExecutionContext
+import play.api.Play.current
+
+object Contexts {
+  implicit val tagOperationContext: ExecutionContext = Akka.system.dispatchers.lookup("tag-operation-context")
+  implicit val capiContext: ExecutionContext = Akka.system.dispatchers.lookup("capi-context")
+}

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProces
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
-import com.amazonaws.services.kinesis.clientlibrary.types.{ProcessRecordsInput, InitializationInput, ShutdownReason, ShutdownInput}
+import com.amazonaws.services.kinesis.clientlibrary.types.{InitializationInput, ProcessRecordsInput, ShutdownInput, ShutdownReason}
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import com.amazonaws.services.kinesis.model.Record
 import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream
@@ -16,13 +16,14 @@ import play.api.Logger
 import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.language.implicitConversions
 
 class KinesisConsumer(streamName: String, appName: String, processor: KinesisStreamRecordProcessor) {
 
   val kinesisClientLibConfiguration =
     new KinesisClientLibConfiguration(appName, streamName,
       new DefaultAWSCredentialsProviderChain,
-      s"$appName-worker");
+      s"$appName-worker")
 
   kinesisClientLibConfiguration
     .withRegionName(AWS.region.getName)

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,18 @@
 addCommandAlias("dist", ";riffRaffArtifact")
 
-import play.PlayImport.PlayKeys._
+import play.sbt.PlayImport.PlayKeys._
 
 name := "tag-manager"
 
 version := "1.0"
+
+scalacOptions ++= Seq(
+  "-target:jvm-1.8",
+  "-encoding", "UTF-8",
+  "-unchecked",
+  "-deprecation",
+  "-feature"
+)
 
 resolvers += "Guardian Bintray" at "https://dl.bintray.com/guardian/editorial-tools"
 
@@ -46,8 +54,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact
         "packages/cloudformation/tag-manager.json"
     ),
     doc in Compile <<= target.map(_ / "none"),
-    scalaVersion := "2.11.7",
-    scalaVersion in ThisBuild := "2.11.7",
+    scalaVersion := "2.11.8",
+    scalaVersion in ThisBuild := "2.11.8",
     libraryDependencies ++= dependencies
   )
   .settings(TagManager.settings: _*)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -49,3 +49,17 @@ play.modules.enabled += "modules.sponsorshiplifecycle.SponsorshipLifecycleModule
 # ~~~~~
 # You can disable evolutions if needed
 # evolutionplugin=disabled
+
+tag-operation-context {
+  fork-join-executor {
+    parallelism-factor = 25.0
+    parallelism-max = 200
+  }
+}
+
+capi-context {
+  fork-join-executor {
+    parallelism-factor = 25.0
+    parallelism-max = 200
+  }
+}


### PR DESCRIPTION
Very large mapping manager changes have been causing problems recently due to long running tasks having been run in the main play threadpool. This pool defaults to having one worker per core - which is perfect for a 100% reactive application, but tag manager goes off and does a lot of DB work (and in the case of mapping updates executes a blocking task processing large CAPI result sets, pushing the results onto a kinesis stream).

This PR moves most potentially blocking code into a Future with a new more appropriate execution context - the main target was anything run within a `Command`. 
 - A new `Contexts` object has been created as a home to a new `tagOperationContext`. I've also moved the CAPI context into the same place (using Play's akka stuff deals with cleanup itself)
 - The `Command` trait's `process` method now returns a `Future[Option[T]]` instead of an `Option[T]`
 - Every command has been modified to wrap in a future that executes using the `tagOperationContext`
 - All calls within actions to command processes have now been modified to use `async`
 - All existing imports of the default scala execution context have been removed and replaced with the default play execution context or the new `tagExecutionContext` as appropriate

As much as possible I've not modified the existing code structure, simply lifted the existing flow into one that uses Futures and maps over Futures. There were a couple of places where this was trickier (e.g. multiple process results being dealt with in one location).

I've also bumped the `scalaVersion` and tidied up some compiler warnings.

The tests still pass, but that seems to be because there are not any tests 👼 