### PR TITLE
Adding a new campaign category of email for newsletter embed use

### DIFF
--- a/public/constants/campaignTagTypes.js
+++ b/public/constants/campaignTagTypes.js
@@ -1,3 +1,4 @@
 export const campaignTagTypes = [
-    {name: 'Callout', value: 'callout'}
+    {name: 'Callout', value: 'callout'},
+    {name: 'Email', value: 'email'}
 ];


### PR DESCRIPTION
## What does this change?

Adding a new campaign type of "email" to allow creating tags that will drive email sign up embeds in articles. 

Please see this document for a more detailed description of why this change is needed: https://docs.google.com/document/d/1bnTUhmACDgASeWfFpJV9Aqc14Ce6KtusgXdK6t9sazY/edit?usp=sharing

## How to test

When choosing a tag type of "Campaign" there should now be a campaign type of "email" available along side "callout"
