### PR TITLE
Include upgraded aws-java-sdk-sts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
+  "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.8.9",
   "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
   "com.gu" %% "editorial-permissions-client" % "0.9",


### PR DESCRIPTION
## What does this change?

#442 included upgrades to AWS SDK modules, and changed to only include those that were required. The requirement for the STS module was missed, which meant that the resolved version was in 1.9.x (via kinesis-logstash-appender) causing runtime errors.

Explicitly depend upon the desired version of `aws-java-sdk-sts`