### PR TITLE
Fix tag deletions

### DIFF
--- a/app/repositories/ContentAPI.scala
+++ b/app/repositories/ContentAPI.scala
@@ -95,10 +95,12 @@ object ContentAPI {
 
   @tailrec
   def getContentIdsForTag(apiTagId: String, page: Int = 1, ids: List[String] = Nil): List[String] = {
+    Logger.info(s"getContentIdsForTag: $apiTagId")
     Logger.debug(s"Loading page $page of contentent ids for tag $apiTagId")
     val response = previewApiClient.getResponse(SearchQuery().tag(apiTagId).pageSize(100).page(page))
 
     val resultPage = Await.result(response, 5 seconds)
+    Logger.info(s"getContentIdsForTag result: $resultPage")
 
     val allIds = ids ::: resultPage.results.map(_.id).toList
 
@@ -136,7 +138,7 @@ class DraftContentApiClass(override val apiKey: String, apiUrl: String) extends 
   override val targetUrl = apiUrl
 
   override protected def get(url: String, headers: Map[String, String])(implicit context: ExecutionContext): Future[HttpResponse] = {
-    println(s"DraftContentApiClass: url: $url")
+    Logger.info(s"DraftContentApiClass url: $url")
     val headersWithAuth = ContentAPI.signer.addIAMHeaders(headers, URI.create(url))
     super.get(url, headersWithAuth)
   }

--- a/app/repositories/ContentAPI.scala
+++ b/app/repositories/ContentAPI.scala
@@ -35,30 +35,32 @@ object ContentAPI {
   )
 
   def countOccurencesOfTagInContents(contentIds: List[String], apiTagId: String): Int = {
-    val builder = StringBuilder.newBuilder
-    var pageSize = 0
+    if (contentIds.nonEmpty) {
+      val builder = StringBuilder.newBuilder
+      var pageSize = 0
 
-    var total = 0
+      var total = 0
 
-    for (id <- contentIds) {
-      // ~2048 chars is the max sensible amount for a URL.
-      // Rather than faff about subtracting our URL + query string junk from 2048 we'll just stay well below the max (1500)
-      // Also, CAPI maxes out at 50 items per query
-      if (pageSize >= 50 || builder.length + id.length > 1500) {
-        total += countTags(builder.toString, pageSize, apiTagId)
-        builder.setLength(0)
-        pageSize = 0
+      for (id <- contentIds) {
+        // ~2048 chars is the max sensible amount for a URL.
+        // Rather than faff about subtracting our URL + query string junk from 2048 we'll just stay well below the max (1500)
+        // Also, CAPI maxes out at 50 items per query
+        if (pageSize >= 50 || builder.length + id.length > 1500) {
+          total += countTags(builder.toString, pageSize, apiTagId)
+          builder.setLength(0)
+          pageSize = 0
+        }
+
+        if (builder.nonEmpty) {
+          builder.append(',')
+        }
+        builder.append(id)
+        pageSize += 1
       }
+      total += countTags(builder.toString, pageSize, apiTagId)
 
-      if (builder.nonEmpty) {
-        builder.append(',')
-      }
-      builder.append(id)
-      pageSize += 1
-    }
-    total += countTags(builder.toString, pageSize, apiTagId)
-
-    total
+      total
+    } else 0
   }
 
   private def countTags(ids: String, pageSize: Int, apiTagId: String): Int = {
@@ -95,12 +97,10 @@ object ContentAPI {
 
   @tailrec
   def getContentIdsForTag(apiTagId: String, page: Int = 1, ids: List[String] = Nil): List[String] = {
-    Logger.info(s"getContentIdsForTag: $apiTagId")
     Logger.debug(s"Loading page $page of contentent ids for tag $apiTagId")
     val response = previewApiClient.getResponse(SearchQuery().tag(apiTagId).pageSize(100).page(page))
 
     val resultPage = Await.result(response, 5 seconds)
-    Logger.info(s"getContentIdsForTag result: $resultPage")
 
     val allIds = ids ::: resultPage.results.map(_.id).toList
 
@@ -138,7 +138,6 @@ class DraftContentApiClass(override val apiKey: String, apiUrl: String) extends 
   override val targetUrl = apiUrl
 
   override protected def get(url: String, headers: Map[String, String])(implicit context: ExecutionContext): Future[HttpResponse] = {
-    Logger.info(s"DraftContentApiClass url: $url")
     val headersWithAuth = ContentAPI.signer.addIAMHeaders(headers, URI.create(url))
     super.get(url, headersWithAuth)
   }

--- a/app/repositories/ContentAPI.scala
+++ b/app/repositories/ContentAPI.scala
@@ -1,12 +1,11 @@
 package repositories
 
-import java.util.concurrent.Executors
+import java.net.URI
 
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.gu.contentapi.client.{ContentApiClientLogic, GuardianContentApiError, IAMSigner}
 import com.gu.contentapi.client.model._
-import dispatch.FunctionHandler
 import play.api.Logger
 import services.{Config, Contexts}
 
@@ -14,6 +13,7 @@ import scala.annotation.tailrec
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
 
 
 object ContentAPI {
@@ -100,7 +100,7 @@ object ContentAPI {
 
     val resultPage = Await.result(response, 5 seconds)
 
-    val allIds = ids ::: resultPage.results.map(_.id)
+    val allIds = ids ::: resultPage.results.map(_.id).toList
 
     if (page >= resultPage.pages) {
       allIds
@@ -116,7 +116,7 @@ object ContentAPI {
 
     val resultPage = Await.result(response, 5 seconds)
 
-    val allIds = ids ::: resultPage.results.map(_.id)
+    val allIds = ids ::: resultPage.results.map(_.id).toList
 
     if (page >= resultPage.pages) {
       allIds
@@ -135,16 +135,9 @@ object ContentAPI {
 class DraftContentApiClass(override val apiKey: String, apiUrl: String) extends ContentApiClientLogic() {
   override val targetUrl = apiUrl
 
-  override protected def get(url: String, headers: Map[String, String])
-                            (implicit context: ExecutionContext): Future[HttpResponse] = {
-
-    val headersWithAuth = ContentAPI.signer.addIAMHeaders(headers, url)
-
-    val req = headersWithAuth.foldLeft(dispatch.url(url)) {
-      case (r, (name, value)) => r.setHeader(name, value)
-    }
-
-    def handler = new FunctionHandler(r => HttpResponse(r.getResponseBody("utf-8"), r.getStatusCode, r.getStatusText))
-    http(req.toRequest, handler)
+  override protected def get(url: String, headers: Map[String, String])(implicit context: ExecutionContext): Future[HttpResponse] = {
+    println(s"DraftContentApiClass: url: $url")
+    val headersWithAuth = ContentAPI.signer.addIAMHeaders(headers, URI.create(url))
+    super.get(url, headersWithAuth)
   }
 }

--- a/app/repositories/PathManager.scala
+++ b/app/repositories/PathManager.scala
@@ -1,6 +1,6 @@
 package repositories
 
-import com.squareup.okhttp.{FormEncodingBuilder, OkHttpClient, Request}
+import okhttp3.{FormBody, OkHttpClient, Request}
 import play.api.Logger
 import play.api.libs.json.Json
 import services.Config
@@ -12,13 +12,13 @@ case class PathRemoveFailed(m: String) extends RuntimeException(m)
 
 object PathManager {
 
-  val httpClient = new OkHttpClient()
+  val httpClient = new OkHttpClient.Builder().connectTimeout(5, TimeUnit.SECONDS).build
 
 
   def registerPathAndGetPageId(path: String): Long = {
     Logger.info(s"registering path $path")
 
-    val formBody = new FormEncodingBuilder()
+    val formBody = new FormBody.Builder()
       .add("path", path)
       .add("system", "tagmanager")
       .build()
@@ -27,7 +27,6 @@ object PathManager {
       .post(formBody)
       .build
 
-    httpClient.setConnectTimeout(5, TimeUnit.SECONDS)
     val resp = httpClient.newCall(req).execute
 
     resp.code match {
@@ -49,7 +48,6 @@ object PathManager {
   def removePathForId(id: Long) = {
     Logger.info(s"removing path entries for $id")
 
-    httpClient.setConnectTimeout(5, TimeUnit.SECONDS)
     val req = new Request.Builder().url(s"${Config().pathManagerUrl}paths/$id").delete().build
     val resp = httpClient.newCall(req).execute
 
@@ -63,8 +61,6 @@ object PathManager {
   }
 
   def isPathInUse(path: String): Boolean = {
-
-    httpClient.setConnectTimeout(2, TimeUnit.SECONDS)
     val req = new Request.Builder().url(s"${Config().pathManagerUrl}paths?path=$path").build
     val resp = httpClient.newCall(req).execute
 

--- a/app/repositories/PathManager.scala
+++ b/app/repositories/PathManager.scala
@@ -39,8 +39,9 @@ object PathManager {
         pathId
       }
       case c => {
-        Logger.warn(s"failed to register $path. response code $c, message ${resp.body}")
-        throw PathRegistrationFailed(s"failed to register $path. response code $c, message ${resp.body}")
+        val body = resp.body
+        Logger.warn(s"failed to register $path. response code $c, message $body")
+        throw PathRegistrationFailed(s"failed to register $path. response code $c, message $body")
       }
     }
   }
@@ -54,8 +55,9 @@ object PathManager {
     resp.code match {
       case 204 => Logger.info(s"path entries for $id removed")
       case c => {
-        Logger.warn(s"failed to remove paths for $id. response code $c, message ${resp.body}")
-        throw new PathRemoveFailed(s"failed to remove paths for $id. response code $c, message ${resp.body}")
+        val body = resp.body
+        Logger.warn(s"failed to remove paths for $id. response code $c, message $body")
+        throw new PathRemoveFailed(s"failed to remove paths for $id. response code $c, message $body")
       }
     }
   }
@@ -68,8 +70,9 @@ object PathManager {
       case 404 => false // not found = not in use
       case 200 => true
       case c => {
-        Logger.warn(s"failed to check path $path in use. response code $c, message ${resp.body}")
-        throw new RuntimeException(s"failed to check path $path in use. response code $c, message ${resp.body}")
+        val body = resp.body
+        Logger.warn(s"failed to check path $path in use. response code $c, message $body")
+        throw new RuntimeException(s"failed to check path $path in use. response code $c, message $body")
       }
     }
   }

--- a/app/services/ImageMetadata.scala
+++ b/app/services/ImageMetadata.scala
@@ -54,8 +54,9 @@ object ImageMetadataService {
         Some(ImageMetadata(image.getWidth, image.getHeight, bytes.size, mediaId, mimeType))
       }
       case c => {
-        Logger.warn(s"failed to get image metadata for $uri. response code $c, message ${response.body}")
-        throw ImageMetadataFetchFail(s"failed to get image metadata for $uri. response code $c, message ${response.body}")
+        val body = response.body
+        Logger.warn(s"failed to get image metadata for $uri. response code $c, message $body")
+        throw ImageMetadataFetchFail(s"failed to get image metadata for $uri. response code $c, message $body")
       }
     }
   }

--- a/app/services/ImageMetadata.scala
+++ b/app/services/ImageMetadata.scala
@@ -4,15 +4,12 @@ import java.io.{File, ByteArrayInputStream}
 import javax.imageio.ImageIO
 
 import java.security.MessageDigest
-import javax.imageio.stream.ImageInputStream
 import play.api.Logger
 
-import com.squareup.okhttp.Request.Builder
-import com.squareup.okhttp.{OkHttpClient, Request}
+import okhttp3.Request.Builder
+import okhttp3.OkHttpClient
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Format}
-
-import scala.util.control.NonFatal
 
 case class ImageMetadataFetchFail(m: String) extends RuntimeException(m)
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,18 +23,18 @@ lazy val dependencies = Seq(
   "com.gu" %% "editorial-permissions-client" % "0.2",
   ws, // for panda
   "org.cvogt" %% "play-json-extensions" % "0.6.0",
-  "com.squareup.okhttp" % "okhttp" % "2.4.0",
+  "com.squareup.okhttp3" % "okhttp" % "3.9.0",
   "org.apache.thrift" % "libthrift" % "0.8.0",
   "com.twitter" %% "scrooge-core" % "4.12.0",
   "com.google.guava" % "guava" % "18.0",
-  "com.gu" %% "content-api-client" % "7.7",
+  "com.gu" %% "content-api-client" % "11.51",
   "com.gu" %% "tags-thrift-schema" % "2.1.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",
   "com.gu"  %% "panda-hmac" % "1.2.0",
-  "com.gu" %% "content-api-client-aws" % "0.2"
+  "com.gu" %% "content-api-client-aws" % "0.3"
 )
 
 import com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd


### PR DESCRIPTION
1. Stop using dispatch for capi preview requests as it's not working properly (by default the `content-api-client` uses okhttp, which we already use elsewhere in tagmanager).
2. Stop sending requests to capi with no content ids, e.g. `...&ids=` in `countOccurencesOfTagInContents`. This fails because the signing logic drops the invalid param, so the actual url doesn't match.
3. Also, only consume the response body stream once when logging error responses (it breaks otherwise)