### PR TITLE
Capi preview IAM

### DIFF
--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -27,9 +27,9 @@ sealed trait Config {
 
   def capiUrl: String = getRequiredStringProperty("capi.url")
   def capiKey: String = getRequiredStringProperty("capi.key")
-  def capiPreviewUrl: String = getRequiredStringProperty("capi.preview.url")
-  def capiPreviewUser: String = getRequiredStringProperty("capi.preview.username")
-  def capiPreviewPassword: String = getRequiredStringProperty("capi.preview.password")
+  def capiPreviewIAMUrl: String = getRequiredStringProperty("capi.preview.iamUrl")
+  def capiPreviewRole: String = getRequiredStringProperty("capi.preview.role")
+
   def hmacSecret: String = getRequiredStringProperty("hmac.secret")
 
   def pathManagerUrl: String = getRequiredStringProperty("pathmanager.url")
@@ -44,6 +44,7 @@ sealed trait Config {
     lazy val stack = readTag("Stack") getOrElse "flexible"
     lazy val stage = readTag("Stage") getOrElse "DEV"
     lazy val app = readTag("App") getOrElse "tag-manager"
+    lazy val region = remoteConfiguration.getOrDefault("aws.region", "eu-west-1")
   }
 
   private def loadConfiguration = {

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -2,10 +2,8 @@ package services
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
-import com.amazonaws.services.kinesis.clientlibrary.types.{InitializationInput, ProcessRecordsInput, ShutdownInput, ShutdownReason}
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, ShutdownReason, Worker}
+import com.amazonaws.services.kinesis.clientlibrary.types.{InitializationInput, ProcessRecordsInput, ShutdownInput}
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import com.amazonaws.services.kinesis.model.Record
 import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@ scalacOptions ++= Seq(
 resolvers += "Guardian Bintray" at "https://dl.bintray.com/guardian/editorial-tools"
 
 lazy val dependencies = Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.10.33",
-  "com.amazonaws" % "amazon-kinesis-client" % "1.6.1",
+  "com.amazonaws" % "aws-java-sdk" % "1.11.259",
+  "com.amazonaws" % "amazon-kinesis-client" % "1.8.9",
   "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",
   "com.gu" %% "editorial-permissions-client" % "0.2",
   ws, // for panda
@@ -33,7 +33,8 @@ lazy val dependencies = Seq(
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",
-  "com.gu"  %% "panda-hmac" % "1.2.0"
+  "com.gu"  %% "panda-hmac" % "1.2.0",
+  "com.gu" %% "content-api-client-aws" % "0.2"
 )
 
 import com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -38,6 +38,9 @@ Parameters:
     Description: Security group that grants access to the account's Vulnerability
       Scanner
     Type: AWS::EC2::SecurityGroup::Id
+  CapiPreviewRole:
+    Type: String
+    Description: ARN of the CAPI preview role
 Mappings:
   Config:
     CODE:
@@ -297,3 +300,16 @@ Resources:
           #!/bin/bash -ev
           aws s3 cp s3://composer-dist/flexible/${Stage}/tag-manager/tag-manager.deb /tmp
           dpkg -i /tmp/tag-manager.deb
+
+  AssumeCapiPreviewRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: assume-capi-preview-role
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action: sts:AssumeRole
+          Resource:
+            Ref: CapiPreviewRole
+      Roles:
+      - Ref: TagManagerRole

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,8 @@ To read the database and interact with the AWS infrastructure you will need AWS 
 Composer account available to the default credentials provider chain. The easiest way to configure this is to obtain the
 credentials via [janus](https://janus.gutools.co.uk/) and export the credentials to your shell using the handy script provided by janus.
 
+Tag Manager also makes requests to CAPI preview. This means you will also need CAPI credentials from janus (with 'API Gateway invocation' permission).
+
 If you are working on the commercial tag functionality and need to be able to upload logos you will also need AWS credentials for 
 the frontend aws account available as an AWS profile named "frontend". This can also be obtained via janus.
 


### PR DESCRIPTION
We are in the process of changing how we authorise access to CAPI preview. In the past we have used basic auth (in Concierge), with the usernames/passwords maintained by the CAPI team.
Instead we will use api-gateway to move authorisation out of concierge and avoid having to maintain usernames/passwords.

The api-gateway uses IAM authorisation. This means the app assumes a cross-account role, and signs each (preview) request using this role.

Note - this means you will now need capi credentials to run the app locally

tested in CODE