### PR TITLE
Add README instructions to connect to Path Manager via tunnel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,13 @@ Tag Manager also makes requests to CAPI preview. This means you will also need C
 If you are working on the commercial tag functionality and need to be able to upload logos you will also need AWS credentials for 
 the frontend aws account available as an AWS profile named "frontend". This can also be obtained via janus.
 
+If you want to integrate with [Path Manager](https://github.com/guardian/path-manager), e.g. to create tags, you'll need to
+create a tunnel from your local server (localhost 6000) to the Path Manager load balancer. This can be done using this command:
+```
+ssm ssh -x -t tag-manager,CODE -p composer --tunnel 6000:<internal-path-manager-url>:80
+```
+The internal path manager DNS name can be found in EC2 load balancers in AWS.
+
 Run `./scripts/start.sh` to start the full app.
 
 Client Side Development


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds instructions to the README on how to create a tunnel between your local server and the [Path Manager](https://github.com/guardian/path-manager) load balancer when running locally. This is needed to create tags, for example.

Previously the Path Manager URL was accessible via the VPN, however this is no longer the case, so instead we need to set up a tunnel to access this.

The DEV config in S3 has been amended, changing the path manager url to `localhost:6000` instead of the Path Manager URL - this is the port that should be used to create the tunnel.

## How to test

- follow instructions in the README to set up a tunnel
- run tag manager locally
- create a tag

If this works successfully, this indicates the tunnel has been created successfully and you have been able to access the required Path Manager URL to create a tag.