### PR TITLE
Single CPU hack

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -55,7 +55,7 @@ akka {
     default-dispatcher {
       fork-join-executor {
         # Hack to avoid deadlocks on servers with on one CPU
-        parallelism-factor = 2.0
+        parallelism-factor = 10.0
       }
     }
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,6 +50,17 @@ play.modules.enabled += "modules.sponsorshiplifecycle.SponsorshipLifecycleModule
 # You can disable evolutions if needed
 # evolutionplugin=disabled
 
+akka {
+  actor {
+    default-dispatcher {
+      fork-join-executor {
+        # Hack to avoid deadlocks on servers with on one CPU
+        parallelism-factor = 2.0
+      }
+    }
+  }
+}
+
 tag-operation-context {
   fork-join-executor {
     parallelism-factor = 25.0
@@ -63,3 +74,4 @@ capi-context {
     parallelism-max = 200
   }
 }
+


### PR DESCRIPTION
Tag manager suffers deadlocks on single CPU machines. This should fix that.

The real fix is to do a proper analysis of all blocking IO and ensure it's all on the correct execution context (or shifted to an async approach).