### PR TITLE
reverse tag select list if its growing from the bottom

### DIFF
--- a/public/components/utils/TagSelect.js
+++ b/public/components/utils/TagSelect.js
@@ -2,6 +2,7 @@ import React from 'react';
 import tagManagerApi from '../../util/tagManagerApi';
 import debounce from 'lodash.debounce';
 import * as tagTypes from '../../constants/tagTypes';
+import R from 'ramda';
 
 const BLANK_STATE = {
   selectedTag: undefined,
@@ -62,10 +63,12 @@ export default class TagSelect extends React.Component {
         return false;
       }
 
+      const suggestions = this.props.showResultsAbove ? R.reverse(this.state.suggestions) : this.state.suggestions;
+
       return (
         <div className="tag-select__suggestions">
           <ul>
-            {this.state.suggestions.filter(tag => this.isAllowedTagType(tag.type)).map(tag => {
+            {suggestions.filter(tag => this.isAllowedTagType(tag.type)).map(tag => {
               const tagTypeKey = Object.keys(tagTypes).filter((tagTypeKey) => {
                 return tagTypes[tagTypeKey].name === tag.type;
               })[0];


### PR DESCRIPTION
"Quick win" to fix an issue where a tag you want is pushed off the top of the screen if there are too many other tags.

This problem is most apparent when you're using a tag name which is a substring of many ohter tags. E.g. "law" is a substring of "lawless", "lawrence", etc, etc.