### PR TITLE
Revert "Upgrade to panda v1.0.6"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ public/build
 npm-debug.log
 
 .DS_Store
-.bsp

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
+addCommandAlias("dist", ";riffRaffArtifact")
+
 import play.sbt.PlayImport.PlayKeys._
 
 name := "tag-manager"
 
 version := "1.0"
-
-lazy val scalaVer = "2.12.16"
 
 scalacOptions ++= Seq(
   "-target:jvm-1.8",
@@ -14,16 +14,10 @@ scalacOptions ++= Seq(
   "-feature"
 )
 
-lazy val awsVersion = "1.11.1034"
-
 lazy val dependencies = Seq(
-  "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
-  "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
-  "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion,
-  "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
-  "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
+  "com.amazonaws" % "aws-java-sdk" % "1.11.678",
   "com.amazonaws" % "amazon-kinesis-client" % "1.8.9",
-  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
+  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
   "com.gu" %% "editorial-permissions-client" % "0.9",
   ws, // for panda
   "ai.x" %% "play-json-extensions" % "0.42.0",
@@ -35,7 +29,7 @@ lazy val dependencies = Seq(
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",
-  "com.gu"  %% "panda-hmac-play_2-8" % "2.0.1",
+  "com.gu"  %% "panda-hmac-play_2-6" % "1.3.1",
   "com.gu" %% "content-api-client-aws" % "0.5",
   "com.beachape" %% "enumeratum" % "1.5.13",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
@@ -70,10 +64,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact
     packageDescription := """manage tags""",
 
     Compile / doc := (target.value / "none"),
-    scalaVersion := scalaVer,
-    ThisBuild / scalaVersion := scalaVer,
-    libraryDependencies ++= dependencies,
-
-    gzip / includeFilter := "*.html" || "*.css" || "*.js",
-    pipelineStages := Seq(digest, gzip),
+    scalaVersion := "2.12.13",
+    ThisBuild / scalaVersion := "2.12.13",
+    libraryDependencies ++= dependencies
   )
+  .settings(TagManager.settings: _*)

--- a/project/TagManager.scala
+++ b/project/TagManager.scala
@@ -1,0 +1,21 @@
+import com.typesafe.sbt.web.PathMapping
+import com.typesafe.sbt.web.pipeline.Pipeline
+import sbt._
+import sbt.Keys._
+
+import com.typesafe.sbt.web.Import._
+import com.typesafe.sbt.digest.Import._
+import com.typesafe.sbt.gzip.Import._
+import com.typesafe.sbt.web.Import.WebKeys._
+
+
+/**
+ * Front-end specific settings for Tag Manager in SBT.
+ */
+object TagManager {
+  val gzipSettings = Seq(includeFilter in gzip := "*.html" || "*.css" || "*.js")
+
+  val assetPipelineSettings = Seq(pipelineStages := Seq(digest, gzip))
+
+  val settings = gzipSettings ++ assetPipelineSettings
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.5.7

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Before you run for the first time you will need to run `./scripts/setup.sh` this
 dependencies needed for the app (you may need to install npm before you can run this successfully). If any frontend
 dependencies are changed you should re run the setup script.
 
-**N.B.** If you encounter errors during setup when installing npm packages (particularly `node-sass`), use [nvm](https://github.com/creationix/nvm) to install and use the expected version of nodejs.
+**N.B.** If you encounter errors during setup when installing npm packages (particularly `node-sass`), use [nvm](https://github.com/creationix/nvm) to install and use `node v6.14.3`
 
 The Nginx setup uses the [dev-nginx](https://github.com/guardian/dev-nginx) tool. After running this the tag manager
 will be available on [https://tagmanager.local.dev-gutools.co.uk](https://tagmanager.local.dev-gutools.co.uk)


### PR DESCRIPTION
Reverts guardian/tagmanager#442

There are some version conflicts in the aws library that make this fail