### PR TITLE
Allow podcasts to have an optional podcast type

### DIFF
--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -13,7 +13,8 @@ case class PodcastMetadata( linkUrl: String,
                             clean: Boolean = false,
                             explicit: Boolean = false,
                             image: Option[Image] = None,
-                            categories: Option[PodcastCategory] = None
+                            categories: Option[PodcastCategory] = None,
+                            podcastType: Option[String] = None
 ) {
 
   def asThrift = ThriftPodcastMetadata(
@@ -25,7 +26,8 @@ case class PodcastMetadata( linkUrl: String,
     clean =             clean,
     explicit =          explicit,
     image =             image.map(_.asThrift),
-    categories =        categories.map((cat) => List(cat.asThrift))
+    categories =        categories.map((cat) => List(cat.asThrift)),
+    podcastType =       podcastType
   )
 
   def asExportedXml = {
@@ -38,6 +40,7 @@ case class PodcastMetadata( linkUrl: String,
     <explicit>{this.explicit}</explicit>
     <image>{this.image.map(x => x.asExportedXml).getOrElse("")}</image>
     <categories>{this.categories.map(_.asExportedXml).getOrElse("")}</categories>
+    <type>{this.podcastType.getOrElse("")}</type>
   }
 }
 
@@ -55,7 +58,8 @@ object PodcastMetadata {
       clean =             thriftPodcastMetadata.clean,
       explicit =          thriftPodcastMetadata.explicit,
       image =             thriftPodcastMetadata.image.map(Image(_)),
-      categories =        thriftPodcastMetadata.categories.map(x => PodcastCategory(x.head))
+      categories =        thriftPodcastMetadata.categories.map(x => PodcastCategory(x.head)),
+      podcastType =       thriftPodcastMetadata.podcastType
     )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val dependencies = Seq(
   "com.twitter" %% "scrooge-core" % "4.12.0",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client" % "7.7",
-  "com.gu" %% "tags-thrift-schema" % "1.1.0",
+  "com.gu" %% "tags-thrift-schema" % "1.1.1",
   "com.gu" %% "auditing-thrift-model" % "0.2",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -68,6 +68,23 @@ export default class PodcastMetadata extends React.Component {
     }));
   }
 
+  updatePodcastType(e) {
+
+      const newType = e.target.value;
+
+      if (!newType) {
+          this.props.updateTag(R.merge(this.props.tag, {
+              podcastMetadata: R.omit(['podcastType'], this.props.tag.podcastMetadata)
+          }));
+
+          return;
+      }
+
+      this.props.updateTag(R.merge(this.props.tag, {
+          podcastMetadata: R.merge(this.props.tag.podcastMetadata, {podcastType: e.target.value})
+          }));
+  }
+
   renderMetadataForm() {
     if (!this.tagHasPodcast()) {
       return false;
@@ -78,6 +95,14 @@ export default class PodcastMetadata extends React.Component {
         <PodcastCategorySelect
           tag={this.props.tag}
           updateTag={this.props.updateTag}/>
+        <div className="tag-edit__field">
+          <label className="tag-edit__label">Podcast Type</label>
+          <select value={this.props.tag.podcastMetadata.podcastType || ""} onChange={this.updatePodcastType.bind(this)} >
+            <option value=""></option>
+            <option value="episodic" key="episodic">Episodic</option>
+            <option value="serial" key="serial">Serial</option>
+          </select>
+        </div>
         <div className="tag-edit__field">
           <label className="tag-edit__label">Link URL</label>
           <input type="text"


### PR DESCRIPTION
iOS 11 gives podcast level information about type. This impacts how episodes are displayed to users, but is an optional field as `episodic` will be the default. 