### PR TITLE
Update TagSyncUpdateProcessor.scala to change error log to info

### DIFF
--- a/app/modules/clustersync/TagSyncUpdateProcessor.scala
+++ b/app/modules/clustersync/TagSyncUpdateProcessor.scala
@@ -44,7 +44,7 @@ object TagSyncUpdateProcessor extends KinesisStreamRecordProcessor {
   }
 
   private def updateTagsLookupCache(tagEvent: TagEvent): Unit = {
-    Logger.error(s"TagEvent received: \n $tagEvent")
+    Logger.info(s"TagEvent received: \n $tagEvent")
     tagEvent.eventType match {
       case EventType.Update =>
         Logger.info(s"inserting updated tag ${tagEvent.tagId} into lookup cache")


### PR DESCRIPTION
## What does this change?
 
The changed error log looks like an info to me, and is currently polluting TM logs.

## How to test

Deploy to CODE (or PROD, as this change should be transparent to users). The logs for this line should be emitted at level `info`.
