### PR TITLE
Revert "Move tagmanager to Graviton instances"

### DIFF
--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -43,12 +43,12 @@ Mappings:
       MinSize: 1
       MaxSize: 2
       DesiredCapacity: 1
-      InstanceType: t4g.medium
+      InstanceType: t3.medium
     PROD:
       MinSize: 3
       MaxSize: 6
       DesiredCapacity: 3
-      InstanceType: t4g.medium
+      InstanceType: t3.medium
 Resources:
   TagManagerRole:
     Type: AWS::IAM::Role

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
     parameters:
       amiTags:
         BuiltBy: amigo
-        Recipe: editorial-tools-bionic-java8-ARM
+        Recipe: editorial-tools-xenial-java8
         AmigoStage: PROD
       amiEncrypted: true
       prependStackToCloudFormationStackName: false


### PR DESCRIPTION
Reverts guardian/tagmanager#389 rerevert at the end of the month. @srbd 