### PR TITLE
Increase DNS TTL back to 3600s

### DIFF
--- a/cloudformation/tag-manager.yaml
+++ b/cloudformation/tag-manager.yaml
@@ -389,7 +389,7 @@ Resources:
           - - !GetAtt TagManagerCloudFrontDistribution.DomainName
             - "."
       Stage: !Ref Stage
-      TTL: 60
+      TTL: 3600
   TagManagerLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:


### PR DESCRIPTION
This was the value before the switch to Cloudfront. Now that we are happy with the change, we can dial the TTL back up