### PR TITLE
More logs for cache update

### DIFF
--- a/app/modules/clustersync/ClusterSynchronisation.scala
+++ b/app/modules/clustersync/ClusterSynchronisation.scala
@@ -45,7 +45,6 @@ class ClusterSynchronisation @Inject() (lifecycle: ApplicationLifecycle) {
       Logger.info(s"Starting tag sync kinesis consumer with appName: $appName")
 
       val tagUpdateConsumer = new KinesisConsumer(Config().tagUpdateStreamName, appName, TagSyncUpdateProcessor)
-      Logger.info("starting tag sync consumer")
       tagUpdateConsumer.start()
       tagCacheSynchroniser.set(Some(tagUpdateConsumer))
     } catch {

--- a/app/modules/clustersync/TagSyncUpdateProcessor.scala
+++ b/app/modules/clustersync/TagSyncUpdateProcessor.scala
@@ -16,7 +16,7 @@ object TagSyncUpdateProcessor extends KinesisStreamRecordProcessor {
 
     tagEvent.eventType match {
       case EventType.Update => {
-        Logger.info(s"insertion fof updated tag ${tagEvent.tagId} into lookup cache started")
+        Logger.info(s"insertion of updated tag ${tagEvent.tagId} into lookup cache started")
 
         tagEvent.tag match {
           case Some(t) => TagLookupCache.insertTag(Tag(t))

--- a/app/modules/clustersync/TagSyncUpdateProcessor.scala
+++ b/app/modules/clustersync/TagSyncUpdateProcessor.scala
@@ -16,8 +16,14 @@ object TagSyncUpdateProcessor extends KinesisStreamRecordProcessor {
 
     tagEvent.eventType match {
       case EventType.Update => {
-        Logger.info(s"inserting updated tag ${tagEvent.tagId} into lookup cache")
-        tagEvent.tag.foreach { t => TagLookupCache.insertTag(Tag(t)) }
+        Logger.info(s"insertion fof updated tag ${tagEvent.tagId} into lookup cache started")
+
+        tagEvent.tag match {
+          case Some(t) => TagLookupCache.insertTag(Tag(t))
+          case None =>
+            Logger.warn(s"TagEvent for ${tagEvent.tagId} did not contain any tag object")
+        }
+
       }
       case EventType.Delete => {
         Logger.info(s"removing tag ${tagEvent.tagId} from lookup cache")

--- a/app/repositories/TagRepository.scala
+++ b/app/repositories/TagRepository.scala
@@ -181,7 +181,7 @@ object TagLookupCache {
       val newTags = (tag :: currentTags.filterNot(_.id == tag.id)).sortBy(_.internalName)
 
       if (allTags.compareAndSet(currentTags, newTags)) {
-        Logger.info(s"updated TagLookupCache with new tag: {internalName: ${tag.internalName}, id: ${tag.id}")
+        Logger.info(s"updated TagLookupCache with new tag: (internalName: ${tag.internalName}, id: ${tag.id})")
         return
       }
     }

--- a/app/repositories/TagRepository.scala
+++ b/app/repositories/TagRepository.scala
@@ -172,15 +172,16 @@ object TagLookupCache {
     while (true) {
       val currentTags = allTags.get()
 
-      val current = currentTags.find(_.id == tag.id).foreach(currentTag => {
+      currentTags.find(_.id == tag.id).foreach(currentTag => {
         if (tag.updatedAt < currentTag.updatedAt) {
-          return;
+          return
         }
       })
 
       val newTags = (tag :: currentTags.filterNot(_.id == tag.id)).sortBy(_.internalName)
 
       if (allTags.compareAndSet(currentTags, newTags)) {
+        Logger.info(s"updated TagLookupCache with new tag: {internalName: ${tag.internalName}, id: ${tag.id}")
         return
       }
     }

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -33,8 +33,14 @@ class KinesisConsumer(streamName: String, appName: String, processor: KinesisStr
     .config(kinesisClientLibConfiguration)
     .build()
 
-  def start() { Future{ worker.run() } }
-  def stop() { worker.shutdown() }
+  def start() {
+    Logger.info(s"starting Kinesis consumer for (stream: $streamName, appName: $appName)")
+    Future{ worker.run() }
+  }
+  def stop() {
+    Logger.info(s"stopping Kinesis consumer for (stream: $streamName, appName: $appName)")
+    worker.shutdown()
+  }
 
 }
 

--- a/tagmanager.iml
+++ b/tagmanager.iml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/app" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.11.12:jar" level="project" />
+  </component>
+</module>

--- a/test/repositories/TagLookupCacheTest.scala
+++ b/test/repositories/TagLookupCacheTest.scala
@@ -1,0 +1,70 @@
+package repositories
+
+import model.Tag
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+
+class TagLookupCacheTest extends FlatSpec with BeforeAndAfterEach with Matchers {
+
+  private val cache = TagLookupCache
+
+  override def beforeEach(): Unit = cache.allTags.set(Nil)
+
+  behavior of "TagLookupCache.insertTag"
+
+  it should "insert new tag to cache" in {
+
+    val testTag = generateTestTag("test", 1, 0)
+    cache.insertTag(testTag)
+
+    cache.allTags.get.contains(testTag) shouldEqual true
+  }
+
+  it should "update the tag if the cache have older version of tag" in {
+    val tagId = 1
+    val testTag = generateTestTag("test", tagId, 0)
+
+    cache.insertTag(testTag)
+
+    cache.allTags.get.find(_.id == tagId).get shouldEqual testTag
+
+    val testTagAfterUpdate = generateTestTag("test updated", tagId, 1)
+
+    cache.insertTag(testTagAfterUpdate)
+    cache.allTags.get.size shouldEqual 1
+    cache.allTags.get.find(_.id == tagId).get shouldEqual testTagAfterUpdate
+  }
+
+  it should "do not update the tag if the cache have already more up to date tag version" in {
+    val tagId = 1
+    val mostRecentTag = generateTestTag("test", tagId, 1)
+    cache.insertTag(mostRecentTag)
+
+    val notUpToDateTestTagForUpdateRequestWith = generateTestTag("test updated", tagId, 0)
+
+    cache.insertTag(notUpToDateTestTagForUpdateRequestWith)
+    cache.allTags.get.size shouldEqual 1
+    cache.allTags.get.find(_.id == tagId).get shouldEqual mostRecentTag
+  }
+
+  private def generateTestTag(tInternalName: String, tid: Long, tUpdatedAt: Long) = {
+    Tag(
+      id = tid,
+      path = "test",
+      pageId = 1,
+      `type` = "Topic",
+      internalName = tInternalName,
+      externalName = "",
+      slug = "",
+      comparableValue = "",
+      section = None,
+      publication = None,
+      isMicrosite = false,
+      trackingInformation = None,
+      campaignInformation = None,
+      adBlockingLevel = None,
+      contributionBlockingLevel = None,
+      updatedAt = tUpdatedAt
+    )
+  }
+
+}


### PR DESCRIPTION
Introducing slightly more logs for TagLookupCache
It was not obvious before as if the tags were actually updated as TagEvent may not contain any tag as it is Option (coverd in logs) and the tag update function may ignore the tag update event

change includes as well adding unit tests for `insertTag` function