### PR TITLE
correct git URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/npm.git"
+    "url" : "https://github.com/guardian/tagmanager"
   }
 }


### PR DESCRIPTION
I noticed this unmerged commit on an old branch and thought I'd just replicate it rather than going through the effort of digging out the old commit https://github.com/guardian/tagmanager/commit/fd6f367bb028d7134c4ffb84770ed6aa697ac8d5