### PR TITLE
Fix load balancer App tag

### DIFF
--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -250,7 +250,7 @@ Resources:
       - Key: Stack
         Value: flexible
       - Key: App
-        Value: feeds
+        Value: tag-manager
   AutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:


### PR DESCRIPTION
## What does this change?

I think this load balancer has an incorrect `App` tag? This PR fixes the tagging to make it consistent with the [ASG tags](https://github.com/guardian/tagmanager/blob/70393ec374d33d5a075655c4bbf04886f3fb80ba/cloudformation/tag-manager.yaml#L275).

## How to test

Tag updates should be safe, but I will deploy this to `CODE` before merging to confirm this.