### PR TITLE
Improve error handling of Tag image uploads

### DIFF
--- a/public/components/TagEdit/formComponents/TagImageEdit.react.js
+++ b/public/components/TagEdit/formComponents/TagImageEdit.react.js
@@ -1,4 +1,4 @@
-import React from 'react';
+  import React from 'react';
 import { validateImageUrl } from '../../../util/validateImage';
 import { getImageMetadata } from '../../../util/supportApi.js';
 
@@ -126,8 +126,18 @@ export default class TagImageEdit extends React.Component {
     }
 
     if (this.state.metadataFetchStatus === FETCH_STATES.error) {
-      return renderButtonError(`Server has failed to read image metadata. If this problem persists,
-        contact Central Production.`);
+      const message = (<span>
+          Server has failed to read image metadata.
+          <div className="tag-edit__image-guidelines">
+            <a href="https://docs.google.com/document/d/1XgjxraonT-6bd5Rxzrv3tkty30dQuXWpb8HcdsPo3e4" target="_blank" rel="noopener noreferrer">
+              Please read about common issues <strong>here</strong>.
+            </a>
+            <span>
+              {" "}If this problem persists, please contact Central Production.
+            </span>
+          </div>
+        </span>);
+      return renderButtonError(message);
     }
 
     if (this.state.metadataFetchStatus === FETCH_STATES.badURL) {

--- a/public/style/components/tag-edit/_index.scss
+++ b/public/style/components/tag-edit/_index.scss
@@ -283,3 +283,11 @@ $tag-edit-padding: $standard-padding/2;
   margin-top: 6px;
   margin-left: 3px;
 }
+
+.tag-edit__image-guidelines {
+  color: $c-grey-700;
+  font-size: 0.75rem;
+  margin-top: 6px;
+  margin-left: 3px;
+}
+


### PR DESCRIPTION
The reason for errors when uploading a tag image were not differentiated for users. 

This has now been fixed:

![screen shot 2019-01-29 at 13 48 10](https://user-images.githubusercontent.com/32312712/51913818-57d09280-23cf-11e9-8607-a4919d30a2ff.png)
![screen shot 2019-01-29 at 13 48 19](https://user-images.githubusercontent.com/32312712/51913821-57d09280-23cf-11e9-9e73-43326f6a9d5a.png)
![screen shot 2019-01-29 at 13 48 37](https://user-images.githubusercontent.com/32312712/51913824-57d09280-23cf-11e9-8f2f-04d9f8ef5685.png)
