### PR TITLE
Validate external names cannot have a leading space

### DIFF
--- a/public/util/validateTag.js
+++ b/public/util/validateTag.js
@@ -94,7 +94,7 @@ function validateTrackingTag(tag) {
 }
 
 function validateTagName(tag) {
-  let errors = [];
+  const errors = [];
   if (tag.externalName && tag.externalName.endsWith(' ')) {
     errors.push({
       fieldName: 'externalName',

--- a/public/util/validateTag.js
+++ b/public/util/validateTag.js
@@ -94,14 +94,22 @@ function validateTrackingTag(tag) {
 }
 
 function validateTagName(tag) {
+  let errors = [];
   if (tag.externalName && tag.externalName.endsWith(' ')) {
-    return [{
+    errors.push({
       fieldName: 'externalName',
       message: 'External name has a trailing space.'
-    }];
+    });
   }
 
-  return [];
+  if (tag.externalName && tag.externalName.startsWith(' ')) {
+    errors.push({
+      fieldName: 'externalName',
+      message: 'External name has a leading space.'
+    });
+  }
+
+  return errors;
 }
 
 export function validateTag(tag) {


### PR DESCRIPTION
Should prevent the issue which recently cropped up where people cannot find a tag in composer because it's external name has a leading space.

I presume this is caused by copy-pasting from other documents or something...