### PR TITLE
Add Cloudfront Distribution to Tagmanager

### DIFF
--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -286,7 +286,7 @@ Resources:
     Type: "AWS::CloudFront::CachePolicy"
     Properties:
       CachePolicyConfig:
-        DefaultTTL: 3600
+        DefaultTTL: 0
         MaxTTL: 3600
         MinTTL: 0
         Name: !Sub "tag-manager-cache-policy-${Stage}"

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -143,7 +143,7 @@ Resources:
           Action: sts:AssumeRole
           Resource: arn:aws:iam::642631414762:role/composerWriteToStaticBucket
       Roles:
-      - !Ref 'TagManagerRole'    
+      - !Ref 'TagManagerRole'
   TagManagerPermissionsBucketPolicy:
     Type: AWS::IAM::Policy
     Properties:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -59,14 +59,12 @@ Mappings:
       DesiredCapacity: 1
       InstanceType: t4g.medium
       DNSName: tagmanager.code.dev-gutools.co.uk
-      TTL: 7200
     PROD:
       MinSize: 3
       MaxSize: 6
       DesiredCapacity: 3
       InstanceType: t4g.medium
       DNSName: tagmanager.gutools.co.uk
-      TTL: 14400
 Resources:
   TagManagerRole:
     Type: AWS::IAM::Role
@@ -291,7 +289,7 @@ Resources:
         DefaultTTL: 86400
         MaxTTL: 31536000
         MinTTL: 0
-        Name: !Ref TagManagerCloudfrontCachePolicy
+        Name: !Sub "tag-manager-cache-policy-${Stage}"
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
             CookieBehavior: "all"
@@ -311,41 +309,42 @@ Resources:
             QueryStringBehavior: "all"
   TagManagerCloudFrontDistribution:
     Type: "AWS::CloudFront::Distribution"
-    DistributionConfig:
-      Aliases:
-        - !FindInMap [Config, !Ref 'Stage', DNSName]
-      DefaultCacheBehavior:
-        AllowedMethods:
-          - "GET"
-          - "HEAD"
-          - "OPTIONS"
-        CachePolicyId: !Ref 'TagManagerCloudfrontCachePolicy'
-        Compress: true
-        TargetOriginId: !Ref 'TagManagerLoadBalancer'
-      ViewerProtocolPolicy: "allow-all"
-      Enabled: true
-      HttpVersion: "http2"
-      IPV6Enabled: true
-      Origins:
-        - CustomOriginConfig:
-            OriginProtocolPolicy: "https-only"
-            OriginSSLProtocols:
-              - "TLSv1.2"
-          DomainName: !FindInMap [Config, !Ref 'Stage', DNSName]
-          Id: !Ref 'TagManagerLoadBalancer'
-      ViewerCertificate:
-        AcmCertificateArn: !Sub '{{resolve:ssm:/${Stage}/flexible/tagmanager/cloudFrontCertificateArn}}'
-        MinimumProtocolVersion: "TLSv1.2_2021"
-        SslSupportMethod: "sni-only"
-    Tags:
-      - Key: "gu:repo"
-        Value: "guardian/tagmanager"
-      - Key: Stack
-        Value: flexible
-      - Key: Stage
-        Value: !Ref 'Stage'
-      - Key: App
-        Value: tag-manager
+    Properties:
+      DistributionConfig:
+        Aliases:
+          - !FindInMap [Config, !Ref 'Stage', DNSName]
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - "GET"
+            - "HEAD"
+            - "OPTIONS"
+          CachePolicyId: !Ref 'TagManagerCloudfrontCachePolicy'
+          Compress: true
+          TargetOriginId: !Ref 'TagManagerLoadBalancer'
+        ViewerProtocolPolicy: "allow-all"
+        Enabled: true
+        HttpVersion: "http2"
+        IPV6Enabled: true
+        Origins:
+          - CustomOriginConfig:
+              OriginProtocolPolicy: "https-only"
+              OriginSSLProtocols:
+                - "TLSv1.2"
+            DomainName: !FindInMap [Config, !Ref 'Stage', DNSName]
+            Id: !Ref 'TagManagerLoadBalancer'
+        ViewerCertificate:
+          AcmCertificateArn: !Sub '{{resolve:ssm:/${Stage}/flexible/tagmanager/cloudFrontCertificateArn}}'
+          MinimumProtocolVersion: "TLSv1.2_2021"
+          SslSupportMethod: "sni-only"
+      Tags:
+        - Key: "gu:repo"
+          Value: "guardian/tagmanager"
+        - Key: Stack
+          Value: flexible
+        - Key: Stage
+          Value: !Ref 'Stage'
+        - Key: App
+          Value: tag-manager
   AutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
@@ -383,10 +382,10 @@ Resources:
       ResourceRecords:
       - Fn::Join:
           - ""
-          - - !GetAtt TagManagerLoadBalancer.DNSName
+          - - !GetAtt TagManagerCloudFrontDistribution.DNSName
             - "."
       Stage: !Ref Stage
-      TTL: !FindInMap [Config, !Ref 'Stage', TTL]
+      TTL: 3600
   TagManagerLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -334,7 +334,7 @@ Resources:
           DomainName: !FindInMap [Config, !Ref 'Stage', DNSName]
           Id: !Ref 'TagManagerLoadBalancer'
       ViewerCertificate:
-        AcmCertificateArn: !Sub '{{resolve:ssm:/${Stage}/tagmanager/cloudFrontCertificateArn}}'
+        AcmCertificateArn: !Sub '{{resolve:ssm:/${Stage}/flexible/tagmanager/cloudFrontCertificateArn}}'
         MinimumProtocolVersion: "TLSv1.2_2021"
         SslSupportMethod: "sni-only"
     Tags:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -389,7 +389,7 @@ Resources:
           - - !GetAtt TagManagerCloudFrontDistribution.DNSName
             - "."
       Stage: !Ref Stage
-      TTL: 3600
+      TTL: 60
   TagManagerLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -334,7 +334,7 @@ Resources:
               OriginProtocolPolicy: "https-only"
               OriginSSLProtocols:
                 - "TLSv1.2"
-            DomainName: !FindInMap [Config, !Ref 'Stage', DNSName]
+            DomainName: !GetAtt TagManagerLoadBalancer.DNSName
             Id: !Ref 'TagManagerLoadBalancer'
         ViewerCertificate:
           AcmCertificateArn: !Sub '{{resolve:ssm:/${Stage}/flexible/tagmanager/cloudFrontCertificateArn}}'

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -145,7 +145,7 @@ Resources:
           Action: sts:AssumeRole
           Resource: arn:aws:iam::642631414762:role/composerWriteToStaticBucket
       Roles:
-      - !Ref 'TagManagerRole'
+      - !Ref 'TagManagerRole'    
   TagManagerPermissionsBucketPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -282,6 +282,68 @@ Resources:
         Value: !Ref 'Stage'
       - Key: Stack
         Value: flexible
+      - Key: App
+        Value: tag-manager
+  TagManagerCloudfrontCachePolicy:
+    Type: "AWS::CloudFront::CachePolicy"
+    Properties:
+      CachePolicyConfig:
+        DefaultTTL: 86400
+        MaxTTL: 31536000
+        MinTTL: 0
+        Name: !Ref TagManagerCloudfrontCachePolicy
+        ParametersInCacheKeyAndForwardedToOrigin:
+          CookiesConfig:
+            CookieBehavior: "all"
+          EnableAcceptEncodingBrotli: false
+          EnableAcceptEncodingGzip: false
+          HeadersConfig:
+            HeaderBehavior: "whitelist"
+            Headers:
+              - "Host"
+              - "Origin"
+              - "Access-Control-Request-Headers"
+              - "Access-Control-Request-Method"
+              - "X-Gu-Tools-HMAC-Token"
+              - "X-Gu-Tools-HMAC-Date"
+              - "X-Gu-Tools-Service-Name"
+          QueryStringsConfig:
+            QueryStringBehavior: "all"
+  TagManagerCloudFrontDistribution:
+    Type: "AWS::CloudFront::Distribution"
+    DistributionConfig:
+      Aliases:
+        - !FindInMap [Config, !Ref 'Stage', DNSName]
+      DefaultCacheBehavior:
+        AllowedMethods:
+          - "GET"
+          - "HEAD"
+          - "OPTIONS"
+        CachePolicyId: !Ref 'TagManagerCloudfrontCachePolicy'
+        Compress: true
+        TargetOriginId: !Ref 'TagManagerLoadBalancer'
+      ViewerProtocolPolicy: "allow-all"
+      Enabled: true
+      HttpVersion: "http2"
+      IPV6Enabled: true
+      Origins:
+        - CustomOriginConfig:
+            OriginProtocolPolicy: "https-only"
+            OriginSSLProtocols:
+              - "TLSv1.2"
+          DomainName: !FindInMap [Config, !Ref 'Stage', DNSName]
+          Id: !Ref 'TagManagerLoadBalancer'
+      ViewerCertificate:
+        AcmCertificateArn: !Sub '{{resolve:ssm:/${Stage}/tagmanager/cloudFrontCertificateArn}}'
+        MinimumProtocolVersion: "TLSv1.2_2021"
+        SslSupportMethod: "sni-only"
+    Tags:
+      - Key: "gu:repo"
+        Value: "guardian/tagmanager"
+      - Key: Stack
+        Value: flexible
+      - Key: Stage
+        Value: !Ref 'Stage'
       - Key: App
         Value: tag-manager
   AutoscalingGroup:

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -386,7 +386,7 @@ Resources:
       ResourceRecords:
       - Fn::Join:
           - ""
-          - - !GetAtt TagManagerCloudFrontDistribution.DNSName
+          - - !GetAtt TagManagerCloudFrontDistribution.DomainName
             - "."
       Stage: !Ref Stage
       TTL: 60

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -319,6 +319,7 @@ Resources:
             - "HEAD"
             - "OPTIONS"
             - "PUT"
+            - "PATCH"
             - "POST"
             - "DELETE"
           CachePolicyId: !Ref 'TagManagerCloudfrontCachePolicy'

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -321,7 +321,7 @@ Resources:
           CachePolicyId: !Ref 'TagManagerCloudfrontCachePolicy'
           Compress: true
           TargetOriginId: !Ref 'TagManagerLoadBalancer'
-        ViewerProtocolPolicy: "allow-all"
+          ViewerProtocolPolicy: "allow-all"
         Enabled: true
         HttpVersion: "http2"
         IPV6Enabled: true

--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -286,15 +286,15 @@ Resources:
     Type: "AWS::CloudFront::CachePolicy"
     Properties:
       CachePolicyConfig:
-        DefaultTTL: 86400
-        MaxTTL: 31536000
+        DefaultTTL: 3600
+        MaxTTL: 3600
         MinTTL: 0
         Name: !Sub "tag-manager-cache-policy-${Stage}"
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
             CookieBehavior: "all"
-          EnableAcceptEncodingBrotli: false
-          EnableAcceptEncodingGzip: false
+          EnableAcceptEncodingBrotli: true
+          EnableAcceptEncodingGzip: true
           HeadersConfig:
             HeaderBehavior: "whitelist"
             Headers:
@@ -318,10 +318,13 @@ Resources:
             - "GET"
             - "HEAD"
             - "OPTIONS"
+            - "PUT"
+            - "POST"
+            - "DELETE"
           CachePolicyId: !Ref 'TagManagerCloudfrontCachePolicy'
           Compress: true
           TargetOriginId: !Ref 'TagManagerLoadBalancer'
-          ViewerProtocolPolicy: "allow-all"
+          ViewerProtocolPolicy: "redirect-to-https"
         Enabled: true
         HttpVersion: "http2"
         IPV6Enabled: true


### PR DESCRIPTION
## What does this change?

This adds a CloudFront Distribution to Tagmanager, along with a CloudFront Cache Policy.

Traffic to Tagmanager will now go to via the Cloudfront CDN, rather than directly to our Load balancer, which should improve load times for users further from `eu-west-1` (Ireland), for example editorial staff in the US and Australia.

This branch is dependent on:
- https://github.com/guardian/tagmanager/pull/515 (define DNS record in CloudFormation).
- https://github.com/guardian/tagmanager/pull/516 (add Cloudformation Certificate)

In order for this PR to work in PROD, the Certificate PR will need to be merged, and the ARN of the created certificate in `us-east-1` will need to be manually added to Parameter Store in `eu-west-1` (e.g. in the AWS web dashboard), under the name `/PROD/flexible/tagmanager/cloudFrontCertificateArn`.

The PR also reduces the DNS times for PROD and CODE to a consistent `3600` seconds (i.e 1 hour)

## How to test

Deploy this branch to CODE. Does the deploy successfully complete?

Check back after at least 2 hours (the TTL set before this PR for the DNS record). Does the DNS record now point to the CloudFront distribution? 

You should be able to check the DNS record with `dig tagmanager.gutools.co.uk @dns1.p02.nsone.net.` and compare against the CloudFront DNS record in the AWS console.
