### PR TITLE
bump aws libraries

### DIFF
--- a/app/repositories/ExternalReferencesTypeRepository.scala
+++ b/app/repositories/ExternalReferencesTypeRepository.scala
@@ -5,7 +5,7 @@ import model.ExternalReferenceType
 import play.api.libs.json.JsValue
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.collection.convert.ImplicitConversions._
 
 
 object ExternalReferencesTypeRepository {

--- a/app/repositories/JobRepository.scala
+++ b/app/repositories/JobRepository.scala
@@ -7,10 +7,11 @@ import com.amazonaws.services.dynamodbv2.model._
 import model.Section
 import model.jobs.{Job, JobStatus}
 import play.api.libs.json.JsValue
+
 import scala.util.control.NonFatal
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.collection.convert.ImplicitConversions._
 
 
 object JobRepository {

--- a/app/repositories/PillarAuditRepository.scala
+++ b/app/repositories/PillarAuditRepository.scala
@@ -2,11 +2,10 @@ package repositories
 
 import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition
 import model.PillarAudit
-import helpers.JodaDateTimeFormat._
 import org.joda.time.{DateTime, Duration, ReadableDuration}
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.collection.convert.ImplicitConversions._
 
 
 object PillarAuditRepository {

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -1,12 +1,10 @@
 package services
 
 import java.util.Properties
-
 import com.amazonaws.services.s3.model.GetObjectRequest
 import services.Config._
 
-import scala.collection.JavaConversions._
-
+import scala.collection.convert.ImplicitConversions._
 
 object Config extends AwsInstanceTags {
 

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -1,7 +1,6 @@
 package services
 
 import java.nio.ByteBuffer
-
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, ShutdownReason, Worker}
@@ -13,7 +12,7 @@ import org.apache.thrift.protocol.{TCompactProtocol, TProtocol}
 import org.apache.thrift.transport.TIOStreamTransport
 import play.api.Logging
 
-import scala.collection.JavaConversions._
+import scala.collection.convert.ImplicitConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.language.implicitConversions

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalacOptions ++= Seq(
   "-feature"
 )
 
-lazy val awsVersion = "1.12.403"
+lazy val awsVersion = "1.12.472"
 
 lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps AWS versions to deal with some vulns

## How to test

`sbt clean compile test dependencyBrowseTree`. The final command opens the dependency tree in a browser and allows you to check that the vulnerable versions are gone

## How can we measure success?

Fewer vuln counts

## Have we considered potential risks?

This PR has not been extensively tested beyond the above described, but AWS patch are basically never breaking, so this is fine to go out as is I reckon. 
