### PR TITLE
Move tagmanager to Graviton instances

### DIFF
--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -43,12 +43,12 @@ Mappings:
       MinSize: 1
       MaxSize: 2
       DesiredCapacity: 1
-      InstanceType: t3.medium
+      InstanceType: t4g.medium
     PROD:
       MinSize: 3
       MaxSize: 6
       DesiredCapacity: 3
-      InstanceType: t3.medium
+      InstanceType: t4g.medium
 Resources:
   TagManagerRole:
     Type: AWS::IAM::Role

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
     parameters:
       amiTags:
         BuiltBy: amigo
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-bionic-java8-ARM
         AmigoStage: PROD
       amiEncrypted: true
       prependStackToCloudFormationStackName: false


### PR DESCRIPTION
## What does this change?

Moves tagmanager to the new Graviton instances.

## How to test

The app should work as before! Tested in CODE – riffraff includes the CF deploy, so merging should update the CF and then deploy with the new instance type.

## How can we measure success?

TM runs on Graviton.

## Have we considered potential risks?

Tested in CODE. IIRC deploying a previous build should be enough to move us back to the previous instance type.
