### PR TITLE
FIX: for bug that broke tag saving

### DIFF
--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -124,6 +124,7 @@ case class CreateTagCommand(
     val tagSubType: Option[String] =  `type` match {
       case "Tracking" => trackingInformation.map(_.trackingType)
       case "Campaign" => campaignInformation.map(_.campaignType)
+      case _ => None
     }
 
     val calculatedPath = preCalculatedPath match {


### PR DESCRIPTION
A switch statement without a default state broke tag saving. For tags without a subtype. 
Caused by adding a new tag in PR yesterday. 

This appears to solve the problem. 