### PR TITLE
Remove GAPI script include

### DIFF
--- a/app/views/Application/app.scala.html
+++ b/app/views/Application/app.scala.html
@@ -10,6 +10,4 @@
     </script>
 
     <script src="@jsLocation"></script>
-
-    <script async src="https://apis.google.com/js/client.js?onload=init"></script>
 }


### PR DESCRIPTION
## What does this change?

I can't see any evidence of the google api client being used in this repo (searches for `google` and `gapi` return nothing relevant) so delete the script tag that adds it to tagmanager.