### PR TITLE
Add new Campaign Tag with subtype of callouts

### DIFF
--- a/app/model/CampaignInformation.scala
+++ b/app/model/CampaignInformation.scala
@@ -1,0 +1,26 @@
+package model
+
+import play.api.libs.json._
+import org.cvogt.play.json.Jsonx
+import com.gu.tagmanagement.{CampaignInformation => ThriftCampaignInformation}
+
+case class CampaignInformation(campaignType: String) {
+
+  def asThrift = ThriftCampaignInformation(
+      campaignType = campaignType
+  )
+
+  def asExportedXml = {
+    <campaignType>{this.campaignType}</campaignType>
+  }
+}
+
+object CampaignInformation {
+
+  implicit val trackingFormat = Jsonx.formatCaseClass[CampaignInformation]
+
+  def apply(thriftCampaignInformation: ThriftCampaignInformation): CampaignInformation =
+    CampaignInformation(
+      campaignType = thriftCampaignInformation.campaignType
+    )
+}

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -36,6 +36,7 @@ case class Tag(
   isMicrosite: Boolean,
   capiSectionId: Option[String] = None,
   trackingInformation: Option[TrackingInformation],
+  campaignInformation: Option[CampaignInformation],
   activeSponsorships: List[Long] = Nil,
   sponsorship: Option[Long] = None, // for paid content tags, they have an associated sponsorship but it may not be active
   paidContentInformation: Option[PaidContentInformation] = None,
@@ -157,6 +158,7 @@ object Tag {
       isMicrosite       = thriftTag.isMicrosite,
       capiSectionId     = thriftTag.capiSectionId,
       trackingInformation = thriftTag.trackingInformation.map(TrackingInformation(_)),
+      campaignInformation = thriftTag.campaignInformation.map(CampaignInformation(_)),
       updatedAt = thriftTag.updatedAt.getOrElse(0L),
       activeSponsorships = thriftTag.activeSponsorships.map(_.map(_.id).toList).getOrElse(Nil),
       sponsorship = thriftTag.sponsorshipId,
@@ -188,6 +190,7 @@ case class DenormalisedTag (
   isMicrosite: Boolean,
   capiSectionId: Option[String] = None,
   trackingInformation: Option[TrackingInformation],
+  campaignInformation: Option[CampaignInformation],
   activeSponsorships: List[Long] = Nil,
   sponsorship: Option[Sponsorship] = None, // for paid content tags, they have an associated sponsorship but it may not be active
   paidContentInformation: Option[PaidContentInformation] = None,
@@ -219,6 +222,7 @@ case class DenormalisedTag (
       isMicrosite = isMicrosite,
       capiSectionId = capiSectionId,
       trackingInformation = trackingInformation,
+      campaignInformation = campaignInformation,
       activeSponsorships = activeSponsorships,
       sponsorship = sponsorship.map(_.id), // for paid content tags, they have an associated sponsorship but it may not be active
       paidContentInformation = paidContentInformation,
@@ -255,6 +259,7 @@ object DenormalisedTag{
     isMicrosite = t.isMicrosite,
     capiSectionId = t.capiSectionId,
     trackingInformation = t.trackingInformation,
+    campaignInformation = t.campaignInformation,
     activeSponsorships = t.activeSponsorships,
     sponsorship = t.sponsorship.flatMap(SponsorshipRepository.getSponsorship), // for paid content tags, they have an associated sponsorship but it may not be active
     paidContentInformation = t.paidContentInformation,

--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -72,6 +72,7 @@ case class CreateTagCommand(
                       isMicrosite: Boolean,
                       capiSectionId: Option[String] = None,
                       trackingInformation: Option[TrackingInformation] = None,
+                      campaignInformation: Option[CampaignInformation] = None,
                       preCalculatedPath: Option[String] = None, //This is used so path isn't calculated
                       sponsorship: Option[InlinePaidContentSponsorshipCommand] = None,
                       paidContentInformation: Option[PaidContentInformation] = None,
@@ -120,9 +121,14 @@ case class CreateTagCommand(
 
     val createdSectionId = if(createMicrosite) { sectionId } else { None }
 
+    val tagSubType: Option[String] =  `type` match {
+      case "Tracking" => trackingInformation.map(_.trackingType)
+      case "Campaign" => campaignInformation.map(_.campaignType)
+    }
+
     val calculatedPath = preCalculatedPath match {
       case Some(path) => path
-      case None => TagPathCalculator.calculatePath(`type`, slug, sectionId, trackingInformation.map(_.trackingType))
+      case None => TagPathCalculator.calculatePath(`type`, slug, sectionId, tagSubType)
         // Note we don't pass the paid contnet subtype here as the path munging has now been applied to the created microsite
         // so the standard section / slug logic is the desired logic
     }
@@ -155,6 +161,7 @@ case class CreateTagCommand(
       isMicrosite = isMicrosite || createMicrosite,
       capiSectionId = capiSectionId,
       trackingInformation = trackingInformation,
+      campaignInformation = campaignInformation,
       activeSponsorships = if(createdSponsorshipActive) List(createdSponsorship.map(_.id).get) else Nil,
       sponsorship = createdSponsorship.map(_.id),
       paidContentInformation = paidContentInformation,

--- a/app/model/command/MergeTagCommand.scala
+++ b/app/model/command/MergeTagCommand.scala
@@ -36,7 +36,7 @@ case class MergeTagCommand(removingTagId: Long, replacementTagId: Long) extends 
 }
 
 object MergeTagCommand {
-  val blockedTagTypes = List("Publication", "NewspaperBook", "NewspaperBookSection", "Tracking", "ContentType")
+  val blockedTagTypes = List("Publication", "NewspaperBook", "NewspaperBookSection", "Tracking", "ContentType", "Campaign")
 
   implicit val mergeTagCommandFormat: Format[MergeTagCommand] = (
     (JsPath \ "removingTagId").format[Long] and

--- a/app/model/command/logic/TagPathCalculator.scala
+++ b/app/model/command/logic/TagPathCalculator.scala
@@ -19,6 +19,7 @@ object TagPathCalculator {
       case ("publication", _) => s"$slug/all"
       case ("series", _) => s"${sectionPathPrefix}series/$slug"
       case ("tracking", trackingType) => s"tracking/${trackingType.getOrElse("")}/$slug"
+      case ("campaign", campaignType) => s"campaign/${campaignType.getOrElse("")}/$slug"
       case ("paidcontent", Some("hostedcontent")) => s"advertiser-content/$slug"
       case (_, _) => sectionPathPrefix + slug
     }

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val dependencies = Seq(
   "com.twitter" %% "scrooge-core" % "4.12.0",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client" % "11.51",
-  "com.gu" %% "tags-thrift-schema" % "2.1.0",
+  "com.gu" %% "tags-thrift-schema" % "2.2.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/public/components/TagEdit/TagEdit.react.js
+++ b/public/components/TagEdit/TagEdit.react.js
@@ -12,6 +12,8 @@ import PublicationInfoEdit from './formComponents/publication/PublicationInfoEdi
 import NewspaperBookInfoEdit from './formComponents/newspaperbook/NewspaperBookInfoEdit.react';
 import PaidContentInfoEdit from './formComponents/paidcontent/PaidContentInfoEdit.react';
 import TrackingInfoEdit from './formComponents/tracking/TrackingInformation.react.js';
+import CampaignInfoEdit from './formComponents/campaigns/CampaignInformation.react.js';
+
 
 import * as tagTypes from '../../constants/tagTypes';
 
@@ -115,6 +117,10 @@ export default class TagEdit extends React.Component {
       return <TrackingInfoEdit tag={this.props.tag} updateTag={this.props.updateTag} tagEditable={this.props.tagEditable}/>;
     }
 
+    renderCampaignFields() {
+      return <CampaignInfoEdit tag={this.props.tag} updateTag={this.props.updateTag} tagEditable={this.props.tagEditable} />;
+    }
+
     renderTagTypeSpecificFields() {
 
       if (!this.props.tag.type) {
@@ -147,6 +153,10 @@ export default class TagEdit extends React.Component {
 
       if (this.props.tag.type === tagTypes.tracking.name) {
         return this.renderTrackingFields();
+      }
+
+      if (this.props.tag.type === tagTypes.campaign.name) {
+        return this.renderCampaignFields();
       }
 
       return false;

--- a/public/components/TagEdit/formComponents/TagName.react.js
+++ b/public/components/TagEdit/formComponents/TagName.react.js
@@ -118,6 +118,12 @@ export default class TagNameEdit extends React.Component {
       return 'tracking/' + trackingTypeName + '/';
     }
 
+    //Campaigns Type Exception
+    if (this.props.tag.type === tagTypes.campaign.name) {
+      const campaignTypeName = this.props.tag.campaignInformation && this.props.tag.campaignInformation.campaignType ? this.props.tag.campaignInformation.campaignType.toLowerCase() : '...';
+      return 'campaign/' + campaignTypeName + '/';
+    }
+
     // Paid content with sub type of hosted exception
 
     if (this.props.tag.type === tagTypes.paidContent.name

--- a/public/components/TagEdit/formComponents/campaigns/CampaignInformation.react.js
+++ b/public/components/TagEdit/formComponents/campaigns/CampaignInformation.react.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {campaignTagTypes} from '../../../../constants/campaignTagTypes';
+
+export default class CampaignInformation extends React.Component {
+
+    constructor(props) {
+        super(props);
+    }
+
+    updateCampaignType(e) {
+        this.props.updateTag(Object.assign({}, this.props.tag, {
+            campaignInformation: Object.assign({}, this.props.tag.campaignInformation, {
+                campaignType: e.target.value
+            })
+        }));
+    }
+
+    render () {
+
+        const selectCampaignType = this.props.tag.campaignInformation ? this.props.tag.campaignInformation.campaignType : undefined;
+
+        return (
+            <div className="tag-edit__input-group">
+                <label className="tag-edit__input-group__header">Campaign Information</label>
+                <div className="tag-edit__field">
+                    <label className="tag-edit__label">Campaign Type</label>
+                    <select value={selectCampaignType || ""} onChange={this.updateCampaignType.bind(this)} disabled={!this.props.tagEditable}>
+                        {!selectCampaignType ? <option value={false}></option> : false}
+                        {campaignTagTypes.sort((a, b) => {return a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1;}).map(function(t) {
+                            return (
+                                <option value={t.value} key={t.value} >{t.name}</option>
+                            );
+                        })}
+                    </select>
+                </div>
+            </div>
+        );
+    }
+}

--- a/public/constants/campaignTagTypes.js
+++ b/public/constants/campaignTagTypes.js
@@ -1,0 +1,3 @@
+export const campaignTagTypes = [
+    {name: 'Callout', value: 'callout'}
+];

--- a/public/constants/tagTypes.js
+++ b/public/constants/tagTypes.js
@@ -60,3 +60,9 @@ export const tracking = {
   displayName: 'Tracking',
   pathPrefix: 'tracking'
 };
+
+export const campaign = {
+    name: 'Campaign',
+    displayName: 'Campaign',
+    pathPrefix: 'campaign'
+};


### PR DESCRIPTION
This creates a new Tag Type called "Campaign" with the subtype "Callout"
It will work in a similar way to the Tracking tag 

As part of the changes to introduce callouts in the frontend, we need a new way to attach them to individual articles. In Targeting, we want to create a new unique tag for each callout. It will be of type "campaign".

**Tag manager UI with Campaign options**

![screen shot 2018-04-30 at 13 48 16](https://user-images.githubusercontent.com/10324129/39427871-45b2f6a8-4c7d-11e8-9c49-1d8d72d7d689.png)

**How frontend will render the campaign (off the config object**
![screen shot 2018-04-13 at 13 32 35](https://user-images.githubusercontent.com/10324129/39428192-7018e122-4c7e-11e8-91f4-fbf0c00767ba.png)

