### PR TITLE
Remove bintray as a resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,6 @@ scalacOptions ++= Seq(
   "-feature"
 )
 
-resolvers += "Guardian Bintray" at "https://dl.bintray.com/guardian/editorial-tools"
-
 lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.11.678",
   "com.amazonaws" % "amazon-kinesis-client" % "1.8.9",


### PR DESCRIPTION
## What does this change?
Removes Bintray as a resolver from build.sbt and re-sources orphaned packages. One package updated in this PR: #397

## How to test
Follow [these instructions](https://docs.google.com/document/d/1oWJs5I1TnCQkoiswMLRI6zaU1nvRXw1onVvoktsY43U/edit#) to prevent Bintray from resolving locally, and build the project. Is it successful?