### PR TITLE
Add details in merge UI

### DIFF
--- a/public/components/MergeTag.react.js
+++ b/public/components/MergeTag.react.js
@@ -89,6 +89,12 @@ export default class MergeTag extends React.Component {
         <div className="merge__tag">
           {tag.internalName}
           <i className="i-cross" onClick={setTagFn.bind(this, undefined)} />
+          <ul className="merge__select__details">
+            <li>Path: {tag.path}</li>
+            <li>ID: {tag.id}</li>
+            <li>Internal Name: {tag.internalName}</li>
+            <li>External Name: {tag.externalName}</li>
+          </ul>
           <CapiStats tag={tag}/>
         </div>
       );

--- a/public/style/components/merge-tag/_index.scss
+++ b/public/style/components/merge-tag/_index.scss
@@ -36,3 +36,8 @@
 .merge__warning {
     color: $c-orange;
 }
+
+.merge__select__details {
+  list-style-type: initial;
+  margin-left: $standard-padding * 1.5;
+}


### PR DESCRIPTION
Ronseal. Should help when doing lots of merges against tags with similar names and paths.

<img width="788" alt="51a3f6e1ee95d2a609bffc4160eeaad7" src="https://user-images.githubusercontent.com/395805/45816792-9a24ed00-bcd4-11e8-9583-5fab3b479009.png">
