### PR TITLE
Add Platform Functional tracking tag

### DIFF
--- a/public/constants/trackingTagTypes.js
+++ b/public/constants/trackingTagTypes.js
@@ -1,3 +1,4 @@
 export const trackingTagTypes = [
-  {name: 'Commissioning Desk', value: 'commissioningdesk'}
+  {name: 'Commissioning Desk', value: 'commissioningdesk'},
+  {name: 'Platform Functional', value: 'platformfunctional'}
 ];


### PR DESCRIPTION
We need a way in Frontend to check a request in our whitelist to render by existing frontend instead of going to the new DCR rendering service (for example, that existing whitelist only allows tone/news tag and a few other checks).

Adding a new tracking tag type `platformFunctional` allows us to track these.