### PR TITLE
Slow down tag reindexing

### DIFF
--- a/app/model/jobs/steps/ReindexTags.scala
+++ b/app/model/jobs/steps/ReindexTags.scala
@@ -22,6 +22,7 @@ case class ReindexTags(`type`: String = ReindexTags.`type`, var stepStatus: Stri
 
         progress += tags.size
         ReindexProgressRepository.updateTagReindexProgress(progress, total)
+        Thread.sleep(500)
       }
       ReindexProgressRepository.completeTagReindex(progress, total)
     } catch {


### PR DESCRIPTION
Very hacky fix to get tag reindexing working - we're getting `ProvisionedThroughputExceededException`.
