### PR TITLE
fix reset mode button in batch tagger

### DIFF
--- a/public/components/BatchTagControls/BatchTagControls.js
+++ b/public/components/BatchTagControls/BatchTagControls.js
@@ -64,6 +64,12 @@ export default class BatchTagControls extends React.Component {
         }
     }
 
+    resetMode() {
+        this.setState({
+            mode: ''
+        });
+    }
+
     performBatchTag(tag, operation) {
       const {toAddToTop, toAddToBottom, toRemove} = this.state;
       const toId = (tag) => tag.id;
@@ -105,7 +111,7 @@ export default class BatchTagControls extends React.Component {
               {text}
             </div>
             <TagSelect onTagClick={func.bind(this)} showResultsAbove={true} />
-            <i className="i-cross" onClick={this.resetMode}></i>
+            <i className="i-cross batch-status__cancel" onClick={this.resetMode.bind(this)}></i>
           </div>
       );
     }

--- a/public/style/components/batch-status/_index.scss
+++ b/public/style/components/batch-status/_index.scss
@@ -11,10 +11,10 @@ $batch-status-height: 30px;
   background-color: $c-grey-200;
   border-top: 1px solid $c-grey-300;
   width: 100%;
+  height: 50px;
 
   text-align: left;
   padding: 10px;
-
 }
 
 .batch-status {
@@ -103,4 +103,8 @@ $batch-status-height: 30px;
 .batch-status-transition-leave-active.batch-status__container {
   transform: translateY($batch-status-height);
   transition: transform 500ms ease-out;
+}
+
+.batch-status__cancel {
+    cursor: pointer;
 }


### PR DESCRIPTION
Accidentally deleted the reset mode function when moving to the basket based batch tagger.