### PR TITLE
Unexpiring tags as part of sponsored content launch

### DIFF
--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -19,6 +19,7 @@ import repositories.{TagLookupCache, TagRepository}
 import services.{AWS, Config, ImageMetadataService}
 
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 
 object Support extends Controller with PanDomainAuthActions {
@@ -141,6 +142,25 @@ object Support extends Controller with PanDomainAuthActions {
       Future.successful(BadRequest("Expecting sectionId in JSON"))
     }
 
+  }
+
+  // TODO delete this!
+  def unexpireTag = APIAuthAction { req =>
+    implicit val username = Option(req.user.email)
+
+    req.body.asJson.map { json =>
+      val tagId = (json \ "tagId").as[Long]
+      import repositories.SponsorshipOperations
+      try {
+        SponsorshipOperations.unexpirePaidContentTag(tagId)
+
+        Ok
+      } catch {
+        case NonFatal(e) => BadRequest(e.toString)
+      }
+    }.getOrElse {
+        BadRequest("Expecting sectionId in JSON")
+    }
   }
 
   def fixDanglingParents = APIAuthAction.async { req =>

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -159,7 +159,7 @@ object Support extends Controller with PanDomainAuthActions {
         case NonFatal(e) => BadRequest(e.toString)
       }
     }.getOrElse {
-        BadRequest("Expecting sectionId in JSON")
+        BadRequest("Expecting tagId in JSON")
     }
   }
 

--- a/app/modules/sponsorshiplifecycle/SponsorshipLifecycleModule.scala
+++ b/app/modules/sponsorshiplifecycle/SponsorshipLifecycleModule.scala
@@ -66,6 +66,11 @@ class SponsorshipLauncher extends AbstractScheduledService {
           tagId <- tags
         ) {
           addSponsorshipToTag(s.id, tagId)
+          // If the sponsorship type is paid content then we also need to go and unexpire any associated tags
+          // If it is a sponsorship or foundation type sponsor then the tags won't have been expired in the first place.
+          if (activated.sponsorshipType == "paidContent") {
+            unexpirePaidContentTag(tagId)
+          }
         }
         for(
           sections <- s.sections;

--- a/conf/routes
+++ b/conf/routes
@@ -111,6 +111,9 @@ GET            /support/flexSlugMigrationData                          controlle
 POST           /support/unexpireSectionContent                         controllers.Support.unexpireSectionContent
 POST           /support/expireSectionContent                           controllers.Support.expireSectionContent
 
+# TODO DELETE THIS
+POST           /support/unexpireTag                                    controllers.Support.unexpireTag
+
 GET            /support/fixDanglingParents                             controllers.Support.fixDanglingParents
 
 # Migration endpoints


### PR DESCRIPTION
Also contains an endpoint for manually fixing up some broken ones in prod. I'll submit a new PR to get rid of this once I've got a comprehensive list of busted tags from Tim or Kelvin.