### PR TITLE
Podcasts: Add a field for Google Podcasts & Spotify Links

### DIFF
--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -14,7 +14,8 @@ case class PodcastMetadata( linkUrl: String,
                             explicit: Boolean = false,
                             image: Option[Image] = None,
                             categories: Option[PodcastCategory] = None,
-                            podcastType: Option[String] = None
+                            podcastType: Option[String] = None,
+                            googlePodcastsUrl: Option[String] = None
 ) {
 
   def asThrift = ThriftPodcastMetadata(
@@ -27,7 +28,8 @@ case class PodcastMetadata( linkUrl: String,
     explicit =          explicit,
     image =             image.map(_.asThrift),
     categories =        categories.map((cat) => List(cat.asThrift)),
-    podcastType =       podcastType
+    podcastType =       podcastType,
+    googlePodcastsUrl = googlePodcastsUrl
   )
 
   def asExportedXml = {
@@ -36,6 +38,7 @@ case class PodcastMetadata( linkUrl: String,
     <authorText>{this.authorText.getOrElse("")}</authorText>
     <iTunesUrl>{this.iTunesUrl.getOrElse("")}</iTunesUrl>
     <iTunesBlock>{this.iTunesBlock}</iTunesBlock>
+    <GooglePodcastsUrl>{this.googlePodcastsUrl.getOrElse("")}</GooglePodcastsUrl>
     <clean>{this.clean}</clean>
     <explicit>{this.explicit}</explicit>
     <image>{this.image.map(x => x.asExportedXml).getOrElse("")}</image>
@@ -59,7 +62,8 @@ object PodcastMetadata {
       explicit =          thriftPodcastMetadata.explicit,
       image =             thriftPodcastMetadata.image.map(Image(_)),
       categories =        thriftPodcastMetadata.categories.map(x => PodcastCategory(x.head)),
-      podcastType =       thriftPodcastMetadata.podcastType
+      podcastType =       thriftPodcastMetadata.podcastType,
+      googlePodcastsUrl = thriftPodcastMetadata.googlePodcastsUrl
     )
 }
 

--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -15,7 +15,8 @@ case class PodcastMetadata( linkUrl: String,
                             image: Option[Image] = None,
                             categories: Option[PodcastCategory] = None,
                             podcastType: Option[String] = None,
-                            googlePodcastsUrl: Option[String] = None
+                            googlePodcastsUrl: Option[String] = None,
+                            spotifyUrl: Option[String] = None
 ) {
 
   def asThrift = ThriftPodcastMetadata(
@@ -29,7 +30,8 @@ case class PodcastMetadata( linkUrl: String,
     image =             image.map(_.asThrift),
     categories =        categories.map((cat) => List(cat.asThrift)),
     podcastType =       podcastType,
-    googlePodcastsUrl = googlePodcastsUrl
+    googlePodcastsUrl = googlePodcastsUrl,
+    spotifyUrl =        spotifyUrl
   )
 
   def asExportedXml = {
@@ -39,6 +41,7 @@ case class PodcastMetadata( linkUrl: String,
     <iTunesUrl>{this.iTunesUrl.getOrElse("")}</iTunesUrl>
     <iTunesBlock>{this.iTunesBlock}</iTunesBlock>
     <GooglePodcastsUrl>{this.googlePodcastsUrl.getOrElse("")}</GooglePodcastsUrl>
+    <SpotifyUrl>{this.spotifyUrl.getOrElse("")}</SpotifyUrl>
     <clean>{this.clean}</clean>
     <explicit>{this.explicit}</explicit>
     <image>{this.image.map(x => x.asExportedXml).getOrElse("")}</image>
@@ -63,7 +66,8 @@ object PodcastMetadata {
       image =             thriftPodcastMetadata.image.map(Image(_)),
       categories =        thriftPodcastMetadata.categories.map(x => PodcastCategory(x.head)),
       podcastType =       thriftPodcastMetadata.podcastType,
-      googlePodcastsUrl = thriftPodcastMetadata.googlePodcastsUrl
+      googlePodcastsUrl = thriftPodcastMetadata.googlePodcastsUrl,
+      spotifyUrl =        thriftPodcastMetadata.spotifyUrl
     )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val dependencies = Seq(
   "com.twitter" %% "scrooge-core" % "4.12.0",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client" % "11.51",
-  "com.gu" %% "tags-thrift-schema" % "2.2.0",
+  "com.gu" %% "tags-thrift-schema" % "2.2.1",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val dependencies = Seq(
   "com.twitter" %% "scrooge-core" % "4.12.0",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client" % "11.51",
-  "com.gu" %% "tags-thrift-schema" % "2.2.1",
+  "com.gu" %% "tags-thrift-schema" % "2.2.2",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -44,6 +44,12 @@ export default class PodcastMetadata extends React.Component {
     }));
   }
 
+  updateGooglePodcastsUrl(e) {
+    this.props.updateTag(R.merge(this.props.tag, {
+      podcastMetadata: R.merge(this.props.tag.podcastMetadata, {googlePodcastsUrl: e.target.value})
+    }));
+  }
+
   updateiTunesBlock(e) {
     this.props.updateTag(R.merge(this.props.tag, {
       podcastMetadata: R.merge(this.props.tag.podcastMetadata, {iTunesBlock: e.target.checked})
@@ -141,6 +147,14 @@ export default class PodcastMetadata extends React.Component {
             checked={this.props.tag.podcastMetadata.iTunesBlock || false}
             disabled={!this.props.tagEditable}/>
           <label className="tag-edit__label"> Block from iTunes</label>
+        </div>
+        <div className="tag-edit__field">
+          <label className="tag-edit__label">Google Podcasts Url</label>
+          <input type="text"
+                 className="tag-edit__input"
+                 value={this.props.tag.podcastMetadata.googlePodcastsUrl || ''}
+                 onChange={this.updateGooglePodcastsUrl.bind(this)}
+                 disabled={!this.props.tagEditable}/>
         </div>
         <div className="tag-edit__field">
           <input type="checkbox"

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -50,6 +50,12 @@ export default class PodcastMetadata extends React.Component {
     }));
   }
 
+  updateSpotifyUrl(e) {
+    this.props.updateTag(R.merge(this.props.tag, {
+      podcastMetadata: R.merge(this.props.tag.podcastMetadata, {spotifyUrl: e.target.value})
+    }));
+  }
+
   updateiTunesBlock(e) {
     this.props.updateTag(R.merge(this.props.tag, {
       podcastMetadata: R.merge(this.props.tag.podcastMetadata, {iTunesBlock: e.target.checked})
@@ -154,6 +160,14 @@ export default class PodcastMetadata extends React.Component {
                  className="tag-edit__input"
                  value={this.props.tag.podcastMetadata.googlePodcastsUrl || ''}
                  onChange={this.updateGooglePodcastsUrl.bind(this)}
+                 disabled={!this.props.tagEditable}/>
+        </div>
+        <div className="tag-edit__field">
+          <label className="tag-edit__label">Spotify Url</label>
+          <input type="text"
+                 className="tag-edit__input"
+                 value={this.props.tag.podcastMetadata.spotifyUrl || ''}
+                 onChange={this.updateSpotifyUrl.bind(this)}
                  disabled={!this.props.tagEditable}/>
         </div>
         <div className="tag-edit__field">


### PR DESCRIPTION
We want to send over Google Podcasts links and Spotify links, in addition to the iTunes url.

This updates the interface for Podcast series and the backend too.
