### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+# Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+name: CI
+
+on:
+  pull_request:
+
+  # Manual invocation.
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    permissions:
+      # required by aws-actions/configure-aws-credentials
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: 'package-lock.json'
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'corretto'
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: SBT
+        run: sbt "clean;compile;test;Debian / packageBin"
+
+      # Make the filename produced by SBT easier.
+      - name: Rename debian artifact
+        run: mv target/tag-manager_1.0_all.deb target/tag-manager.deb
+
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: editorial-tools:tag-manager
+          buildNumberOffset: 1654
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            tag-manager:
+              - target/tag-manager.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build app
         run: npm run build
 
+      - name: Build icons
+        run: npm run build-icons
+
       - name: SBT
         run: sbt "clean;compile;test;Debian / packageBin"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,7 @@ jobs:
           buildNumberOffset: 1654
           configPath: riff-raff.yaml
           contentDirectories: |
+            cloudformation:
+              - cloudformation/tag-manager.yaml
             tag-manager:
               - target/tag-manager.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'corretto'
+          cache: 'sbt'
 
       - name: Install NPM dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm run build-icons
 
       - name: SBT
-        run: sbt "clean;compile;test;Debian / packageBin"
+        run: sbt clean compile test Debian/packageBin
 
       # Make the filename produced by SBT easier.
       - name: Rename debian artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
+      - name: Build app
+        run: npm run build
+
       - name: SBT
         run: sbt "clean;compile;test;Debian / packageBin"
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,21 +47,12 @@ lazy val dependencies = Seq(
 
 dependencyOverrides += "org.bouncycastle" % "bcprov-jdk15on" % "1.67"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, SbtWeb, JDebPackaging, SystemdPlugin)
+lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, JDebPackaging, SystemdPlugin)
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(
     playDefaultPort := 8247,
     Universal / name := normalizedName.value,
     topLevelDirectory := Some(normalizedName.value),
-    riffRaffPackageType := (Debian / packageBin).value,
-    riffRaffManifestProjectName := s"editorial-tools:${name.value}",
-    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    riffRaffArtifactResources := Seq(
-      baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
-      riffRaffPackageType.value -> s"${name.value}/${name.value}.deb",
-      baseDirectory.value / "cloudformation" / "tag-manager.yaml" -> "cloudformation/tag-manager.yaml"
-    ),
     Universal / javaOptions ++= Seq(
       "-Dpidfile.path=/dev/null"
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
 // need to add jdeb dependency explicitly because https://github.com/sbt/sbt-native-packager/issues/1053
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
 

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-npm config set registry https://registry.npmjs.org
-npm install
-npm run build
-npm run build-icons


### PR DESCRIPTION
## What does this change?
This change adopt GitHub Actions for CI, replacing TeamCity which DevX are switching off in Q2 2023.

This change isn't exactly a no-op switch, as the [`sbt-riffraff-artifact` plugin](https://github.com/guardian/sbt-riffraff-artifact) has been removed in favour of [`guardian/actions-riff-raff`](https://github.com/guardian/actions-riff-raff). 

## How to test
- [x] Deploy to CODE and observe it succeeding

## Notes
- I've paused the [TeamCity project](https://teamcity.gutools.co.uk/buildConfiguration/EditorialTools_Tagmanager?mode=branches).
