### PR TITLE
enforce tag_manager_access permission

### DIFF
--- a/app/views/Application/authError.scala.html
+++ b/app/views/Application/authError.scala.html
@@ -1,0 +1,13 @@
+@(message: String)
+<!DOCTYPE html>
+<html>
+  <head lang="en">
+    <meta charset="UTF-8">
+    <title>Tag Manager - access denied</title>
+  </head>
+  <body>
+    <h1>Tag Manager - access denied</h1>
+    <p>@message</p>
+    <p>If you require access to the Tag Manager tool, please contact <a href="mailto:central.production@@theguardian.com">Central Production</a> for assistance</p>
+  </body>
+</html>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Follows up #513 to enforce the new tag_manager_access permission.

Need to grant access to all users who need to access before we can merge this...