### PR TITLE
Remove external auditing system

### DIFF
--- a/app/model/AppAudit.scala
+++ b/app/model/AppAudit.scala
@@ -7,7 +7,10 @@ import play.api.libs.json.{Json, JsPath, Format}
 import play.api.Logger
 import scala.util.control.NonFatal
 
-case class AppAudit(action: String, date: DateTime, user: String, description: String) {
+case class AppAudit(action: String, date: DateTime, user: String, description: String) extends Audit {
+  override def operation: String = action
+  override def auditType = "application"
+
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }
 

--- a/app/model/AppAudit.scala
+++ b/app/model/AppAudit.scala
@@ -10,6 +10,8 @@ import scala.util.control.NonFatal
 case class AppAudit(action: String, date: DateTime, user: String, description: String) extends Audit {
   override def operation: String = action
   override def auditType = "application"
+  override def resourceId = None
+  override def message = None
 
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }

--- a/app/model/Audit.scala
+++ b/app/model/Audit.scala
@@ -1,0 +1,12 @@
+package model
+
+import play.api.Logger
+
+trait Audit {
+ def user: String
+ def operation: String
+ def description: String
+ def auditType: String
+
+ def logAudit = Logger.info(s"User '$user' performed a '$operation' $auditType operation: '$description'")
+}

--- a/app/model/Audit.scala
+++ b/app/model/Audit.scala
@@ -1,12 +1,35 @@
 package model
 
+import net.logstash.logback.marker.Markers
+import org.joda.time.DateTime
 import play.api.Logger
 
-trait Audit {
- def user: String
- def operation: String
- def description: String
- def auditType: String
+import scala.collection.JavaConverters._
 
- def logAudit = Logger.info(s"User '$user' performed a '$operation' $auditType operation: '$description'")
+trait Audit {
+  def user: String
+  def operation: String
+  def description: String
+  def date: DateTime
+
+  def auditType: String
+
+  def resourceId: Option[String]
+  def message: Option[String]
+
+  def logAudit = Logger.logger.info(createMarkers(), "Tag Manager Audit")
+
+  private def createMarkers() =
+    Markers.appendEntries((
+        Map(
+          "type" -> auditType,
+          "operation" -> operation,
+          "userEmail" -> user,
+          "date" -> date.toString,
+          "shortMessage" -> description
+        )
+          ++ message.map("message" -> _)
+          ++ resourceId.map("resourceId" -> _)
+      ).asJava
+    )
 }

--- a/app/model/PillarAudit.scala
+++ b/app/model/PillarAudit.scala
@@ -17,7 +17,9 @@ case class PillarAudit(
                         user: String,
                         description: String,
                         pillar: Pillar
-                       ) {
+                       ) extends Audit {
+  override def auditType = "pillar"
+
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }
 

--- a/app/model/PillarAudit.scala
+++ b/app/model/PillarAudit.scala
@@ -1,7 +1,6 @@
 package model
 
 import com.amazonaws.services.dynamodbv2.document.Item
-import com.gu.auditing.model.v1.{App, Notification}
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.functional.syntax._
@@ -19,6 +18,8 @@ case class PillarAudit(
                         pillar: Pillar
                        ) extends Audit {
   override def auditType = "pillar"
+  override def resourceId = Some(pillarId.toString)
+  override def message = None
 
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }

--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -21,16 +21,6 @@ case class SectionAudit(
                      sectionSummary: SectionSummary
                    ) {
   def toItem = Item.fromJSON(Json.toJson(this).toString())
-
-  def asAuditingThrift = Notification(
-    app = App.TagManager,
-    operation = operation,
-    userEmail = user,
-    date = date.toString,
-    resourceId = Some(sectionId.toString),
-    message = Some(s"${description}. Section: ${sectionSummary.toString}"),
-    shortMessage = Some(description)
-  )
 }
 
 object SectionAudit {
@@ -68,7 +58,6 @@ object SectionAudit {
   def removedEdition(section: Section, editionName: String)(implicit user: Option[String] = None): SectionAudit = {
     SectionAudit(section.id, "removed edition", new DateTime(), user.getOrElse("default user"), s"removed ${editionName} edition from section '${section.name}", SectionSummary(section))
   }
-
 }
 
 case class SectionSummary(

--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -19,7 +19,9 @@ case class SectionAudit(
                      user: String,
                      description: String,
                      sectionSummary: SectionSummary
-                   ) {
+                   ) extends Audit {
+  override def auditType: String = "section"
+
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }
 

--- a/app/model/SectionAudit.scala
+++ b/app/model/SectionAudit.scala
@@ -1,13 +1,10 @@
 package model
 
 import com.amazonaws.services.dynamodbv2.document.Item
-import com.gu.auditing.model.v1.{App, Notification}
-import com.gu.pandomainauth.model.User
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, JsPath, Json}
-import repositories.SectionRepository
 
 import scala.util.control.NonFatal
 
@@ -20,7 +17,9 @@ case class SectionAudit(
                      description: String,
                      sectionSummary: SectionSummary
                    ) extends Audit {
-  override def auditType: String = "section"
+  override def auditType = "section"
+  override def resourceId = Some(sectionId.toString)
+  override def message = None
 
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }

--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -22,16 +22,6 @@ case class TagAudit(
   secondaryTagSummary: Option[TagSummary]
 ) {
   def toItem = Item.fromJSON(Json.toJson(this).toString())
-
-  def asAuditingThrift = Notification(
-    app = App.TagManager,
-    operation = operation,
-    userEmail = user,
-    date = date.toString,
-    resourceId = Some(tagId.toString),
-    message = Some(s"${description}. Primary Tag: ${tagSummary.toString}. Secondary Tag: ${secondaryTagSummary.toString}"),
-    shortMessage = Some(description)
-  )
 }
 
 object TagAudit {

--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -20,7 +20,9 @@ case class TagAudit(
   description: String,
   tagSummary: TagSummary,
   secondaryTagSummary: Option[TagSummary]
-) {
+) extends Audit {
+  override def auditType: String = "tag"
+
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }
 

--- a/app/model/TagAudit.scala
+++ b/app/model/TagAudit.scala
@@ -1,7 +1,6 @@
 package model
 
 import com.amazonaws.services.dynamodbv2.document.Item
-import com.gu.auditing.model.v1.{App, Notification}
 import com.gu.pandomainauth.model.User
 import org.joda.time.DateTime
 import play.api.Logger
@@ -21,7 +20,9 @@ case class TagAudit(
   tagSummary: TagSummary,
   secondaryTagSummary: Option[TagSummary]
 ) extends Audit {
-  override def auditType: String = "tag"
+  override def auditType = "tag"
+  override def resourceId = Some(tagId.toString)
+  override def message = Some(s"$description - Tag 1: ${tagSummary.toString} Tag 2: ${secondaryTagSummary.toString}")
 
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 }

--- a/app/repositories/AppAuditRepository.scala
+++ b/app/repositories/AppAuditRepository.scala
@@ -9,6 +9,7 @@ import scala.collection.JavaConversions._
 
 object AppAuditRepository {
   def upsertAppAudit(appAudit: AppAudit): Unit = {
+    appAudit.logAudit
     Dynamo.appAuditTable.putItem(appAudit.toItem)
   }
 

--- a/app/repositories/AppAuditRepository.scala
+++ b/app/repositories/AppAuditRepository.scala
@@ -8,13 +8,8 @@ import services.Dynamo
 import scala.collection.JavaConversions._
 
 object AppAuditRepository {
-  def upsertAppAudit(appAudit: AppAudit) = {
-    try {
-      Dynamo.appAuditTable.putItem(appAudit.toItem)
-      Some(appAudit)
-    } catch {
-      case e: Error => None
-    }
+  def upsertAppAudit(appAudit: AppAudit): Unit = {
+    Dynamo.appAuditTable.putItem(appAudit.toItem)
   }
 
   def getRecentAuditOfOperation(operation: String, timePeriod: ReadableDuration = Duration.standardDays(7)): List[AppAudit] = {

--- a/app/repositories/PillarAuditRepository.scala
+++ b/app/repositories/PillarAuditRepository.scala
@@ -11,15 +11,8 @@ import scala.collection.JavaConversions._
 
 object PillarAuditRepository {
 
-  def upsertPillarAudit(pillarAudit: PillarAudit) = {
-    try {
-      Dynamo.pillarAuditTable.putItem(pillarAudit.toItem)
-      Some(pillarAudit)
-    } catch {
-      case e: Error =>
-        Logger.warn(s"Error updating pillar ${pillarAudit.pillarId}: ${e.getMessage}", e)
-        None
-    }
+  def upsertPillarAudit(pillarAudit: PillarAudit): Unit = {
+    Dynamo.pillarAuditTable.putItem(pillarAudit.toItem)
   }
 
   def getAuditTrailForPillar(pillarId: Long): List[PillarAudit] = {

--- a/app/repositories/PillarAuditRepository.scala
+++ b/app/repositories/PillarAuditRepository.scala
@@ -3,7 +3,6 @@ package repositories
 import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition
 import model.PillarAudit
 import org.joda.time.{DateTime, Duration, ReadableDuration}
-import play.api.Logger
 import services.Dynamo
 
 import scala.collection.JavaConversions._
@@ -12,6 +11,7 @@ import scala.collection.JavaConversions._
 object PillarAuditRepository {
 
   def upsertPillarAudit(pillarAudit: PillarAudit): Unit = {
+    pillarAudit.logAudit
     Dynamo.pillarAuditTable.putItem(pillarAudit.toItem)
   }
 

--- a/app/repositories/SectionAuditRepository.scala
+++ b/app/repositories/SectionAuditRepository.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConversions._
 object SectionAuditRepository {
 
   def upsertSectionAudit(sectionAudit: SectionAudit): Unit = {
-    Logger.info(s"User '${sectionAudit.user}' performed a '${sectionAudit.operation}' section operation: '${sectionAudit.description}'")
+    sectionAudit.logAudit
     Dynamo.sectionAuditTable.putItem(sectionAudit.toItem)
   }
 

--- a/app/repositories/SectionAuditRepository.scala
+++ b/app/repositories/SectionAuditRepository.scala
@@ -3,26 +3,17 @@ package repositories
 import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition
 import model.SectionAudit
 import org.joda.time.{DateTime, Duration, ReadableDuration}
-import services.{Config, Dynamo, KinesisStreams}
+import play.api.Logger
+import services.Dynamo
 
 import scala.collection.JavaConversions._
 
 
 object SectionAuditRepository {
 
-  def upsertSectionAudit(sectionAudit: SectionAudit) = {
-
-    //Send onto Auditing Stream
-    if (Config().enableAuditStreaming) {
-      KinesisStreams.auditingEventsStream.publishUpdate("tag-manager-updates", sectionAudit.asAuditingThrift)
-    }
-
-    try {
-      Dynamo.sectionAuditTable.putItem(sectionAudit.toItem)
-      Some(sectionAudit)
-    } catch {
-      case e: Error => None
-    }
+  def upsertSectionAudit(sectionAudit: SectionAudit): Unit = {
+    Logger.info(s"User '${sectionAudit.user}' performed a '${sectionAudit.operation}' section operation: '${sectionAudit.description}'")
+    Dynamo.sectionAuditTable.putItem(sectionAudit.toItem)
   }
 
   def getAuditTrailForSection(sectionId: Long): List[SectionAudit] = {

--- a/app/repositories/TagAuditRepository.scala
+++ b/app/repositories/TagAuditRepository.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConversions._
 
 object TagAuditRepository {
   def upsertTagAudit(tagAudit: TagAudit): Unit = {
-    Logger.info(s"User '${tagAudit.user}' performed a '${tagAudit.operation}' tag operation: '${tagAudit.description}'")
+    tagAudit.logAudit
     Dynamo.tagAuditTable.putItem(tagAudit.toItem)
   }
 

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -115,9 +115,6 @@ sealed trait Config {
   def corsableDomains: Seq[String]
 
   def frontendBucketWriteRole: Option[String] = None
-  def auditingKinesisWriteRole: Option[String] = None
-  def enableAuditStreaming: Boolean = true
-
   def tagSearchPageSize = 25
 }
 
@@ -165,9 +162,6 @@ class DevConfig extends Config {
     "https://targeting.local.dev-gutools.co.uk",
     "https://campaign-central.local.dev-gutools.co.uk"
   )
-
-  //Disables submission of audits to the audit Kinesis server, requires frontCms credentials locally to enable
-  override def enableAuditStreaming: Boolean = false
 }
 
 class CodeConfig extends Config {
@@ -219,7 +213,6 @@ class CodeConfig extends Config {
     "https://campaign-central.local.dev-gutools.co.uk")
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
-  override def auditingKinesisWriteRole: Option[String] = Some("arn:aws:iam::163592447864:role/auditing-kinesis-cross-ac-CrossAccountKinesisAcces-PI8TASUEN2FE")
 }
 
 class ProdConfig extends Config {
@@ -267,6 +260,4 @@ class ProdConfig extends Config {
     "https://campaign-central.gutools.co.uk")
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
-  override def auditingKinesisWriteRole: Option[String] = Some("arn:aws:iam::163592447864:role/auditing-kinesis-cross-ac-CrossAccountKinesisAcces-PI8TASUEN2FE")
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,6 @@ lazy val dependencies = Seq(
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client" % "7.7",
   "com.gu" %% "tags-thrift-schema" % "2.1.0",
-  "com.gu" %% "auditing-thrift-model" % "0.2",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -34,9 +34,6 @@ Parameters:
   CertificateArn:
     Description: ARN of the SSL certificate for this service
     Type: String
-  AuditingRoleToAssume:
-    Description: Auditing to assume for cross account access to auditing account
-    Type: String
   VulnerabilityScanningSecurityGroup:
     Description: Security group that grants access to the account's Vulnerability
       Scanner
@@ -187,18 +184,6 @@ Resources:
           Action:
           - sqs:*
           Resource: '*'
-      Roles:
-      - !Ref 'TagManagerRole'
-  TagManagerCrossAccountPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: TagManagerCrossAccountPolicy
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Action: sts:AssumeRole
-          Resource: !Ref 'AuditingRoleToAssume'
       Roles:
       - !Ref 'TagManagerRole'
   TagManagerInstanceProfile:


### PR DESCRIPTION
The external auditing system is almost entirely unused and is costing us in elasticsearch instances, kinesis streams, AWS complexity, etc.

Time to remove it.
  
Also makes auditing a side effect and won't hide auditing failures.

Hiding auditing failures is bad because octopus needs audits to know events have happened.