### PR TITLE
Assume that froms have been converted to tos

### DIFF
--- a/app/model/jobs/steps/MergeTagForContent.scala
+++ b/app/model/jobs/steps/MergeTagForContent.scala
@@ -42,8 +42,6 @@ case class MergeTagForContent(from: Tag, to: Tag, fromSection: Option[Section], 
 
     // We're basically assuming here that if there's no 'from's left that everything has successfully merged.
     // The way flexible-feeds currently works means this is true.
-
-    // Also: Returning a boolean expression like this makes me uncomfortable
     fromCount == 0
   }
 

--- a/app/model/jobs/steps/MergeTagForContent.scala
+++ b/app/model/jobs/steps/MergeTagForContent.scala
@@ -11,12 +11,11 @@ import repositories._
 
 import scala.language.postfixOps
 
-case class MergeTagForContent(from: Tag, to: Tag, fromSection: Option[Section], toSection: Option[Section], username: Option[String], var contentCount: Int = -1,
+case class MergeTagForContent(from: Tag, to: Tag, fromSection: Option[Section], toSection: Option[Section], username: Option[String],
   `type`: String = MergeTagForContent.`type`, var stepStatus: String = StepStatus.ready, var stepMessage: String = "Waiting", var attempts: Int = 0) extends Step {
 
   override def process = {
     val contentIds = ContentAPI.getContentIdsForTag(from.path)
-    contentCount = contentIds.size + ContentAPI.countContentWithTag(to.path)
 
     contentIds foreach { contentPath =>
       val taggingOperation = TaggingOperation(
@@ -38,14 +37,14 @@ case class MergeTagForContent(from: Tag, to: Tag, fromSection: Option[Section], 
 
   override def check: Boolean = {
     val fromCount = ContentAPI.countContentWithTag(from.path)
-    val toCount = ContentAPI.countContentWithTag(to.path)
 
-    Logger.info(s"Checking merge tag CAPI counts. From tag: '${from.path}' remains on $fromCount pieces of content. To tag: '${to.path}' on to $toCount pieces of content, ${contentCount - toCount} left to add.")
-    if (fromCount == 0 && toCount == contentCount) {
-      true
-    } else {
-      false
-    }
+    Logger.info(s"Checking merge tag CAPI counts. From tag: '${from.path}' remains on $fromCount pieces of content.")
+
+    // We're basically assuming here that if there's no 'from's left that everything has successfully merged.
+    // The way flexible-feeds currently works means this is true.
+
+    // Also: Returning a boolean expression like this makes me uncomfortable
+    fromCount == 0
   }
 
   override def rollback = {


### PR DESCRIPTION
So currently we store the amount of content we expect to have the 'to' tag on once a merge tag is completed for content.

The issue is we calculate this number as follows:

`contentWithFromTag.length + contentWithToTag.length`

Now if there's content with BOTH the to and from on it (not super unusual) we end up expecting more articles than there really are.

As it currently stands flex feeds performs the addition and deletion part of a merge tag in a single operation so we can assume that if the 'from' tag count is zero then the 'to's have been applied appropriately.

Potential issues are broadly similar to current issues. If you run a deletion during a merge then we'll assume everything has been merged in content. Which doesn't really help us very much and means we can't recover these merges. In practice we're only losing as much data as we would with the current design.