### PR TITLE
add stale PR checker

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+# Automatically mark any pull requests that have been inactive for 30 days as "Stale"
+# then close them 3 days later if there is still no activity.
+name: "Stale PR Handler"
+
+on:
+  schedule:
+    # Check for Stale PRs every Monday to Thursday morning
+    # Don't check on Fridays as it wouldn't be very nice to have a bot mark your PR as Stale on Friday and then close it on Monday morning!
+    - cron: "0 6 * * MON-THU"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        id: stale
+        # Read about options here: https://github.com/actions/stale#all-options
+        with:
+          # never automatically mark issues as stale
+          days-before-issue-stale: -1
+
+          # Wait 30 days before marking a PR as stale
+          days-before-stale: 30
+          stale-pr-message: >
+            This PR is stale because it has been open 30 days with no activity.
+            Unless a comment is added or the “stale” label removed, this will be closed in 3 days
+
+          # Wait 3 days after a PR has been marked as stale before closing
+          days-before-close: 3
+          close-pr-message: This PR was closed because it has been stalled for 3 days with no activity.
+
+          # Ignore PR's raised by Dependabot
+          exempt-pr-labels: "dependencies"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Automatically mark any pull requests that have been inactive for 30 days as "Stale" then close them 3 days later if there is still no activity.

Uses standard template: https://github.com/actions/stale#all-options

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
I think this PR would need to be merged and we can see if it marks and closes stale PRs accordingly

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Stale PRs are marked and closed according to set timelines
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
Low risk as we can always re-open stale PRs if needed
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
