### PR TITLE
allow blog tags to be sponsored

### DIFF
--- a/public/components/SponsorshipEdit/TargetingEdit.react.js
+++ b/public/components/SponsorshipEdit/TargetingEdit.react.js
@@ -72,7 +72,7 @@ export default class TargetingEdit extends React.Component {
               </div>
             )
           })}
-          <TagSelect onTagClick={selectTagFn} tagType="topic,series" />
+          <TagSelect onTagClick={selectTagFn} tagType="blog,topic,series" />
         </div>
     );
   }


### PR DESCRIPTION
We'd like to be able to sponsor legacy blog tags.

As far as I can tell this restriction on the tag type was only enforced client side.