### PR TITLE
Changes the "bucket" parameter to "bucketSsmLookup: true" within the …

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -5,7 +5,7 @@ deployments:
   tag-manager:
     type: autoscaling
     parameters:
-      bucket: composer-dist
+      bucketSsmLookup: true
     dependencies:
       - cloudformation
 


### PR DESCRIPTION
…riff-raff.yaml

See Akash's email (riff-raff.yaml and bucket names) - Removes warning from projects that explicitly set a bucket name in riff-raff.yaml for autoscaling or aws-lambda deployments by changing the "bucket" parameter to "bucketSsmLookup: true" within the riff-raff.yaml

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Warnings Encountered' should no longer appear in the Status tab in 'History' in RiffRaff

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy something - look at 'History' in RiffRaff - 'Warnings Encountered' should no longer appear in the Status tab

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
