### PR TITLE
Check a reference is applicable to CAPI before issuing reindex

### DIFF
--- a/app/model/command/UpdateTagCommand.scala
+++ b/app/model/command/UpdateTagCommand.scala
@@ -60,14 +60,14 @@ case class UpdateTagCommand(denormalisedTag: DenormalisedTag) extends Command {
 
     existingTag foreach { existing =>
 
-      val referenceHasChanged = tag.externalReferences.exists { reference =>
+      val capiReferenceHasChanged = tag.externalReferences.exists { reference =>
         val isACapiExternalReference = ExternalReferencesTypeRepository.getReferenceType(reference.`type`).exists(_.capiType.isDefined)
         val newOrUpdated = !existing.externalReferences.contains(reference)
 
         isACapiExternalReference && newOrUpdated
       }
 
-      if (referenceHasChanged) {
+      if (capiReferenceHasChanged) {
         Logger.info("Detected references change, triggering reindex")
         FlexTagReindexCommand(tag).process
       }


### PR DESCRIPTION
Diff external reference changes and make sure they're CAPI references before reindexing