### PR TITLE
Add pocketcasts url

### DIFF
--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -18,7 +18,8 @@ case class PodcastMetadata( linkUrl: String,
                             podcastType: Option[String] = None,
                             googlePodcastsUrl: Option[String] = None,
                             spotifyUrl: Option[String] = None,
-                            acastId: Option[String] = None
+                            acastId: Option[String] = None,
+                            pocketCastsUrl: Option[String] = None
 ) {
 
   def asThrift = ThriftPodcastMetadata(
@@ -34,7 +35,8 @@ case class PodcastMetadata( linkUrl: String,
     podcastType =       podcastType,
     googlePodcastsUrl = googlePodcastsUrl,
     spotifyUrl =        spotifyUrl,
-    acastId =           acastId
+    acastId =           acastId,
+    pocketCastsUrl =    pocketCastsUrl
   )
 
   def asExportedXml = {
@@ -46,6 +48,7 @@ case class PodcastMetadata( linkUrl: String,
     <GooglePodcastsUrl>{this.googlePodcastsUrl.getOrElse("")}</GooglePodcastsUrl>
     <SpotifyUrl>{this.spotifyUrl.getOrElse("")}</SpotifyUrl>
     <AcastId>{this.acastId.getOrElse("")}</AcastId>
+    <PocketCastsUrl>{this.pocketCastsUrl.getOrElse("")}</PocketCastsUrl>
     <clean>{this.clean}</clean>
     <explicit>{this.explicit}</explicit>
     <image>{this.image.map(x => x.asExportedXml).getOrElse("")}</image>
@@ -72,7 +75,8 @@ object PodcastMetadata {
       podcastType =       thriftPodcastMetadata.podcastType,
       googlePodcastsUrl = thriftPodcastMetadata.googlePodcastsUrl,
       spotifyUrl =        thriftPodcastMetadata.spotifyUrl,
-      acastId =           thriftPodcastMetadata.acastId
+      acastId =           thriftPodcastMetadata.acastId,
+      pocketCastsUrl =    thriftPodcastMetadata.pocketCastsUrl
     )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val dependencies = Seq(
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client-default" % "17.24.1",
-  "com.gu" %% "tags-thrift-schema" % "2.8.2",
+  "com.gu" %% "tags-thrift-schema" % "2.8.1",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val dependencies = Seq(
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client-default" % "17.24.1",
-  "com.gu" %% "tags-thrift-schema" % "2.8.0",
+  "com.gu" %% "tags-thrift-schema" % "2.8.2",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "com.gu" % "kinesis-logback-appender" % "1.0.5",
   "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -62,6 +62,12 @@ export default class PodcastMetadata extends React.Component {
     }));
   }
 
+  updatePocketCastsUrl(e) {
+    this.props.updateTag(R.merge(this.props.tag, {
+      podcastMetadata: R.merge(this.props.tag.podcastMetadata, {pocketCastsUrl: e.target.value})
+    }));
+  }
+
   updateiTunesBlock(e) {
     this.props.updateTag(R.merge(this.props.tag, {
       podcastMetadata: R.merge(this.props.tag.podcastMetadata, {iTunesBlock: e.target.checked})
@@ -174,6 +180,14 @@ export default class PodcastMetadata extends React.Component {
                  className="tag-edit__input"
                  value={this.props.tag.podcastMetadata.spotifyUrl || ''}
                  onChange={this.updateSpotifyUrl.bind(this)}
+                 disabled={!this.props.tagEditable}/>
+        </div>
+        <div className="tag-edit__field">
+          <label className="tag-edit__label">Pocket Casts Url</label>
+          <input type="text"
+                 className="tag-edit__input"
+                 value={this.props.tag.podcastMetadata.pocketCastsUrl || ''}
+                 onChange={this.updatePocketCastsUrl.bind(this)}
                  disabled={!this.props.tagEditable}/>
         </div>
         <div className="tag-edit__field">


### PR DESCRIPTION
## What does this change?

MSS team are looking to provide Pocket Casts URL for podcast cards in MAPI so that the native app can allow users to open podcast with the Pocket Casts app directly.

This PR adds a pocketCastsUrl to tagmanager so that PocketCasts URL can be added to podcast tags.

Paired with @silvacb 

## How to test

We deployed the change to CODE and confirmed that the new UI field was added.

We tried setting the pocket casts URL in the new field and we were able to retrieve the URL when we opened the tag later.

## Images

![Screenshot 2023-02-22 at 14 35 32](https://user-images.githubusercontent.com/89925410/220655609-0df59676-8638-467c-9a2b-366cbff3a179.png)
