### PR TITLE
bump pan-domain-auth and permissions

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -34,7 +34,7 @@ class AppComponents(context: Context, config: Config)
   // to request them. Seems to be a timing bug...
   //
   // This should only be a temporary fix @ 2016/02/09
-//  Permissions.list(PermissionsUser("preload@permissions"))
+//  Permissions.listPermission(PermissionsUser("preload@permissions"))
 
   val panDomainSettings = new PanDomainAuthSettingsRefresher(
     domain = config.pandaDomain,

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,4 +1,3 @@
-import com.gu.editorial.permissions.client.PermissionsUser
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import controllers.AssetsComponents
 import model.jobs.JobRunner
@@ -35,7 +34,7 @@ class AppComponents(context: Context, config: Config)
   // to request them. Seems to be a timing bug...
   //
   // This should only be a temporary fix @ 2016/02/09
-  Permissions.list(PermissionsUser("preload@permissions"))
+//  Permissions.list(PermissionsUser("preload@permissions"))
 
   val panDomainSettings = new PanDomainAuthSettingsRefresher(
     domain = config.pandaDomain,

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,4 +1,6 @@
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
 import controllers.AssetsComponents
 import model.jobs.JobRunner
 import modules.clustersync.ClusterSynchronisation
@@ -12,6 +14,7 @@ import play.api.routing.Router
 import play.filters.HttpFiltersComponents
 import router.Routes
 import services._
+
 import scala.language.postfixOps
 
 class AppComponents(context: Context, config: Config)
@@ -28,13 +31,6 @@ class AppComponents(context: Context, config: Config)
   new ClusterSynchronisation(context.lifecycle)
   new JobRunner(context.lifecycle)
   new SponsorshipLifecycleJobs(context.lifecycle)
-
-  // This is requried because there's an issue in the permissions client
-  // which causes the permissions to come back as denied for the first person
-  // to request them. Seems to be a timing bug...
-  //
-  // This should only be a temporary fix @ 2016/02/09
-//  Permissions.listPermission(PermissionsUser("preload@permissions"))
 
   val panDomainSettings = new PanDomainAuthSettingsRefresher(
     domain = config.pandaDomain,

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -33,7 +33,7 @@ class Migration(
 
   def migratePaidContent = APIAuthAction(parse.multipartFormData) { req =>
     req.body.file("migrationFile").map{ jsonFile =>
-      val jsonString = Source.fromFile(jsonFile.ref.file, "UTF-8").getLines().mkString("\n")
+      val jsonString = Source.fromFile(jsonFile.ref.path.toFile, "UTF-8").getLines().mkString("\n")
 
       val json = Json.parse(jsonString)
       val sponsorships = json.as[List[Sponsorship]]

--- a/app/permissions/PermissionActionCheck.scala
+++ b/app/permissions/PermissionActionCheck.scala
@@ -34,6 +34,7 @@ abstract class BasePermissionCheck(
 // Tag Edit
 case class CreateTagPermissionsCheck()(implicit executionContext: ExecutionContext)
   extends BasePermissionCheck(Permissions.TagEdit, "create tag")
+
 case class UpdateTagPermissionsCheck()(implicit executionContext: ExecutionContext)
   extends BasePermissionCheck(Permissions.TagEdit, "update tag")
 

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -1,6 +1,6 @@
 package permissions
 
-import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
 import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 import services.Config
 

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -1,40 +1,65 @@
 package permissions
 
-import com.gu.editorial.permissions.client._
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 import services.Config
 
-import scala.concurrent.Future
+//import scala.concurrent.Future
 
-object Permissions extends PermissionsProvider {
+//object Permissions extends PermissionsProvider {
 
-  lazy val TagEdit = Permission("tag_edit", "tag-manager", PermissionDenied)
-  lazy val TagAdmin = Permission("tag_admin", "tag-manager", PermissionDenied)
-  lazy val CommercialTags = Permission("commercial_tags", "tag-manager", PermissionDenied)
-  lazy val TagUnaccessible = Permission("tag_no_one", "tag-manager", PermissionDenied)
+//  lazy val TagEdit = Permission("tag_edit", "tag-manager", PermissionDenied)
+//  lazy val TagAdmin = Permission("tag_admin", "tag-manager", PermissionDenied)
+//  lazy val CommercialTags = Permission("commercial_tags", "tag-manager", PermissionDenied)
+//  lazy val TagUnaccessible = Permission("tag_no_one", "tag-manager", PermissionDenied)
+//
+//  lazy val all = Seq(TagAdmin)
 
-  lazy val all = Seq(TagAdmin)
+//  implicit def config = PermissionsConfig(
+//    app = "tag-manager",
+//    all = all,
+//    s3BucketPrefix = Config().permissionsStage,
+//    s3Region = Some("eu-west-1")
+//  )
 
-  implicit def config = PermissionsConfig(
-    app = "tag-manager",
-    all = all,
-    s3BucketPrefix = Config().permissionsStage,
-    s3Region = Some("eu-west-1")
+//  def testUser(permission: Permission)(email: String): Future[PermissionAuthorisation] = {
+//    println("Permissions for: " + email)
+//    implicit val permissionsUser: PermissionsUser = PermissionsUser(email)
+//
+//    Permissions.get(permission)
+//  }
+//
+//  def getPermissionsForUser(email: String): Future[Map[String, Boolean]] = {
+//    implicit val permissionsUser: PermissionsUser = PermissionsUser(email)
+//
+//    Permissions.list.map(_.filter(_._1.app == "tag-manager").flatMap( _ match {
+//      case (p: Permission, PermissionGranted) => Map(p.name -> true)
+//      case (p: Permission, PermissionDenied) => Map(p.name -> false)
+//    }))
+//  }
+object Permissions {
+  val app = "tag-manager"
+
+  val TagEdit = PermissionDefinition("tag_edit", app)
+  val TagAdmin = PermissionDefinition("tag_admin", app)
+  val CommercialTags = PermissionDefinition("commercial_tags", app)
+  val TagUnaccessible = PermissionDefinition("tag_no_one", app)
+
+  private val permissionDefinitions = Map(
+    "tagEdit" -> TagEdit,
+    "tagAdmin" -> TagAdmin,
+    "commercialTags" -> CommercialTags,
+    "tagUnaccessible" -> TagUnaccessible
   )
 
-  def testUser(permission: Permission)(email: String): Future[PermissionAuthorisation] = {
+  private val credentials: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()
+
+  private val permissions: PermissionsProvider = PermissionsProvider(PermissionsConfig(Config().permissionsStage, Config().aws.region, credentials))
+
+  def testUser(email: String)(permission: PermissionDefinition): Boolean = {
     println("Permissions for: " + email)
-    implicit val permissionsUser: PermissionsUser = PermissionsUser(email)
-
-    Permissions.get(permission)
+    permissions.hasPermission(permission, email)
   }
-
-  def getPermissionsForUser(email: String): Future[Map[String, Boolean]] = {
-    implicit val permissionsUser: PermissionsUser = PermissionsUser(email)
-
-    Permissions.list.map(_.filter(_._1.app == "tag-manager").flatMap( _ match {
-      case (p: Permission, PermissionGranted) => Map(p.name -> true)
-      case (p: Permission, PermissionDenied) => Map(p.name -> false)
-    }))
-  }
+  def getPermissionsForUser(email: String): Map[String, Boolean] = permissionDefinitions.transform((_, permission) => permissions.hasPermission(permission, email))
 }
 

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -23,7 +23,7 @@ object Permissions {
 
   private val permissions: PermissionsProvider = PermissionsProvider(PermissionsConfig(Config().permissionsStage, Config().aws.region, credentials))
 
-  def testUser(email: String)(permission: PermissionDefinition): Boolean = {
+  def testUser(permission:PermissionDefinition)(email: String): Boolean = {
     println("Permissions for: " + email)
     permissions.hasPermission(permission, email)
   }

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -4,52 +4,19 @@ import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProvider
 import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 import services.Config
 
-//import scala.concurrent.Future
-
-//object Permissions extends PermissionsProvider {
-
-//  lazy val TagEdit = Permission("tag_edit", "tag-manager", PermissionDenied)
-//  lazy val TagAdmin = Permission("tag_admin", "tag-manager", PermissionDenied)
-//  lazy val CommercialTags = Permission("commercial_tags", "tag-manager", PermissionDenied)
-//  lazy val TagUnaccessible = Permission("tag_no_one", "tag-manager", PermissionDenied)
-//
-//  lazy val all = Seq(TagAdmin)
-
-//  implicit def config = PermissionsConfig(
-//    app = "tag-manager",
-//    all = all,
-//    s3BucketPrefix = Config().permissionsStage,
-//    s3Region = Some("eu-west-1")
-//  )
-
-//  def testUser(permission: Permission)(email: String): Future[PermissionAuthorisation] = {
-//    println("Permissions for: " + email)
-//    implicit val permissionsUser: PermissionsUser = PermissionsUser(email)
-//
-//    Permissions.get(permission)
-//  }
-//
-//  def getPermissionsForUser(email: String): Future[Map[String, Boolean]] = {
-//    implicit val permissionsUser: PermissionsUser = PermissionsUser(email)
-//
-//    Permissions.list.map(_.filter(_._1.app == "tag-manager").flatMap( _ match {
-//      case (p: Permission, PermissionGranted) => Map(p.name -> true)
-//      case (p: Permission, PermissionDenied) => Map(p.name -> false)
-//    }))
-//  }
 object Permissions {
   val app = "tag-manager"
 
-  val TagEdit = PermissionDefinition("tag_edit", app)
-  val TagAdmin = PermissionDefinition("tag_admin", app)
-  val CommercialTags = PermissionDefinition("commercial_tags", app)
-  val TagUnaccessible = PermissionDefinition("tag_no_one", app)
+  val TagEdit: PermissionDefinition = PermissionDefinition("tag_edit", app)
+  val TagAdmin: PermissionDefinition = PermissionDefinition("tag_admin", app)
+  val CommercialTags: PermissionDefinition = PermissionDefinition("commercial_tags", app)
+  val TagUnaccessible: PermissionDefinition = PermissionDefinition("tag_no_one", app)
 
   private val permissionDefinitions = Map(
-    "tagEdit" -> TagEdit,
-    "tagAdmin" -> TagAdmin,
-    "commercialTags" -> CommercialTags,
-    "tagUnaccessible" -> TagUnaccessible
+    "tag_edit" -> TagEdit,
+    "tag_admin" -> TagAdmin,
+    "commercial_tags" -> CommercialTags,
+    "tag_no_one" -> TagUnaccessible
   )
 
   private val credentials: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()

--- a/app/permissions/SectionSpecificPermissions.scala
+++ b/app/permissions/SectionSpecificPermissions.scala
@@ -17,24 +17,26 @@ object SectionPermissionMap {
 
 trait SectionSpecificPermissionActionFilter extends ActionFilter[UserRequest] {
 
-  val testAccess: (PermissionDefinition => (String => Future[Boolean]))
+  val testAccess: PermissionDefinition => String => Boolean;
   val restrictedAction: String
 
-  def commonTestAccess: PermissionDefinition => String => Future[Boolean] =
-    permission => email => Future.successful(Permissions.testUser(email)(permission))
+  def commonTestAccess: PermissionDefinition => String => Boolean =
+    Permissions.testUser
 
   override def filter[A](request: UserRequest[A]): Future[Option[Result]] = {
     request.body match {
       case b: AnyContent => {
         b.asJson.map { json =>
           val isMicrosite = (json \ "isMicrosite").as[Boolean]
-
           val permission = SectionPermissionMap(isMicrosite).getOrElse { return Future.successful(None) }
 
-          testAccess(permission)(request.user.email).map {
-            case true => None
-            case false => Some(Results.Unauthorized)
-          }(executionContext)
+          val hasAccess = testAccess(permission)(request.user.email)
+
+          if (hasAccess) {
+            return Future.successful(None)
+          } else {
+            return Future.successful(Some(Results.Unauthorized))
+          }
         }.getOrElse {
           Future.successful(Some(Results.BadRequest("Expecting Json data")))
         }
@@ -45,11 +47,11 @@ trait SectionSpecificPermissionActionFilter extends ActionFilter[UserRequest] {
 }
 
 case class UpdateSectionPermissionsCheck()(implicit val executionContext: ExecutionContext) extends SectionSpecificPermissionActionFilter {
-  val testAccess: PermissionDefinition => String => Future[Boolean] = commonTestAccess
+  val testAccess: PermissionDefinition => String => Boolean = commonTestAccess
   val restrictedAction = "update section"
 }
 
 case class CreateSectionPermissionsCheck()(implicit val executionContext: ExecutionContext) extends SectionSpecificPermissionActionFilter {
-  val testAccess: PermissionDefinition => String => Future[Boolean] = commonTestAccess
+  val testAccess: PermissionDefinition => String => Boolean = commonTestAccess
   val restrictedAction = "create section"
 }

--- a/app/permissions/SectionSpecificPermissions.scala
+++ b/app/permissions/SectionSpecificPermissions.scala
@@ -4,7 +4,7 @@ import com.gu.pandomainauth.action.UserRequest
 import com.gu.permissions.PermissionDefinition
 import play.api.mvc.{ActionFilter, AnyContent, Result, Results}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Future, ExecutionContext}
 
 object SectionPermissionMap {
   def apply(isMicrosite: Boolean): Option[PermissionDefinition] = {

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.14.10",
-  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
+  "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.3",
   "com.gu" %% "editorial-permissions-client" % "0.9",
   ws, // for panda
   "ai.x" %% "play-json-extensions" % "0.42.0",

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.14.10",
   "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.3",
-  "com.gu" %% "editorial-permissions-client" % "0.9",
+  "com.gu" %% "editorial-permissions-client" % "2.0",
   ws, // for panda
   "ai.x" %% "play-json-extensions" % "0.42.0",
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",

--- a/public/components/TagSearch.react.js
+++ b/public/components/TagSearch.react.js
@@ -114,7 +114,7 @@ export class TagSearch extends React.Component {
     }
 
     render () {
-        const canCreateTags = hasPermission("tag_edit");
+        const canCreateTags = hasPermission("tagEdit");
 
         return (
             <div className="tag-search">

--- a/public/components/TagSearch.react.js
+++ b/public/components/TagSearch.react.js
@@ -114,7 +114,7 @@ export class TagSearch extends React.Component {
     }
 
     render () {
-        const canCreateTags = hasPermission("tagEdit");
+        const canCreateTags = hasPermission("tag_edit");
 
         return (
             <div className="tag-search">


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Bump the pan-domain-auth to prevent invalid auth requests from throwing exceptions ([PR](https://github.com/guardian/pan-domain-authentication/pull/118)). The upgrade also required bumping the permissions library.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Sending request without required cookies should raise bad requests instead of throwing exceptions.
Run Tag Manager on CODE. If you have the necessary permissions in CODE, you should be able to create and edit tags.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Invalid auth requests should stop producing noises in the logs and tag manager continues to function as normal.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
Tested locally and on CODE
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

