### PR TITLE
Fail fast if Stage tag is not available in AWS

### DIFF
--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -11,9 +11,11 @@ import scala.collection.JavaConversions._
 object Config extends AwsInstanceTags {
 
   lazy val conf = readTag("Stage") match {
-    case Some("PROD") =>    new ProdConfig
-    case Some("CODE") =>    new CodeConfig
-    case _ =>               new DevConfig
+    case Some("PROD") => new ProdConfig
+    case Some("CODE") => new CodeConfig
+    // If in AWS and we don't know our stage, fail fast to avoid ending up running an instance with dev config in PROD!
+    case other if instanceId.nonEmpty => throw new IllegalStateException(s"Unable to read Stage tag: $other")
+    case _ => new DevConfig
   }
 
   def apply() = {


### PR DESCRIPTION
A while back we moved Tag Manager onto AWS instances that booted faster. As a result the app started before the instance tags were available and defaulted into the DEV config, causing minor mayhem.

We added a script to the AMI start-up (https://github.com/guardian/amigo/pull/167) to wait until tags were available however we have since seen a re-occurence of the problem.

This PR tries to defend against it but deliberately throwing an exception at start-up if running in AWS (we have an instance id from the magic 169 metadata service) but no Stage tag. This means we don't default to DEV config and will fail the healthcheck, thus failing the deploy.