### PR TITLE
CALLOUTS: Whitelist Targeting to allow to the app to create tags

### DIFF
--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -2,33 +2,10 @@ package controllers
 
 import model._
 import play.api.libs.json._
-import play.api.mvc.{Action, Controller, Request, Result}
+import play.api.mvc.{Action, Controller}
 import repositories._
 import services.Config.conf
-
-import scala.concurrent.Future
-import play.api.libs.concurrent.Execution.Implicits._
-
-case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
-  def apply(request: Request[A]): Future[Result] = {
-    val headers = request.headers.get("Origin").map { origin =>
-      if(origins.contains(origin)) {
-        List(CORSable.CORS_ALLOW_ORIGIN -> origin, CORSable.CORS_CREDENTIALS -> "true")
-      } else { Nil }
-    }
-
-    action(request).map(_.withHeaders(headers.getOrElse(Nil) :_*))
-  }
-
-  lazy val parser = action.parser
-}
-
-object CORSable {
-  val CORS_ALLOW_ORIGIN = "Access-Control-Allow-Origin"
-  val CORS_CREDENTIALS = "Access-Control-Allow-Credentials"
-  val CORS_ALLOW_METHODS = "Access-Control-Allow-Methods"
-  val CORS_ALLOW_HEADERS = "Access-Control-Allow-Headers"
-}
+import helpers.CORSable
 
 object HyperMediaApi extends Controller with PanDomainAuthActions {
   def hyper = CORSable(conf.corsableDomains: _*) {

--- a/app/helpers/CorsHelpers.scala
+++ b/app/helpers/CorsHelpers.scala
@@ -1,0 +1,27 @@
+package helpers
+import play.api.mvc.{Action, Request, Result}
+
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits._
+
+
+case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
+  def apply(request: Request[A]): Future[Result] = {
+    val headers = request.headers.get("Origin").map { origin =>
+      if(origins.contains(origin)) {
+        List(CORSable.CORS_ALLOW_ORIGIN -> origin, CORSable.CORS_CREDENTIALS -> "true")
+      } else { Nil }
+    }
+
+    action(request).map(_.withHeaders(headers.getOrElse(Nil) :_*))
+  }
+
+  lazy val parser = action.parser
+}
+
+object CORSable {
+  val CORS_ALLOW_ORIGIN = "Access-Control-Allow-Origin"
+  val CORS_CREDENTIALS = "Access-Control-Allow-Credentials"
+  val CORS_ALLOW_METHODS = "Access-Control-Allow-Methods"
+  val CORS_ALLOW_HEADERS = "Access-Control-Allow-Headers"
+}

--- a/app/permissions/PermissionActionCheck.scala
+++ b/app/permissions/PermissionActionCheck.scala
@@ -13,12 +13,15 @@ trait PermissionActionFilter extends ActionFilter[UserRequest] {
   val restrictedAction: String
 
   override def filter[A](request: UserRequest[A]) =
-    testAccess(request.user.email).map {
-      case PermissionGranted => None
-      case PermissionDenied =>
-        Logger.info(s"user not authorized to $restrictedAction")
-        println("FAILED")
-        Some(Results.Unauthorized)}
+    if(request.user.email == "hmac-authed-service") {
+      Future.successful(None)
+    } else {
+      testAccess(request.user.email).map {
+        case PermissionGranted => None
+        case PermissionDenied =>
+          Logger.info(s"user not authorized to $restrictedAction")
+          Some(Results.Unauthorized)}
+    }
 }
 
 object AddEditionToSectionPermissionsCheck extends PermissionActionFilter {

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -113,7 +113,10 @@ sealed trait Config {
   def pandaAuthCallback: String
 
   def composerDomain: String
+  def targetingDomain: String
+  def campaignCentralDomain: String
   def corsableDomains: Seq[String]
+  def corsablePostDomains: Seq[String]
 
   def frontendBucketWriteRole: Option[String] = None
   def tagSearchPageSize = 25
@@ -158,10 +161,15 @@ class DevConfig extends Config {
   override def pandaAuthCallback: String = "https://tagmanager.local.dev-gutools.co.uk/oauthCallback"
 
   override def composerDomain: String = "https://composer.local.dev-gutools.co.uk"
+  override def targetingDomain: String = "https://targeting.local.dev-gutools.co.uk"
+  override def campaignCentralDomain: String = "https://campaign-central.local.dev-gutools.co.uk"
   override def corsableDomains: Seq[String] = Seq(
     composerDomain,
-    "https://targeting.local.dev-gutools.co.uk",
-    "https://campaign-central.local.dev-gutools.co.uk"
+    targetingDomain,
+    campaignCentralDomain
+  )
+  override def corsablePostDomains: Seq[String] = Seq(
+    targetingDomain
   )
 }
 
@@ -204,16 +212,22 @@ class CodeConfig extends Config {
   override def pandaAuthCallback: String = "https://tagmanager.code.dev-gutools.co.uk/oauthCallback"
 
   override def composerDomain: String = "https://composer.code.dev-gutools.co.uk"
+  override def targetingDomain: String = "https://targeting.code.dev-gutools.co.uk"
+  override def campaignCentralDomain: String = "https://campaign-central.code.dev-gutools.co.uk"
   override def corsableDomains: Seq[String] = Seq(
     composerDomain,
     "https://composer-secondary.code.dev-gutools.co.uk",
     "https://composer.local.dev-gutools.co.uk",
-    "https://targeting.code.dev-gutools.co.uk",
+    targetingDomain,
     "https://targeting.local.dev-gutools.co.uk",
-    "https://campaign-central.code.dev-gutools.co.uk",
+    campaignCentralDomain,
     "https://campaign-central.local.dev-gutools.co.uk")
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
+  override def corsablePostDomains: Seq[String] = Seq(
+    targetingDomain,
+    "https://targeting.local.dev-gutools.co.uk"
+  )
 }
 
 class ProdConfig extends Config {
@@ -254,11 +268,17 @@ class ProdConfig extends Config {
   override def pandaAuthCallback: String = "https://tagmanager.gutools.co.uk/oauthCallback"
 
   override def composerDomain: String = "https://composer.gutools.co.uk"
+  override def targetingDomain: String = "https://targeting.gutools.co.uk"
+  override def campaignCentralDomain: String = "https://campaign-central.gutools.co.uk"
   override def corsableDomains: Seq[String] = Seq(
     composerDomain,
-    "https://composer-secondary.gutools.co.uk",
-    "https://targeting.gutools.co.uk",
-    "https://campaign-central.gutools.co.uk")
+    targetingDomain,
+    campaignCentralDomain,
+    "https://composer-secondary.gutools.co.uk"
+    )
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
+  override def corsablePostDomains: Seq[String] = Seq(
+    targetingDomain
+  )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val dependencies = Seq(
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",
-  "com.gu"  %% "panda-hmac" % "1.2.0",
+  "com.gu"  %% "panda-hmac" % "1.3.0",
   "com.gu" %% "content-api-client-aws" % "0.5"
 )
 


### PR DESCRIPTION
We want Targeting to be able to:
1.  Create Tags in TagManager
2. Search for Tags in TagManger 
3. Delete tags  in TagManager (of the type campaign)

### Extract CORSable 
To do that, it needs to make POST request and to do that, it needs to overcome Cross Origin Restrictions. 
This PR extracts the `CORSable` function used elsewhere into its own helper.
Have created a short list of: `corsablePostDomains` - which are apps whitelisted to do this. Only Targeting is on the list for now. 

### Wrap 3 functions with CORSable
We now added the CORSable check to the `createTag`, `searchTag` and `deleteTag` function, which allows Targeting to now access this function to create tags. 

### Allow hmac users to pass the email permissions test 
The createTag request comes from the front end of Targeting.
The deleteTag and searchTag requests come from the backend of Targeting so use the HMAC convention. 
Given that HMAC already provides a layer of security, we allow authenticated hmac requests to use a default email address. A change in `panda-hmac` allows this to happen. Hence the version bump 
