### PR TITLE
remove auditing streams from tagmanager

### DIFF
--- a/app/repositories/SectionAuditRepository.scala
+++ b/app/repositories/SectionAuditRepository.scala
@@ -13,9 +13,9 @@ object SectionAuditRepository {
   def upsertSectionAudit(sectionAudit: SectionAudit) = {
 
     //Send onto Auditing Stream
-    if (Config().enableAuditStreaming) {
-      KinesisStreams.auditingEventsStream.publishUpdate("tag-manager-updates", sectionAudit.asAuditingThrift)
-    }
+    //if (Config().enableAuditStreaming) {
+    //  KinesisStreams.auditingEventsStream.publishUpdate("tag-manager-updates", sectionAudit.asAuditingThrift)
+    //}
 
     try {
       Dynamo.sectionAuditTable.putItem(sectionAudit.toItem)

--- a/app/repositories/TagAuditRepository.scala
+++ b/app/repositories/TagAuditRepository.scala
@@ -11,9 +11,9 @@ object TagAuditRepository {
   def upsertTagAudit(tagAudit: TagAudit) = {
 
     //Send onto Auditing Stream
-    if (Config().enableAuditStreaming) {
-      KinesisStreams.auditingEventsStream.publishUpdate("tag-manager-updates", tagAudit.asAuditingThrift)
-    }
+    //if (Config().enableAuditStreaming) {
+    //  KinesisStreams.auditingEventsStream.publishUpdate("tag-manager-updates", tagAudit.asAuditingThrift)
+    //}
 
     try {
       Dynamo.tagAuditTable.putItem(tagAudit.toItem)

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -105,5 +105,5 @@ object KinesisStreams {
   lazy val taggingOperationsStream = new KinesisStreamProducer(streamName = Config().taggingOperationsStreamName)
   lazy val taggingOperationsReIndexStream = new KinesisStreamProducer(streamName = Config().taggingOperationsReIndexStreamName)
   lazy val commercialExpiryStream = new KinesisStreamProducer(streamName = Config().commercialExpiryStreamName)
-  lazy val auditingEventsStream = new KinesisStreamProducer(streamName = Config().auditingStreamName, requireCompressionByte = true, isAuditing = true)
+  //lazy val auditingEventsStream = new KinesisStreamProducer(streamName = Config().auditingStreamName, requireCompressionByte = true, isAuditing = true)
 }

--- a/public/components/MappingManager.react.js
+++ b/public/components/MappingManager.react.js
@@ -24,7 +24,7 @@ export class MappingManager extends React.Component {
     fetchReferences(referenceType) {
       tagManagerApi.getTagsByReferenceType(referenceType.typeName || this.state.selectedReferenceType.typeName).then(tags => {
         this.setState({
-          tags: tags
+          tags: tags.tags
         });
       });
     }


### PR DESCRIPTION
No longer using audit streams so we can murderize them here