### PR TITLE
Enable nightly backups for DynamoDB tables

### DIFF
--- a/cloudformation/pillar-audit-dynamo.yaml
+++ b/cloudformation/pillar-audit-dynamo.yaml
@@ -22,3 +22,6 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: '1'
         WriteCapacityUnits: '1'
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true

--- a/cloudformation/pillar-dynamo.yaml
+++ b/cloudformation/pillar-dynamo.yaml
@@ -18,3 +18,6 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: '1'
         WriteCapacityUnits: '1'
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up `tag-manager`'s DynamoDB tables[^1] using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering & EMs.

## How to test

I've [deployed this to `CODE`](https://riffraff.gutools.co.uk/deployment/view/cc3c399c-366d-4f0a-831b-47f0c66e9a16) to confirm that it works as expected. I will also double check that backups are taken as expected (this should happen the night after this CFN change is applied).

## How can we measure success?

We will be able to recover (most) data stored in these tables in the unlikely event that they are ever deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.

## Deployment

This infrastructure is now deployed via Riff-Raff (https://github.com/guardian/tagmanager/pull/503) and CD is configured, so merging should be sufficient.

[^1]: Note that this PR only modifies the tables that are managed via CloudFormation. I can see that `tag-manager` has several other tables; these will need to be tagged via a script (so it will happen separately).