### PR TITLE
Tag search pagination

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -49,7 +49,8 @@ object App extends Controller with PanDomainAuthActions {
         tagTypes = allTags,
         permittedTagTypes = permittedTags.toList,
         permissions = permissions,
-        reauthUrl = "/reauth"
+        reauthUrl = "/reauth",
+        tagSearchPageSize = Config().tagSearchPageSize
       )
 
       Ok(views.html.Application.app("Tag Manager", jsLocation, Json.toJson(clientConfig).toString()))

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -11,6 +11,7 @@ import play.api.mvc.Controller
 import repositories._
 
 import play.api.libs.concurrent.Execution.Implicits._
+import services.Config
 import scala.concurrent.Future
 
 object TagManagementApi extends Controller with PanDomainAuthActions {
@@ -71,10 +72,11 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
       case(_) => tags.sortBy(_.comparableValue)
     }
 
-    val resultsCount = req.getQueryString("pageSize").getOrElse("25").toInt
     val page = req.getQueryString("page").getOrElse("1").toInt
-    val startIndex = (page - 1) * 25
-    val paginatedTagResults = orderedTags.drop(startIndex).take(resultsCount)
+    val pageSize = Config().tagSearchPageSize
+
+    val startIndex = (page - 1) * pageSize
+    val paginatedTagResults = orderedTags.drop(startIndex).take(pageSize)
     val tagCount = orderedTags.length
 
     Ok(Json.toJson(TagSearchResult(paginatedTagResults, tagCount)))

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -50,7 +50,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def searchTags = APIAuthAction { req =>
-
+    
     val criteria = TagSearchCriteria(
       q = req.getQueryString("q"),
       searchField = req.getQueryString("searchField"),
@@ -72,8 +72,12 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     }
 
     val resultsCount = req.getQueryString("pageSize").getOrElse("25").toInt
+    val page = req.getQueryString("page").getOrElse("1").toInt
+    val startIndex = (page - 1) * 25
+    val paginatedTagResults = orderedTags.drop(startIndex).take(resultsCount)
+    val tagCount = orderedTags.length
 
-    Ok(Json.toJson(orderedTags take resultsCount))
+    Ok(Json.toJson(TagSearchResult(paginatedTagResults, tagCount)))
   }
 
   def getSection(id: Long) = APIAuthAction {

--- a/app/model/ClientConfig.scala
+++ b/app/model/ClientConfig.scala
@@ -12,7 +12,9 @@ case class ClientConfig(username: String,
                         tagTypes: List[String],
                         permittedTagTypes: List[String],
                         permissions: Map[String, Boolean],
-                        reauthUrl: String)
+                        reauthUrl: String,
+                        tagSearchPageSize: Int
+                       )
 
 object ClientConfig {
   implicit val clientConfigFormat = Jsonx.formatCaseClass[ClientConfig]

--- a/app/model/TagSearchResult.scala
+++ b/app/model/TagSearchResult.scala
@@ -1,0 +1,9 @@
+package model
+
+import org.cvogt.play.json.Jsonx
+
+case class TagSearchResult(tags: List[Tag], count: Int)
+
+object TagSearchResult {
+  implicit val tagSearchResultFormat = Jsonx.formatCaseClassUseDefaults[TagSearchResult]
+}

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -112,6 +112,8 @@ sealed trait Config {
   def frontendBucketWriteRole: Option[String] = None
   def auditingKinesisWriteRole: Option[String] = None
   def enableAuditStreaming: Boolean = true
+
+  def tagSearchPageSize = 25
 }
 
 class DevConfig extends Config {

--- a/public/components/TagSearch.react.js
+++ b/public/components/TagSearch.react.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'react-router';
 import tagManagerApi from '../util/tagManagerApi';
 import TagsList from './TagList/TagList.react';
+import PageNavigator from './utils/PageNavigator.react';
+
 
 const searchFields = {
   'Internal Name': 'internalName',
@@ -10,6 +12,9 @@ const searchFields = {
   'Type': 'type',
   'Path': 'path'
 };
+
+const TAG_PAGE_SIZE = 25;
+const PAGE_NAV_SPAN = 5;
 
 export class TagSearch extends React.Component {
 
@@ -20,7 +25,9 @@ export class TagSearch extends React.Component {
           searchString: '',
           tags: [],
           sortResultsBy: 'internalName',
-          searchFieldName:'internalName'
+          searchFieldName:'internalName',
+          currentPage: 1,
+          tagCount: 0
         };
 
         this.sortBy = this.sortBy.bind(this);
@@ -35,6 +42,22 @@ export class TagSearch extends React.Component {
       this.searchTags();
     }
 
+    pageSelectCallback(page) {
+      const self = this;
+      this.setState({currentPage: page});
+
+      tagManagerApi.searchTags(this.state.searchString, {
+        searchFieldName: this.state.searchFieldName,
+        orderByField: this.state.sortBy,
+        page: page
+      })
+      .then(function(resp) {
+          self.setState({tags: resp.tags});
+      }).fail(function(err, msg) {
+          console.log('failed', err, msg);
+      });
+    }
+
     searchTags(searchString, searchFieldName, sortBy) {
 
       var self = this;
@@ -42,7 +65,8 @@ export class TagSearch extends React.Component {
       this.setState({
         searchString: searchString !== undefined ? searchString : this.state.searchString,
         sortBy: sortBy !== undefined ? sortBy : this.state.sortBy,
-        searchFieldName: searchFieldName !== undefined ? searchFieldName : this.state.searchFieldName
+        searchFieldName: searchFieldName !== undefined ? searchFieldName : this.state.searchFieldName,
+        currentPage: 1
       });
 
       tagManagerApi.searchTags(searchString, {
@@ -50,7 +74,10 @@ export class TagSearch extends React.Component {
         orderByField: sortBy
       })
       .then(function(resp) {
-          self.setState({tags: resp});
+        self.setState({
+          tags: resp.tags,
+          tagCount: resp.count
+        });
       }).fail(function(err, msg) {
           console.log('failed', err, msg);
       });
@@ -67,6 +94,23 @@ export class TagSearch extends React.Component {
 
     sortBy(fieldName) {
       this.searchTags(this.state.searchString, this.state.searchFieldName, fieldName);
+    }
+
+    renderPageNavigator() {
+
+      const count = this.state.tagCount;
+      if (count > 0 && count > TAG_PAGE_SIZE) {
+        return (
+          <PageNavigator
+            pageSelectCallback={this.pageSelectCallback.bind(this)}
+            currentPage={this.state.currentPage}
+            pageSpan={PAGE_NAV_SPAN}
+            lastPage={Math.ceil(count / TAG_PAGE_SIZE)}
+          />
+        );
+      }
+
+      return false;
     }
 
     render () {
@@ -86,9 +130,11 @@ export class TagSearch extends React.Component {
                     <Link className="tag-search__create" to="/tag/create">Create a new tag</Link>
 
                 </div>
+                {this.renderPageNavigator()}
                 <div className="tag-search__suggestions">
                     <TagsList tags={this.state.tags} sections={this.props.sections} sortBy={this.sortBy} />
                 </div>
+                {this.renderPageNavigator()}
             </div>
         );
     }

--- a/public/components/TagSearch.react.js
+++ b/public/components/TagSearch.react.js
@@ -13,7 +13,6 @@ const searchFields = {
   'Path': 'path'
 };
 
-const TAG_PAGE_SIZE = 25;
 const PAGE_NAV_SPAN = 5;
 
 export class TagSearch extends React.Component {
@@ -99,13 +98,13 @@ export class TagSearch extends React.Component {
     renderPageNavigator() {
 
       const count = this.state.tagCount;
-      if (count > 0 && count > TAG_PAGE_SIZE) {
+      if (count > 0 && count > this.props.config.tagSearchPageSize) {
         return (
           <PageNavigator
             pageSelectCallback={this.pageSelectCallback.bind(this)}
             currentPage={this.state.currentPage}
             pageSpan={PAGE_NAV_SPAN}
-            lastPage={Math.ceil(count / TAG_PAGE_SIZE)}
+            lastPage={Math.ceil(count / this.props.config.tagSearchPageSize)}
           />
         );
       }
@@ -147,7 +146,8 @@ import * as getSections from '../actions/SectionsActions/getSections';
 
 function mapStateToProps(state) {
   return {
-    sections: state.sections
+    sections: state.sections,
+    config: state.config
   };
 }
 

--- a/public/util/tagManagerApi.js
+++ b/public/util/tagManagerApi.js
@@ -248,6 +248,11 @@ export default {
       query.types = options.tagType;
     }
 
+
+    if (options.page) {
+      query.page = options.page;
+    }
+
     return PandaReqwest({
         url: '/api/tags',
         method: 'get',


### PR DESCRIPTION
There was some code that in the controller that was reading the page size from the query from the client which didn't seem right so I added it to the config instead. If we wanted to enforce consistency in the display of the pagination panels, `PAGE_NAV_SPAN`  could go there as well and it could be used by the batch tagging component.