### PR TITLE
replace custom execution contexts test

### DIFF
--- a/app/services/Contexts.scala
+++ b/app/services/Contexts.scala
@@ -1,11 +1,13 @@
 package services
 
+import java.util.concurrent.Executors
+
 import play.api.libs.concurrent.Akka
 
 import scala.concurrent.ExecutionContext
 import play.api.Play.current
 
 object Contexts {
-  implicit val tagOperationContext: ExecutionContext = Akka.system.dispatchers.lookup("tag-operation-context")
-  implicit val capiContext: ExecutionContext = Akka.system.dispatchers.lookup("capi-context")
+  implicit val tagOperationContext: ExecutionContext =  play.api.libs.concurrent.Execution.Implicits.defaultContext //Akka.system.dispatchers.lookup("tag-operation-context")
+  implicit val capiContext: ExecutionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext // Akka.system.dispatchers.lookup("capi-context")
 }


### PR DESCRIPTION
For some reason Akka won't initialise contexts.

This fixes this by just using the default contexts - which don't seem any worse than these distinct ones.