### PR TITLE
Update the client side mapping sorting so that it sorts properly

### DIFF
--- a/public/components/MappingTable/MappingTable.react.js
+++ b/public/components/MappingTable/MappingTable.react.js
@@ -73,7 +73,7 @@ export default class MappingTable extends React.Component {
             </tr>
           </thead>
           <tbody>
-            {mappings.sort((a, b) => a.tagInternalName > b.tagInternalName ? 1 : -1).map((mapping) => {
+            {mappings.sort((a, b) => a.tag.internalName > b.tag.internalName ? 1 : -1).map((mapping) => {
               return (
                 <MappingTableRow
                   tag={mapping.tag}


### PR DESCRIPTION
There is no `taginternalName` property on the props object passed from the above component but there is, however, a `tag.internalName` property, which probably means something changed or someone forgot a `.` somewhere along the way.

## Before
![image](https://user-images.githubusercontent.com/638051/30032034-a3933100-918b-11e7-9d91-819b0e9c2db2.png)


## After
![image](https://user-images.githubusercontent.com/638051/30032005-85132d70-918b-11e7-8456-fc2f9a8a3b07.png)
