### PR TITLE
Define DNS record in tagmanager CloudFormation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,4 @@ npm-debug.log
 .bsp
 .metals
 .vscode
-.yalc
-yalc.lock
 .bloop
-metals.sbt

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,7 @@ npm-debug.log
 .bsp
 .metals
 .vscode
+.yalc
+yalc.lock
 .bloop
+metals.sbt

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -319,7 +319,10 @@ Resources:
       Name: !FindInMap [Config, !Ref 'Stage', DNSName]
       RecordType: CNAME
       ResourceRecords:
-      - !GetAtt TagManagerLoadBalancer.DNSName
+      - Fn::Join:
+          - ""
+          - - !GetAtt TagManagerLoadBalancer.DNSName
+            - "."
       Stage: !Ref Stage
       TTL: !FindInMap [Config, !Ref 'Stage', TTL]
   TagManagerLaunchConfig:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -58,11 +58,13 @@ Mappings:
       MaxSize: 2
       DesiredCapacity: 1
       InstanceType: t4g.medium
+      DNSName: tagmanager.code.dev-gutools.co.uk
     PROD:
       MinSize: 3
       MaxSize: 6
       DesiredCapacity: 3
       InstanceType: t4g.medium
+      DNSName: tagmanager.gutools.co.uk
 Resources:
   TagManagerRole:
     Type: AWS::IAM::Role
@@ -309,6 +311,15 @@ Resources:
       - Key: SystemdUnit
         Value: tag-manager.service
         PropagateAtLaunch: 'true'
+  TagManagerDNSRecord: 
+    Type: Guardian::DNS::RecordSet,
+    Properties:
+      Name: presence.gutools.co.uk,
+      RecordType: CNAME,
+      ResourceRecords:
+      - !GetAtt TagManagerLoadBalancer.DNSName
+      Stage: !Ref Stage
+      TTL: 14400
   TagManagerLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -59,12 +59,14 @@ Mappings:
       DesiredCapacity: 1
       InstanceType: t4g.medium
       DNSName: tagmanager.code.dev-gutools.co.uk
+      TTL: 14400
     PROD:
       MinSize: 3
       MaxSize: 6
       DesiredCapacity: 3
       InstanceType: t4g.medium
       DNSName: tagmanager.gutools.co.uk
+      TTL: 7200
 Resources:
   TagManagerRole:
     Type: AWS::IAM::Role
@@ -312,14 +314,14 @@ Resources:
         Value: tag-manager.service
         PropagateAtLaunch: 'true'
   TagManagerDNSRecord: 
-    Type: Guardian::DNS::RecordSet,
+    Type: Guardian::DNS::RecordSet
     Properties:
-      Name: presence.gutools.co.uk,
-      RecordType: CNAME,
+      Name: !FindInMap [Config, !Ref 'Stage', DNSName]
+      RecordType: CNAME
       ResourceRecords:
       - !GetAtt TagManagerLoadBalancer.DNSName
       Stage: !Ref Stage
-      TTL: 14400
+      TTL: !FindInMap [Config, !Ref 'Stage', TTL]
   TagManagerLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -59,14 +59,14 @@ Mappings:
       DesiredCapacity: 1
       InstanceType: t4g.medium
       DNSName: tagmanager.code.dev-gutools.co.uk
-      TTL: 14400
+      TTL: 7200
     PROD:
       MinSize: 3
       MaxSize: 6
       DesiredCapacity: 3
       InstanceType: t4g.medium
       DNSName: tagmanager.gutools.co.uk
-      TTL: 7200
+      TTL: 14400
 Resources:
   TagManagerRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## What does this change?

This PR adds a Guardian DNS Record custom CloudFormation resource to the stack, so that we can set the DNS record here, rather than manually managing it in our DNS provider.

The TTL is derived from the existing DNS records - the CloudFormation must exactly match the existing records in order for them to take effect.

For comparison:  a similar setup from another repo: https://github.com/guardian/acquisition-health-monitor/pull/9/files

## How to test

You can validate the yaml locally with:
`aws --region eu-west-1 --profile composer cloudformation validate-template --template-body file://cloudformation/tag-manager.yaml`

Deploying to CODE or PROD will validate the DNS record for that stage - if the deploy succeeds, the DNS record has been successfully added.