### PR TITLE
Fix build-dev npm script, used by ./scripts/start.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tool for managing Guardian tags",
   "scripts": {
     "build": "webpack --mode production --entry ./public/app.js --output-path ./public/build/ --config ./public/build_config/webpack.prod.conf.js",
-    "build-dev": "webpack --entry ./public/app.js --output-path ./public/build/ --config ./public/build_config/webpack.dev.conf.js --watch",
+    "build-dev": "webpack --output-path ./public/build/ --config ./public/build_config/webpack.dev.conf.js --watch",
     "build-icons": "svg-sprite -w 16 -h 16 -v true --view-bust false --view-prefix .i-%s --shape-id-separator '' --view-dest . --vs ./public/images/icons.svg --vscss true --view-render-scss-template ./public/images/icons/scssTemplate.scss --view-render-scss-dest ./public/style/_icons.scss  ./public/images/icons/*.svg",
     "client-dev": "node ./public/devserver.js"
   },

--- a/public/build_config/webpack.dev.conf.js
+++ b/public/build_config/webpack.dev.conf.js
@@ -4,6 +4,12 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 module.exports = {
   devtool: 'source-map',
   mode: 'development',
+  entry: {
+    app: './public/app.js'
+  },
+  output: {
+    filename: 'app.js',
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
## What does this change?

Currently, changes to Tag Manager aren't reflected while running the `./scripts/start.sh` script. During Webpack version bumps (probably [my PR from May](https://github.com/guardian/tagmanager/pull/489)), breaking changes in Webpack have prevented the bundled JavaScript from ending up in the expected location (`./public/build/app.js`).

This PR removes misleading command-line arguments from the `build-dev` script in package.json, and adds explicit properties to `webpack.dev.conf.js` so that changes are built as expected while running locally.

## How to test

1. Run this branch locally according to the instructions in the readme. 
2. Run the `./scripts/start.sh` script
3. View `tagmanager`, make some changes to the UI in your source code, and reload the page. Do your changes apply as expected?
