### PR TITLE
Logging of permission status

### DIFF
--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -1,13 +1,26 @@
 package controllers
 
 import com.gu.pandahmac.HMACAuthActions
+import com.gu.pandomainauth.PanDomain
 import com.gu.pandomainauth.model.AuthenticatedUser
 import services.Config
+import permissions.Permissions
+import play.api.Logging
 
-trait PanDomainAuthActions extends HMACAuthActions {
+trait PanDomainAuthActions extends HMACAuthActions with Logging {
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
-    (authedUser.user.email endsWith ("@guardian.co.uk")) && authedUser.multiFactor
+    val isValid = PanDomain.guardianValidation(authedUser)
+
+    val canAccess = Permissions.testUser(Permissions.TagManagerAccess)(authedUser.user.email)
+
+    if (!isValid) {
+      logger.warn(s"User ${authedUser.user.email} is not valid")
+    } else if (!canAccess) {
+      logger.warn(s"User ${authedUser.user.email} does not have tag_manager_access permission")
+    }
+
+    isValid // TODO && canAccess
   }
 
   override def cacheValidation = true

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -7,26 +7,27 @@ import services.Config
 object Permissions {
   val app = "tag-manager"
 
+  val TagManagerAccess: PermissionDefinition = PermissionDefinition("tag_manager_access", app)
   val TagEdit: PermissionDefinition = PermissionDefinition("tag_edit", app)
   val TagAdmin: PermissionDefinition = PermissionDefinition("tag_admin", app)
   val CommercialTags: PermissionDefinition = PermissionDefinition("commercial_tags", app)
-  val TagUnaccessible: PermissionDefinition = PermissionDefinition("tag_no_one", app)
 
   private val permissionDefinitions = Map(
+    "tag_manager_access" -> TagManagerAccess,
     "tag_edit" -> TagEdit,
     "tag_admin" -> TagAdmin,
     "commercial_tags" -> CommercialTags,
-    "tag_no_one" -> TagUnaccessible
   )
 
   private val credentials: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()
 
   private val permissions: PermissionsProvider = PermissionsProvider(PermissionsConfig(Config().permissionsStage, Config().aws.region, credentials))
 
-  def testUser(permission:PermissionDefinition)(email: String): Boolean = {
+  def testUser(permission: PermissionDefinition)(email: String): Boolean = {
     println("Permissions for: " + email)
     permissions.hasPermission(permission, email)
   }
-  def getPermissionsForUser(email: String): Map[String, Boolean] = permissionDefinitions.transform((_, permission) => permissions.hasPermission(permission, email))
+  def getPermissionsForUser(email: String): Map[String, Boolean] =
+    permissionDefinitions.mapValues(permission => permissions.hasPermission(permission, email))
 }
 


### PR DESCRIPTION
Requires https://github.com/guardian/permissions/pull/197


## What does this change?

Perform logging of user's access without the access permission. This lets us see who's actively using the tool, and providing access to an accurate group of users.

