### PR TITLE
Double the resolution for Sponsorship logos to 280×180

### DIFF
--- a/public/components/SponsorshipEdit/SponsorEdit.react.js
+++ b/public/components/SponsorshipEdit/SponsorEdit.react.js
@@ -44,8 +44,8 @@ export default class SponsorEdit extends React.Component {
       return false;
     }
 
-    const logoWidth = this.props.paidContentTagType === PAID_HOSTEDCONTENT_TYPE.value ? false : 140;
-    const logoHeight = this.props.paidContentTagType === PAID_HOSTEDCONTENT_TYPE.value ? false : 90;
+    const logoWidth = this.props.paidContentTagType === PAID_HOSTEDCONTENT_TYPE.value ? false : 280;
+    const logoHeight = this.props.paidContentTagType === PAID_HOSTEDCONTENT_TYPE.value ? false : 180;
 
     return (
       <div className="tag-edit__input-group">


### PR DESCRIPTION
At the request of Aus office who cited client wanting less blurry pics:

![responsible image resizing](https://user-images.githubusercontent.com/6032869/52645197-2fb95700-2ed8-11e9-8421-718c9313b172.gif)
