### PR TITLE
Add IMDSv2 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ scalacOptions ++= Seq(
 resolvers += "Guardian Bintray" at "https://dl.bintray.com/guardian/editorial-tools"
 
 lazy val dependencies = Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.11.259",
+  "com.amazonaws" % "aws-java-sdk" % "1.11.678",
   "com.amazonaws" % "amazon-kinesis-client" % "1.8.9",
   "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.3.0",
   "com.gu" %% "editorial-permissions-client" % "0.2",

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -283,6 +283,8 @@ Resources:
       - !Ref 'VulnerabilityScanningSecurityGroup'
       InstanceType: !FindInMap [Config, !Ref 'Stage', InstanceType]
       IamInstanceProfile: !Ref 'TagManagerInstanceProfile'
+      MetadataOptions:
+        HttpTokens: required
       UserData:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev


### PR DESCRIPTION
## What does this change?

Upversions aws-sdk to enable instances to use [IMDSv2](https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md), and alter the CFN to use it.

## How to test

The app should work as before. When deployed, IMDSv1 usage should stop. CODE:

<img width="372" alt="Screenshot 2021-04-19 at 15 54 11" src="https://user-images.githubusercontent.com/7767575/115256863-83163800-a127-11eb-9edb-8fb4f0e95434.png">



