### PR TITLE
Remove SSH security group

### DIFF
--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -195,16 +195,6 @@ Resources:
       Path: /
       Roles:
       - !Ref 'TagManagerRole'
-  SSHSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Allow SSH access from the office
-      VpcId: !Ref 'VpcId'
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-        CidrIp: 0.0.0.0/0
   AppServerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -290,7 +290,6 @@ Resources:
       ImageId: !Ref 'AMI'
       SecurityGroups:
       - !Ref 'AppServerSecurityGroup'
-      - !Ref 'SSHSecurityGroup'
       - !Ref 'VulnerabilityScanningSecurityGroup'
       InstanceType: !FindInMap [Config, !Ref 'Stage', InstanceType]
       IamInstanceProfile: !Ref 'TagManagerInstanceProfile'


### PR DESCRIPTION
## What does this change?

Remove SSH access for the tag manager boxes.

## How to test

Update the CODE stack, and check our [security dashboard]( https://security-hq.gutools.co.uk/security-groups/composer). It should no longer list the security group as allowing SSH access.
