### PR TITLE
consistent sponsorship read

### DIFF
--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -70,6 +70,8 @@ case class Tag(
     capiSectionId     = capiSectionId,
     trackingInformation = trackingInformation.map(_.asThrift),
     updatedAt = Some(updatedAt),
+    // TODO should this line be flatMap? if there is an active sponsorship ID here, then that sponsorship should
+    // exist in the repository. If it doesn't, unexpected behaviour can & will happen downstream!!
     activeSponsorships = if (activeSponsorships.isEmpty) None else Some(activeSponsorships.flatMap {sid =>
       SponsorshipRepository.getSponsorship(sid).map(_.asThrift)
     }),

--- a/app/repositories/SponsorshipRepository.scala
+++ b/app/repositories/SponsorshipRepository.scala
@@ -1,9 +1,9 @@
 package repositories
 
-import com.amazonaws.services.dynamodbv2.document.ScanFilter
+import com.amazonaws.services.dynamodbv2.document.spec.GetItemSpec
+import com.amazonaws.services.dynamodbv2.document.{PrimaryKey, ScanFilter}
 import model.Sponsorship
 import org.joda.time.DateTime
-import helpers.JodaDateTimeFormat._
 import services.Dynamo
 
 import scala.collection.JavaConversions._
@@ -11,7 +11,10 @@ import scala.collection.JavaConversions._
 
 object SponsorshipRepository {
   def getSponsorship(id: Long) = {
-    Option(Dynamo.sponsorshipTable.getItem("id", id)).map(Sponsorship.fromItem)
+    val getItemSpec = new GetItemSpec()
+      .withPrimaryKey(new PrimaryKey("id", id))
+      .withConsistentRead(true)
+    Option(Dynamo.sponsorshipTable.getItem(getItemSpec)).map(Sponsorship.fromItem)
   }
 
   def updateSponsorship(sponsorship: Sponsorship) = {


### PR DESCRIPTION
## What does this change?

We have previously seen problems where the sponsorship is immediately read back out of the database, but (due to dynamodb being eventually consistent by default) we get old data back, causing strange behaviour downstream.

Read as strongly consistent: super easy to implement, but does increase table read usage. #487 improves further on this to avoid needing to do this read at all.

There may be other places in the codebase behaving in the same way - it might be a good idea to apply this refactor(s) to all.

