### PR TITLE
Prevent spaces in sponsorship links

### DIFF
--- a/public/components/SponsorshipEdit/SponsorEdit.react.js
+++ b/public/components/SponsorshipEdit/SponsorEdit.react.js
@@ -28,13 +28,13 @@ export default class SponsorEdit extends React.Component {
 
   updateLink(e) {
     this.props.updateSponsorship(Object.assign({}, this.props.sponsorship, {
-      sponsorLink: e.target.value
+      sponsorLink: e.target.value.trim()
     }));
   }
 
   updateAboutLink(e) {
     this.props.updateSponsorship(Object.assign({}, this.props.sponsorship, {
-      aboutLink: e.target.value
+      aboutLink: e.target.value.trim()
     }));
   }
 


### PR DESCRIPTION
Apparently this issue 'wreaked havoc on frontend'! Can fairly easily just trim all values since links should never have a space in them.