### PR TITLE
Add ssm role to cloudformation

### DIFF
--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -57,6 +57,7 @@ Resources:
   TagManagerRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns: [ "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM" ]
       AssumeRolePolicyDocument:
         Statement:
         - Effect: Allow


### PR DESCRIPTION
We already use an AMI with the ssm-agent:

https://github.com/guardian/tagmanager/blob/master/riff-raff.yaml#L18
