### PR TITLE
Fixes

### DIFF
--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -73,7 +73,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     }
 
     val page = req.getQueryString("page").getOrElse("1").toInt
-    val pageSize = Config().tagSearchPageSize
+    val pageSize = req.getQueryString("pageSize").map( _.toInt).getOrElse(Config().tagSearchPageSize)
 
     val startIndex = (page - 1) * pageSize
     val paginatedTagResults = orderedTags.drop(startIndex).take(pageSize)

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -253,6 +253,6 @@ class ProdConfig extends Config {
     "https://campaign-central.gutools.co.uk")
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
-  override def auditingKinesisWriteRole: Option[String] = Some("arn:aws:iam::163592447864:role/auditing-CrossAccountKinesisAccess-CC5UXEHZNP5M")
+  override def auditingKinesisWriteRole: Option[String] = Some("arn:aws:iam::163592447864:role/auditing-kinesis-cross-ac-CrossAccountKinesisAcces-PI8TASUEN2FE")
 
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -207,7 +207,7 @@ class CodeConfig extends Config {
     "https://campaign-central.local.dev-gutools.co.uk")
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
-  override def auditingKinesisWriteRole: Option[String] = Some("arn:aws:iam::163592447864:role/auditing-CrossAccountKinesisAccess-CC5UXEHZNP5M")
+  override def auditingKinesisWriteRole: Option[String] = Some("arn:aws:iam::163592447864:role/auditing-kinesis-cross-ac-CrossAccountKinesisAcces-PI8TASUEN2FE")
 }
 
 class ProdConfig extends Config {

--- a/public/components/MappingManager.react.js
+++ b/public/components/MappingManager.react.js
@@ -24,7 +24,7 @@ export class MappingManager extends React.Component {
     fetchReferences(referenceType) {
       tagManagerApi.getTagsByReferenceType(referenceType.typeName || this.state.selectedReferenceType.typeName).then(tags => {
         this.setState({
-          tags: tags
+          tags: tags.tags
         });
       });
     }


### PR DESCRIPTION
Fixes the two problems currently fixed in the temp branch here (https://github.com/guardian/tagmanager/pull/287)

- tag mappings are getting tags from the new api response correctly
- auditing cross account role updated to an existing one so that auditing events are going through again
