### PR TITLE
Sponsorship packages

### DIFF
--- a/app/model/Sponsorship.scala
+++ b/app/model/Sponsorship.scala
@@ -10,7 +10,7 @@ import play.api.Logging
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import repositories.{SectionRepository, TagRepository, TagLookupCache}
-import com.gu.tagmanagement.{Sponsorship => ThriftSponsorship, SponsorshipTargeting => ThriftSponsorshipTargeting, SponsorshipType}
+import com.gu.tagmanagement.{Sponsorship => ThriftSponsorship, SponsorshipTargeting => ThriftSponsorshipTargeting, SponsorshipType, SponsorshipPackage}
 
 import scala.util.control.NonFatal
 
@@ -32,6 +32,7 @@ case class Sponsorship (
   validTo: Option[DateTime],
   status: String,
   sponsorshipType: String,
+  sponsorshipPackage: Option[String],
   sponsorName: String,
   sponsorLogo: Image,
   highContrastSponsorLogo: Option[Image],
@@ -47,6 +48,7 @@ case class Sponsorship (
   def asThrift: ThriftSponsorship = ThriftSponsorship(
     id = id,
     sponsorshipType = SponsorshipType.valueOf(sponsorshipType).get,
+    sponsorshipPackage = sponsorshipPackage.map(SponsorshipPackage.valueOf(_).get),
     sponsorName = sponsorName,
     sponsorLogo = sponsorLogo.asThrift,
     highContrastSponsorLogo = highContrastSponsorLogo.map(_.asThrift),
@@ -81,6 +83,7 @@ case class DenormalisedSponsorship (
                          validTo: Option[DateTime],
                          status: String,
                          sponsorshipType: String,
+                         sponsorshipPackage: Option[String],
                          sponsorName: String,
                          sponsorLogo: Image,
                          highContrastSponsorLogo: Option[Image],
@@ -101,6 +104,7 @@ object DenormalisedSponsorship {
       validTo = s.validTo,
       status = s.status,
       sponsorshipType = s.sponsorshipType,
+      sponsorshipPackage = s.sponsorshipPackage,
       sponsorName = s.sponsorName,
       sponsorLogo = s.sponsorLogo,
       highContrastSponsorLogo = s.highContrastSponsorLogo,

--- a/app/model/Sponsorship.scala
+++ b/app/model/Sponsorship.scala
@@ -45,10 +45,14 @@ case class Sponsorship (
 
   def toItem = Item.fromJSON(Json.toJson(this).toString())
 
+  private def sponsorshipPackageAsThrift(s: String) = SponsorshipPackage.valueOf(
+    s.replace("-", "") // convert us-exclusive to usexclusive
+  )
+
   def asThrift: ThriftSponsorship = ThriftSponsorship(
     id = id,
     sponsorshipType = SponsorshipType.valueOf(sponsorshipType).get,
-    sponsorshipPackage = sponsorshipPackage.map(SponsorshipPackage.valueOf(_).get),
+    sponsorshipPackage = sponsorshipPackage.flatMap(sponsorshipPackageAsThrift),
     sponsorName = sponsorName,
     sponsorLogo = sponsorLogo.asThrift,
     highContrastSponsorLogo = highContrastSponsorLogo.map(_.asThrift),

--- a/app/model/command/CreateSponsorshipCommand.scala
+++ b/app/model/command/CreateSponsorshipCommand.scala
@@ -16,6 +16,7 @@ case class CreateSponsorshipCommand(
   validFrom: Option[DateTime],
   validTo: Option[DateTime],
   sponsorshipType: String,
+  sponsorshipPackage: Option[String],
   sponsorName: String,
   sponsorLogo: Image,
   highContrastSponsorLogo: Option[Image],
@@ -38,6 +39,7 @@ case class CreateSponsorshipCommand(
       validTo = validTo,
       status = status,
       sponsorshipType = sponsorshipType,
+      sponsorshipPackage = sponsorshipPackage,
       sponsorName = sponsorName,
       sponsorLogo = sponsorLogo,
       highContrastSponsorLogo = highContrastSponsorLogo,
@@ -76,6 +78,7 @@ object CreateSponsorshipCommand{
       (JsPath \ "validFrom").formatNullable[DateTime] and
       (JsPath \ "validTo").formatNullable[DateTime] and
       (JsPath \ "sponsorshipType").format[String] and
+      (JsPath \ "sponsorshipPackage").formatNullable[String] and
       (JsPath \ "sponsorName").format[String] and
       (JsPath \ "sponsorLogo").format[Image] and
       (JsPath \ "highContrastSponsorLogo").formatNullable[Image] and

--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -37,6 +37,7 @@ case class InlinePaidContentSponsorshipCommand(
       validTo = validTo,
       status = status,
       sponsorshipType = "paidContent",
+      sponsorshipPackage = None,
       sponsorName = sponsorName,
       sponsorLogo = sponsorLogo,
       highContrastSponsorLogo = highContrastSponsorLogo,

--- a/app/model/command/UpdateSponsorshipCommand.scala
+++ b/app/model/command/UpdateSponsorshipCommand.scala
@@ -17,6 +17,7 @@ case class UpdateSponsorshipCommand(
   validFrom: Option[DateTime],
   validTo: Option[DateTime],
   sponsorshipType: String,
+  sponsorshipPackage: Option[String],
   sponsorName: String,
   sponsorLogo: Image,
   highContrastSponsorLogo: Option[Image],
@@ -39,6 +40,7 @@ case class UpdateSponsorshipCommand(
       validTo = validTo,
       status = status,
       sponsorshipType = sponsorshipType,
+      sponsorshipPackage = sponsorshipPackage,
       sponsorName = sponsorName,
       sponsorLogo = sponsorLogo,
       highContrastSponsorLogo = highContrastSponsorLogo,
@@ -104,6 +106,7 @@ object UpdateSponsorshipCommand{
       (JsPath \ "validFrom").formatNullable[DateTime] and
       (JsPath \ "validTo").formatNullable[DateTime] and
       (JsPath \ "sponsorshipType").format[String] and
+      (JsPath \ "sponsorshipPackage").formatNullable[String] and
       (JsPath \ "sponsorName").format[String] and
       (JsPath \ "sponsorLogo").format[Image] and
       (JsPath \ "highContrastSponsorLogo").formatNullable[Image] and

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ version := "1.0"
 
 lazy val scalaVer = "2.12.16"
 
+resolvers ++= Resolver.sonatypeOssRepos("releases")
+
 scalacOptions ++= Seq(
   "-target:jvm-1.8",
   "-encoding", "UTF-8",

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val dependencies = Seq(
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client-default" % "17.24.1",
-  "com.gu" %% "tags-thrift-schema" % "2.8.1",
+  "com.gu" %% "tags-thrift-schema" % "2.8.3",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",

--- a/public/components/Sponsorship/Create.js
+++ b/public/components/Sponsorship/Create.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import SponsorshipTypeEdit from '../SponsorshipEdit/SponsorshipTypeEdit.react';
+import SponsorshipPackageEdit from '../SponsorshipEdit/SponsorshipPackageEdit.react';
 import SponsorEdit from '../SponsorshipEdit/SponsorEdit.react';
 import ValidityEdit from '../SponsorshipEdit/ValidityEdit.react';
 import TargetingEdit from '../SponsorshipEdit/TargetingEdit.react';
@@ -64,8 +65,7 @@ class SponsorshipCreate extends React.Component {
       return (
         <div className="sponsorship-edit">
           <div className="sponsorship-edit__column--sidebar">
-            <SponsorshipTypeEdit sponsorship={this.props.sponsorship} updateSponsorship={this.props.sponsorshipActions.updateSponsorship}/>
-            <SponsorEdit sponsorship={this.props.sponsorship} updateSponsorship={this.props.sponsorshipActions.updateSponsorship}/>
+            <SponsorEdit sponsorship={this.props.sponsorship} updateSponsorship={this.props.sponsorshipActions.updateSponsorship} creating={true} />
           </div>
           <div className="sponsorship-edit__column">
             <ValidityEdit sponsorship={this.props.sponsorship} updateSponsorship={this.updateSponsorshipAndCheckClashes.bind(this)} />

--- a/public/components/SponsorshipEdit/SponsorEdit.react.js
+++ b/public/components/SponsorshipEdit/SponsorEdit.react.js
@@ -3,6 +3,8 @@ import SponsorLogo from './SponsorLogo.react';
 import {PAID_HOSTEDCONTENT_TYPE} from '../../constants/paidContentTagTypes';
 import ReactTooltip from 'react-tooltip';
 import { Required } from './Required.react';
+import SponsorshipPackageEdit from "./SponsorshipPackageEdit.react";
+import SponsorshipTypeEdit from "./SponsorshipTypeEdit.react";
 
 const imageRules = `
   <p style="text-align:left; margin-left: -10px">This image should:</p>
@@ -57,7 +59,12 @@ export default class SponsorEdit extends React.Component {
     const logoWidth = this.props.paidContentTagType === PAID_HOSTEDCONTENT_TYPE.value ? false : 280;
     const logoHeight = this.props.paidContentTagType === PAID_HOSTEDCONTENT_TYPE.value ? false : 180;
 
-    return (
+    return (<>
+      <div className="tag-edit__input-group">
+        <label className="tag-edit__input-group__header">Sponsorship</label>
+        { <SponsorshipTypeEdit sponsorship={this.props.sponsorship} updateSponsorship={this.props.updateSponsorship} editable={!!this.props.creating}/> }
+        { this.props.sponsorship.sponsorshipType == "sponsored" ? <SponsorshipPackageEdit sponsorship={this.props.sponsorship} updateSponsorship={this.props.updateSponsorship}/> : null }
+      </div>
       <div className="tag-edit__input-group">
         <ReactTooltip html={true}/>
         <label className="tag-edit__input-group__header">Sponsor</label>
@@ -93,6 +100,7 @@ export default class SponsorEdit extends React.Component {
         </div>
 
       </div>
+      </>
     );
 
   }

--- a/public/components/SponsorshipEdit/SponsorLogo.react.js
+++ b/public/components/SponsorshipEdit/SponsorLogo.react.js
@@ -10,7 +10,7 @@ const dropzoneStyles = {
   padding: "10px"
 }
 
-export default class SponsorEdit extends React.Component {
+export default class SponsorLogo extends React.Component {
 
   constructor(props) {
     super(props);

--- a/public/components/SponsorshipEdit/SponsorshipPackageEdit.react.js
+++ b/public/components/SponsorshipEdit/SponsorshipPackageEdit.react.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export default class SponsorshipPackageEdit extends React.Component {
+
+    constructor(props) {
+        super(props);
+    }
+
+    updateType(e) {
+        this.props.updateSponsorship(Object.assign({}, this.props.sponsorship, {
+            sponsorshipPackage: e.target.value
+        }));
+    }
+
+
+    render () {
+
+        if (!this.props.sponsorship) {
+            return false;
+        }
+
+        return (
+            <div className="tag-edit__field">
+                <label className="tag-edit__label">Package</label>
+                <select value={this.props.sponsorship.sponsorshipPackage || "default"} onChange={this.updateType.bind(this)}>
+                    <option value="default">default</option>
+                    <option value="us">Advertising partner (US only)</option>
+                    <option value="us-exclusive">Exclusive advertising partner (US only)</option>
+                </select>
+            </div>
+        );
+    }
+}

--- a/public/components/SponsorshipEdit/SponsorshipTypeEdit.react.js
+++ b/public/components/SponsorshipEdit/SponsorshipTypeEdit.react.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default class SponsorEdit extends React.Component {
+export default class SponsorshipTypeEdit extends React.Component {
 
   constructor(props) {
     super(props);

--- a/public/components/SponsorshipEdit/SponsorshipTypeEdit.react.js
+++ b/public/components/SponsorshipEdit/SponsorshipTypeEdit.react.js
@@ -20,14 +20,14 @@ export default class SponsorshipTypeEdit extends React.Component {
     }
 
     return (
-      <div className="tag-edit__input-group">
-        <label className="tag-edit__input-group__header">Sponsorship type</label>
-        <div className="tag-edit__field">
-          <select value={this.props.sponsorship.sponsorshipType} onChange={this.updateType.bind(this)}>
-            <option value="sponsored">sponsored</option>
-            <option value="foundation">foundation</option>
-          </select>
-        </div>
+      <div className="tag-edit__field">
+        { this.props.editable ? <>
+            <label className="tag-edit__label">Type</label>
+            <select value={this.props.sponsorship.sponsorshipType} onChange={this.updateType.bind(this)}>
+              <option value="sponsored">sponsored</option>
+              <option value="foundation">foundation</option>
+            </select>
+          </> : this.props.sponsorship.sponsorshipType }
       </div>
     );
   }


### PR DESCRIPTION
## What does this change?

Creates a new sponsorship attribute called `sponsorshipPackage`. This is to allow the US Ads team to sell sponsorships under the ‘Advertising partner’ or ‘Exclusive advertising partner’ labels. These labels will never be applied to Foundation funded journalism. 

An update to our externally facing content funding guidelines will be published before this change is used.

## How to test

Cannot be tested until tags-thrift-schema PR is released. See https://github.com/guardian/tags-thrift-schema/pull/43

* Deploy to CODE.
* ensure you have permission 
   <img width="718" alt="image" src="https://github.com/guardian/tagmanager/assets/19289579/e52f2643-3d41-4747-9d09-291184913abc">
* Attempt to create a new sponsored tag
* See that you can set the sponsorshipPackage to default, advertising partner or exclusive advertising partner
* See that once you have created the tag you can edit this field but cannot edit the sponsorship type
* Attempt to edit a pre-existing sponsored tag
* See that its sponsorshipPackage is set to the default value initially

## How can we measure success?

US ads team are able to create new sponsorships that meet their requirements.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Existing tags will continue to have no value for this field until they are first edited. This is captured as an Option value in Scala and an optional field in thrift.

## Images

### Creating a sponsored tag
#### Before
<img width="396" alt="Screenshot 2024-02-16 at 17 27 01" src="https://github.com/guardian/tagmanager/assets/2619836/5181e208-3721-43a4-a0ba-b2ad683fe0bc">

#### After
<img width="396" alt="Screenshot 2024-02-16 at 17 26 37" src="https://github.com/guardian/tagmanager/assets/2619836/08f38f91-5029-49b6-9e72-bee2d882e4c5">

### Editing a sponsored tag
#### Before
<img width="396" alt="Screenshot 2024-02-16 at 17 38 59" src="https://github.com/guardian/tagmanager/assets/2619836/e7d9ce53-978c-44dc-96ad-791ed467a2eb">

#### After
<img width="396" alt="Screenshot 2024-02-16 at 17 26 45" src="https://github.com/guardian/tagmanager/assets/2619836/2370d03d-4d63-4f74-b467-3f1ca8e751df">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
