### PR TITLE
add newspaper book and newspaper book section tag types

### DIFF
--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -82,6 +82,8 @@ case class Tag(
 
     val oldType = this.`type` match {
       case "Topic" => "Keyword"
+      case "NewspaperBook" => "Newspaper Book"
+      case "NewspaperBookSection" => "Newspaper Book Section"
       case t => t
     }
 


### PR DESCRIPTION
I looks like octopus is rejecting all non-R2 newspaper book and newspaper book section tags because the tag types are busted.