### PR TITLE
Add new Tag Fix: Add campaign to thrift model

### DIFF
--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -74,7 +74,8 @@ case class Tag(
     }),
     sponsorshipId = sponsorship,
     paidContentInformation = paidContentInformation.map(_.asThrift),
-    expired = expired
+    expired = expired,
+    campaignInformation = campaignInformation.map(_.asThrift)
   )
 
   // in this limited format for inCopy to consume


### PR DESCRIPTION
A further model needed to be changed to fully pass the information to CAPI. 
This fixes: https://github.com/guardian/tagmanager/pull/317