### PR TITLE
Allow CAPI searches without a string query

### DIFF
--- a/public/util/capiClient.js
+++ b/public/util/capiClient.js
@@ -99,7 +99,7 @@ export function searchPreviewContent (searchString, byline, params) {
 
     return Reqwest({
       url: getCapiPreviewUrl()
-        + '&q=' + buildSearch(searchQueryString)
+        + ( searchQueryString ? '&q=' + buildSearch(searchQueryString) : '')
         + ( byline ? '&byline=' + buildSearch(bylineQueryString) : '')
         + '&' + query
         + '&show-fields=isLive,internalComposerCode&order-by=newest',


### PR DESCRIPTION
Simple fix that allows searching by a filter (a tag, for example) rather than searching by a query.