### PR TITLE
Require tag_edit permission to edit and create tags

### DIFF
--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -25,7 +25,8 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
     }.getOrElse(NotFound)
   }
 
-  def updateTag(id: Long) = (APIAuthAction andThen UpdateTagPermissionsCheck).async { req =>
+  def updateTag(id: Long) =
+    (APIAuthAction andThen UpdateTagPermissionsCheck andThen UpdateTagSpecificPermissionsCheck).async { req =>
     implicit val username = Option(req.user.email)
 
     req.body.asJson.map { json =>
@@ -40,7 +41,7 @@ object TagManagementApi extends Controller with PanDomainAuthActions {
   }
 
   def createTag = CORSable(conf.corsablePostDomains: _*) {
-    (APIAuthAction andThen CreateTagPermissionsCheck).async { req =>
+    (APIAuthAction andThen CreateTagPermissionsCheck andThen CreateTagSpecificPermissionsCheck).async { req =>
       implicit val username = Option(req.user.email)
       req.body.asJson.map { json =>
         json.as[CreateTagCommand].process.map { result =>

--- a/app/permissions/PermissionActionCheck.scala
+++ b/app/permissions/PermissionActionCheck.scala
@@ -24,6 +24,18 @@ trait PermissionActionFilter extends ActionFilter[UserRequest] {
     }
 }
 
+// Tag Edit
+object CreateTagPermissionsCheck extends PermissionActionFilter {
+  val testAccess: String => Future[PermissionAuthorisation] = Permissions.testUser(Permissions.TagEdit)
+  val restrictedAction = "create tag"
+}
+
+object UpdateTagPermissionsCheck extends PermissionActionFilter {
+  val testAccess: String => Future[PermissionAuthorisation] = Permissions.testUser(Permissions.TagEdit)
+  val restrictedAction = "update tag"
+}
+
+// Tag Admin
 object AddEditionToSectionPermissionsCheck extends PermissionActionFilter {
   val testAccess: String => Future[PermissionAuthorisation] = Permissions.testUser(Permissions.TagAdmin)
   val restrictedAction = "add edition to section"

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Future
 
 object Permissions extends PermissionsProvider {
 
+  lazy val TagEdit = Permission("tag_edit", "tag-manager", PermissionDenied)
   lazy val TagAdmin = Permission("tag_admin", "tag-manager", PermissionDenied)
   lazy val CommercialTags = Permission("commercial_tags", "tag-manager", PermissionDenied)
   lazy val TagUnaccessible = Permission("tag_no_one", "tag-manager", PermissionDenied)

--- a/app/permissions/TagSpecificPermissions.scala
+++ b/app/permissions/TagSpecificPermissions.scala
@@ -26,7 +26,7 @@ object TagTypePermissionMap {
 
 trait TagSpecificPermissionActionFilter extends ActionFilter[UserRequest] {
 
-  val testAccess: (Permission => (String => Future[PermissionAuthorisation]))
+  val testAccess: Permission => (String => Future[PermissionAuthorisation])
   val restrictedAction: String
 
   override def filter[A](request: UserRequest[A]): Future[Option[Result]] = {
@@ -50,12 +50,12 @@ trait TagSpecificPermissionActionFilter extends ActionFilter[UserRequest] {
   }
 }
 
-object UpdateTagPermissionsCheck extends TagSpecificPermissionActionFilter {
-  val testAccess: (Permission => (String => Future[PermissionAuthorisation])) = Permissions.testUser
+object UpdateTagSpecificPermissionsCheck extends TagSpecificPermissionActionFilter {
+  val testAccess: Permission => (String => Future[PermissionAuthorisation]) = Permissions.testUser
   val restrictedAction = "update tag"
 }
 
-object CreateTagPermissionsCheck extends TagSpecificPermissionActionFilter {
-  val testAccess: (Permission => (String => Future[PermissionAuthorisation])) = Permissions.testUser
+object CreateTagSpecificPermissionsCheck extends TagSpecificPermissionActionFilter {
+  val testAccess: Permission => (String => Future[PermissionAuthorisation]) = Permissions.testUser
   val restrictedAction = "create tag"
 }

--- a/public/actions/TagActions/getTag.js
+++ b/public/actions/TagActions/getTag.js
@@ -1,6 +1,6 @@
 import tagManagerApi from '../../util/tagManagerApi';
 import {getStore} from '../../util/storeAccessor';
-
+import {hasPermission} from '../../util/verifyPermission';
 
 export const TAG_GET_REQUEST = 'TAG_GET_REQUEST';
 export const TAG_GET_RECEIVE = 'TAG_GET_RECEIVE';
@@ -41,7 +41,7 @@ export function getTag(id) {
               var permitted = store.getState().config.permittedTagTypes;
               var tagType = res.type;
 
-              if (!permitted.some((e, i, a) => e == tagType)) {
+              if (!permitted.some((e, i, a) => e == tagType) || !hasPermission('tag_edit')) {
                 dispatch(recieveTagGet(res, false));
               } else {
                 dispatch(recieveTagGet(res, true));

--- a/public/components/Tag/Display.react.js
+++ b/public/components/Tag/Display.react.js
@@ -93,7 +93,7 @@ class TagDisplay extends React.Component {
       if (!this.props.tagEditable) {
           return (
             <div className="warning-bar">
-              You do not have permission to edit this tag type
+              You do not have permission to edit this tag
             </div>
           );
       }

--- a/public/components/TagSearch.react.js
+++ b/public/components/TagSearch.react.js
@@ -4,7 +4,7 @@ import tagManagerApi from '../util/tagManagerApi';
 import TagsList from './TagList/TagList.react';
 import PageNavigator from './utils/PageNavigator.react';
 import {hasPermission} from '../util/verifyPermission'
-
+import ReactTooltip from 'react-tooltip'
 
 const searchFields = {
   'Internal Name': 'internalName',
@@ -114,8 +114,11 @@ export class TagSearch extends React.Component {
     }
 
     render () {
+        const canCreateTags = hasPermission("tag_edit");
+
         return (
             <div className="tag-search">
+                <ReactTooltip multiline={true} />
                 <div className="tag-search__filters">
                     <div className="tag-search__filters__group">
                         <label>Search</label>
@@ -126,9 +129,18 @@ export class TagSearch extends React.Component {
                           })}
                         </select>
                     </div>
-
-                    <Link className="tag-search__create" to="/tag/create" disabled={!hasPermission("tag_edit")}>Create a new tag</Link>
-
+                    <div className="tag-search__create">
+                        <Link className="tag-search__create-button" to="/tag/create" disabled={!canCreateTags}>Create a new tag</Link>
+                        {
+                            canCreateTags
+                                ?
+                                false
+                                :
+                                <i className="i-info-grey"
+                                   data-tip='You do not have permission to create tags.<br/>If you think this is a mistake please contact central production'>
+                                </i>
+                        }
+                    </div>
                 </div>
                 {this.renderPageNavigator()}
                 <div className="tag-search__suggestions">

--- a/public/components/TagSearch.react.js
+++ b/public/components/TagSearch.react.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 import tagManagerApi from '../util/tagManagerApi';
 import TagsList from './TagList/TagList.react';
 import PageNavigator from './utils/PageNavigator.react';
+import {hasPermission} from '../util/verifyPermission'
 
 
 const searchFields = {
@@ -126,7 +127,7 @@ export class TagSearch extends React.Component {
                         </select>
                     </div>
 
-                    <Link className="tag-search__create" to="/tag/create">Create a new tag</Link>
+                    <Link className="tag-search__create" to="/tag/create" disabled={!hasPermission("tag_edit")}>Create a new tag</Link>
 
                 </div>
                 {this.renderPageNavigator()}

--- a/public/router.js
+++ b/public/router.js
@@ -43,7 +43,7 @@ function clearErrorBar() {
 export const router = (
   <Router history={browserHistory}>
     <Route path="/" component={ReactApp}>
-      <Route name="tag" path="/tag/create" component={TagCreate} />
+      <Route name="tag" path="/tag/create" component={TagCreate} onEnter={requirePermission.bind(this, 'tag_edit')}/>
       <Route name="tagCreate" path="/tag/:tagId" component={TagDisplay} onLeave={clearErrorBar.bind(this)} />
       <Route name="batch" path="/batch" component={BatchTag}/>
       <Route name="mapping" path="/mapping" component={MappingManager} />

--- a/public/style/_base.scss
+++ b/public/style/_base.scss
@@ -34,3 +34,11 @@ input {
   @extend %f-data;
   @extend %fs-data-3;
 }
+
+a[disabled] {
+  pointer-events: none;
+  border-color: $c-grey-600;
+  color: $c-grey-600;
+  background-color: $c-grey-200;
+  user-select: none;
+}

--- a/public/style/components/tag-search/_index.scss
+++ b/public/style/components/tag-search/_index.scss
@@ -19,12 +19,15 @@
 }
 
 .tag-search__create {
-
-  @extend %button--green;
-
   position: absolute;
   right: 0;
   top: 0;
+  padding-right: 10px;
+
+}
+
+.tag-search__create-button {
+  @extend %button--green;
 }
 
 


### PR DESCRIPTION
Pretty self-explanatory!

Tag Manager will now require the `tag_edit` permission in order for users to create and update tags. Users will still be able to view existing tags.

Note that tag creation now has two layers of permissions checking, one for the tag type specific permissions and one for the regular tag editor.