### PR TITLE
Add 5xx alarm

### DIFF
--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -37,6 +37,10 @@ Parameters:
   CapiPreviewRole:
     Type: String
     Description: ARN of the CAPI preview role
+  AlertTopicArn:
+    Description: The ARN of the SNS topic to notify when an alarm occurs
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /account/services/alert.topic.arn
 Mappings:
   Config:
     CODE:
@@ -303,3 +307,46 @@ Resources:
             Ref: CapiPreviewRole
       Roles:
       - Ref: TagManagerRole
+  Tagmanager5XXAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      TreatMissingData: notBreaching
+      AlarmDescription: Tag manager is returning 5x responses
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: '0'
+      EvaluationPeriods: '3'
+      Metrics:
+        - Expression: backend5XX + elb5XX
+          Id: sum
+          Label: "Count of Backend AND ELB 5XX"
+          ReturnData: true
+        - Id: backend5XX
+          ReturnData: false
+          Label: "backend5XX"
+          MetricStat:
+            Metric:
+              MetricName: HTTPCode_Backend_5XX
+              Namespace: AWS/ELB
+              Dimensions:
+              - Name: LoadBalancerName
+                Value: !Ref 'TagManagerLoadBalancer'
+            Period: 300
+            Stat: Sum
+            Unit: Count
+        - Id: elb5XX
+          ReturnData: false
+          Label: "elb5XX"
+          MetricStat:
+            Metric:
+              MetricName: HTTPCode_ELB_5XX
+              Namespace: AWS/ELB
+              Dimensions:
+              - Name: LoadBalancerName
+                Value: !Ref 'TagManagerLoadBalancer'
+            Period: 300
+            Stat: Sum
+            Unit: Count
+      AlarmActions:
+        - !Ref 'AlertTopicArn'
+      OKActions:
+        - !Ref 'AlertTopicArn'

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -41,6 +41,8 @@ Parameters:
     Description: The ARN of the SNS topic to notify when an alarm occurs
     Type: AWS::SSM::Parameter::Value<String>
     Default: /account/services/alert.topic.arn
+Conditions:
+  IsProd: !Equals [!Ref Stage, PROD]
 Mappings:
   Config:
     CODE:
@@ -309,6 +311,7 @@ Resources:
       - Ref: TagManagerRole
   Tagmanager5XXAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
     Properties:
       TreatMissingData: notBreaching
       AlarmDescription: Tag manager is returning 5x responses

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -316,7 +316,7 @@ Resources:
       TreatMissingData: notBreaching
       AlarmDescription: Tag manager is returning 5x responses
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: '0'
+      Threshold: '10'
       EvaluationPeriods: '3'
       Metrics:
         - Expression: backend5XX + elb5XX


### PR DESCRIPTION
DevX have recommended that we add an alert on 5xx errors. They have identified that occasionally this services returns a large number of 5xx response, and it would be good for us to be notified.

As it happens, this 5xx have always been related to bad requests being misreported as server errors (https://github.com/guardian/pan-domain-authentication/pull/118), but still probably worth adding an alert.

The approach is baed on targeting and media-service alerts.

Conveniently `/account/services/alert.topic.arn` is already set for this account.
