### PR TITLE
Improve error handling for sponsorship image upload

### DIFF
--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -39,7 +39,6 @@ class Support(
 
   def checkFileExtension(image: File, filename: String): Either[String, File] = {
     val fileExtension = if(filename.contains(".")) filename.substring(filename.lastIndexOf(".")) else ""
-    }
 
     fileExtension match { 
       case ".jpg" => Right(image)

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -79,7 +79,7 @@ class Support(
     val requiredHeight = req.getQueryString("height").map(_.toLong)
 
     val imageValidationResult = for {
-      fileWithValidExtension <- checkFileExtension(picture.file, filename)
+      fileWithValidExtension <- checkFileExtension(picture.path.toFile, filename)
       image <- validateImageDimensions(fileWithValidExtension, requiredWidth, requiredHeight)
     } yield image
 

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -47,7 +47,7 @@ class Support(
       case ".jpg" => Right(image)
       case ".jpeg" => Right(image)
       case ".png" => Right(image)
-      case _ => Left("Image must have a file extension of '.jpg' or '.png'")
+      case _ => Left("Image must have a file extension of '.png' or '.jpg'")
     }
   }
 

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -47,6 +47,7 @@ class Support(
       case ".jpg" => Right(image)
       case ".jpeg" => Right(image)
       case ".png" => Right(image)
+      case ".bmp" => Right(image) // BMP is not preferable, but is technically supported.
       case _ => Left("Image must have a file extension of '.png' or '.jpg'")
     }
   }

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -65,9 +65,8 @@ class Support(
       case (None, Some(height)) => height >= ImageMetadataService.imageHeight(image)
       case (Some(width), Some(height)) => width >= ImageMetadataService.imageWidth(image) && height >= ImageMetadataService.imageHeight(image)
     }
-    dimensionsAreValid match {
-      case true => Right(image)
-      case false => Left(s"Image must have dimensions w:${requiredWidth.getOrElse("Not Specified")}px h:${requiredHeight.getOrElse("Not Specified")}px")
+    if (dimensionsAreValid) Right(image) 
+    else Left(s"Image must have dimensions w:${requiredWidth.getOrElse("Not Specified")}px h:${requiredHeight.getOrElse("Not Specified")}px")
     }
   }
 

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -78,8 +78,9 @@ class Support(
       image <- validateImageDimensions(fileWithValidExtension, requiredWidth, requiredHeight)
     } yield image
 
-    imageValidationResult match {
-      case Right(file) => {
+    imageValidationResult.fold(
+      err => BadRequest(err),
+      file => {
         val dateSlug = new DateTime().toString("dd/MMM/yyyy")
         val logoPath = s"commercial/sponsor/${dateSlug}/${UUID.randomUUID}-${filename}"
         val contentType = req.contentType
@@ -107,9 +108,7 @@ class Support(
           case Left(err: FetchError) => InternalServerError(err.errMsg)
           case Left(err: InvalidImage) => UnprocessableEntity(err.errMsg)
         }
-      }
-      case Left(err) => BadRequest(err)
-    }
+    })
   }
 
   def previewCapiProxy(path: String) = APIAuthAction { request =>

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -64,9 +64,8 @@ class Support(
       case (None, Some(height)) => height >= ImageMetadataService.imageHeight(image)
       case (Some(width), Some(height)) => width >= ImageMetadataService.imageWidth(image) && height >= ImageMetadataService.imageHeight(image)
     }
-    if (dimensionsAreValid) Right(image) 
+    if(dimensionsAreValid) Right(image)
     else Left(s"Image must have dimensions w:${requiredWidth.getOrElse("Not Specified")}px h:${requiredHeight.getOrElse("Not Specified")}px")
-    }
   }
 
   def uploadLogo(filename: String) = APIAuthAction(parse.temporaryFile) { req =>

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -38,9 +38,7 @@ class Support(
   private val httpClient = new OkHttpClient.Builder().connectTimeout(5, TimeUnit.SECONDS).build
 
   def checkFileExtension(image: File, filename: String): Either[String, File] = {
-    val fileExtension = filename.contains(".") match {
-      case true => filename.substring(filename.lastIndexOf("."));
-      case false => ""
+    val fileExtension = if(filename.contains(".")) filename.substring(filename.lastIndexOf(".")) else ""
     }
 
     fileExtension match { 

--- a/public/components/SponsorshipEdit/SponsorLogo.react.js
+++ b/public/components/SponsorshipEdit/SponsorLogo.react.js
@@ -24,12 +24,19 @@ export default class SponsorEdit extends React.Component {
     this.props.onImageUpdated(undefined);
   }
 
+  constructErrorMessage(error){
+    if (error.status === 400) { // 400 errors are returned by our application, with useful responseText
+      return {errorMessage: error.responseText}
+    } else return {errorMessage: error.statusText} // Other errors are returned by nginx, where statusText is more useful
+  }
+
   fileUploaded(e) {
     const resp = e.target;
     if (resp.status === 200) {
       this.props.onImageUpdated(JSON.parse(e.target.response));
+      this.setState({errorMessage: undefined});
     } else {
-      this.setState({errorMessage: resp.responseText});
+      this.setState(this.constructErrorMessage(e.target));
     }
   }
 
@@ -57,7 +64,12 @@ export default class SponsorEdit extends React.Component {
     if (!this.state.errorMessage) {
       return false;
     }
-    return (<div>{this.state.errorMessage}</div>);
+    return (
+      <div className="tag-edit__image__error">
+        <i className="i-failed-face-red" />
+        {this.state.errorMessage}
+      </div>
+    );
   }
 
   renderImageError(imageAsset) {

--- a/public/components/SponsorshipEdit/SponsorLogo.react.js
+++ b/public/components/SponsorshipEdit/SponsorLogo.react.js
@@ -27,7 +27,9 @@ export default class SponsorEdit extends React.Component {
   constructErrorMessage(error){
     if (error.status === 400) { // 400 errors are returned by our application, with useful responseText
       return {errorMessage: error.responseText}
-    } else return {errorMessage: error.statusText} // Other errors are returned by nginx, where statusText is more useful
+    } else {
+         return {errorMessage: error.statusText} // Other errors are returned by nginx, where statusText is more useful
+    }
   }
 
   fileUploaded(e) {

--- a/public/components/SponsorshipEdit/SponsorLogo.react.js
+++ b/public/components/SponsorshipEdit/SponsorLogo.react.js
@@ -72,18 +72,6 @@ export default class SponsorEdit extends React.Component {
     );
   }
 
-  renderImageError(imageAsset) {
-    if (imageAsset.height < 500 && imageAsset.width < 500 ) {
-      return false;
-    }
-
-    return (
-      <div className="tag-edit__image__error">
-        <i className="i-info-grey" /> Note: The uploaded logo is greater than 500px.
-      </div>
-    );
-  }
-
   render () {
 
     if (!this.props.logo) {
@@ -108,7 +96,6 @@ export default class SponsorEdit extends React.Component {
           <div className="tag-edit__image__remove clickable-icon" onClick={this.removeImage.bind(this)}>
             <i className="i-cross-red" />Remove image
           </div>
-          {this.renderImageError(imageAsset)}
         </div>
       </div>
     );

--- a/public/style/components/tag-edit/_index.scss
+++ b/public/style/components/tag-edit/_index.scss
@@ -112,7 +112,9 @@ $tag-edit-padding: $standard-padding/2;
 }
 
 .tag-edit__image__error {
-  margin-top: 5px;
+  font-size: 14px;
+  margin: 10px 0px;
+  color: $c-red;
 }
 
 .tag-edit__label, .tag-edit__label-inline {


### PR DESCRIPTION
## What does this change?

This PR makes some improvements to error handling of sponsorship image uploads.

Specifically, it:
- Identifies images with incorrect file extensions (e.g. anything that isn't a .png or .jpg), and shows a user-friendly error message in this instance
- Displays the error `statusMessage` for errors that come from nginx instead of showing the html for an error page (as was previously the case). This includes files that are too large to be handled in a request (error `413`).
- Displays the error in a more distinct style (red text, error icon, comfortable margin).
- Models the validation functions as a for comprehension of `Either`s, as a representation of potentially failing dependent operations.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `tagmanager` locally according to the [instructions on the readme](https://github.com/guardian/tagmanager) (with Composer credentials - run `npm install` then `./scripts/start.sh` if you've run the project before).

You will need additional permissions to access the commercial tags section, where you can create a sponsorship. You can [give these to yourself](https://permissions.code.dev-gutools.co.uk/admin) on CODE (also used for local development).

Try uploading bad file formats, files that are large, incorrect dimensions, correct dimensions.

#### This image should work:
![Initech](https://user-images.githubusercontent.com/34686302/143604678-44b089b4-4c43-4436-a4ca-0e8a1bd11e16.png)

## Images

**Incorrect file format:**
| Before | After |
| --- | --- |
|   ![image](https://user-images.githubusercontent.com/34686302/143604863-125f1322-a85c-48a9-98a0-526dd8fc1b7a.png) | ![image](https://user-images.githubusercontent.com/34686302/143605504-32f7daa5-91eb-4fae-a93d-c4863e9ad5ce.png) |

**File too large:**
* The error message here is derived from nginx - it's not particularly user-friendly, but I feel it's better than an html document - using nginx's error message should allow us to describe a greater range of http error statuses without writing specific messages for the less likely ones.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/34686302/143605582-abaae049-8653-4811-a94f-140c3961444f.png) | ![image](https://user-images.githubusercontent.com/34686302/143605440-8d25142c-68ec-4fd1-8b92-75ad19c6f8d0.png) |