### PR TITLE
Pre-Scala 2.13: Remove deprecated `ProcedureSyntax` - use `def x(): Unit = {...}`

### DIFF
--- a/app/model/jobs/JobRunner.scala
+++ b/app/model/jobs/JobRunner.scala
@@ -27,7 +27,7 @@ class JobRunner @Inject() (lifecycle: ApplicationLifecycle)(implicit ec: Executi
   lifecycle.addStopHook{ () => Future.successful(stop) }
   serviceManager.startAsync()
 
-  def stop {
+  def stop: Unit = {
     serviceManager.stopAsync()
     serviceManager.awaitStopped(20, TimeUnit.SECONDS)
   }

--- a/app/model/jobs/Step.scala
+++ b/app/model/jobs/Step.scala
@@ -15,13 +15,13 @@ trait Step extends Logging {
 
   // Inner details
   /** Do work. */
-  protected def process(implicit ec: ExecutionContext)
+  protected def process(implicit ec: ExecutionContext): Unit
 
   /** Confirm this check ran successfully */
   protected def check(implicit ec: ExecutionContext): Boolean
 
   /** Undo this step */
-  protected def rollback
+  protected def rollback: Unit
 
   // Public methods that wrap the status updates
   def processStep(implicit ec: ExecutionContext) = {

--- a/app/modules/clustersync/ClusterSynchronisation.scala
+++ b/app/modules/clustersync/ClusterSynchronisation.scala
@@ -32,7 +32,7 @@ class ClusterSynchronisation @Inject() (lifecycle: ApplicationLifecycle) extends
 
   initialise
 
-  def initialise {
+  def initialise: Unit = {
     try {
       logger.info("starting sync components...")
       val ns = NodeStatusRepository.register()
@@ -57,7 +57,7 @@ class ClusterSynchronisation @Inject() (lifecycle: ApplicationLifecycle) extends
     }
   }
 
-  def pause {
+  def pause: Unit = {
     logger.warn("pausing cluster synchronisation")
     tagCacheSynchroniser.get.foreach{consumer =>
       logger.warn("stopping consumer")
@@ -72,7 +72,7 @@ class ClusterSynchronisation @Inject() (lifecycle: ApplicationLifecycle) extends
     }
   }
 
-  def heartbeat {
+  def heartbeat: Unit = {
     try {
       reservation.get() match {
         case Some(ns) => {

--- a/app/modules/clustersync/NodeStatusRepository.scala
+++ b/app/modules/clustersync/NodeStatusRepository.scala
@@ -90,7 +90,7 @@ object NodeStatusRepository extends Logging {
     }
   }
 
-  def deregister(nodeStatus: NodeStatus) {
+  def deregister(nodeStatus: NodeStatus): Unit = {
 
     logger.info(s"deregistering as node ${nodeStatus.nodeId}")
 

--- a/app/modules/clustersync/SectionSyncUpdateProcessor.scala
+++ b/app/modules/clustersync/SectionSyncUpdateProcessor.scala
@@ -43,7 +43,7 @@ object SectionSyncUpdateProcessor extends KinesisStreamRecordProcessor with Logg
 
   }
 
-  private def updateSectionLookupCache(sectionEvent: SectionEvent) {
+  private def updateSectionLookupCache(sectionEvent: SectionEvent): Unit = {
     sectionEvent.eventType match {
       case EventType.Update =>
         logger.info(s"inserting updated section ${sectionEvent.sectionId} into lookup cache")

--- a/app/modules/clustersync/TagSyncUpdateProcessor.scala
+++ b/app/modules/clustersync/TagSyncUpdateProcessor.scala
@@ -34,7 +34,7 @@ object TagEventDeserialiser {
 
 object TagSyncUpdateProcessor extends KinesisStreamRecordProcessor with Logging {
 
-  override def process(record: Record) {
+  override def process(record: Record): Unit = {
     logger.info(s"Kinesis consumer receives record \n $record")
     TagEventDeserialiser.deserialise(record) match {
       case Success(tagEvent) => updateTagsLookupCache(tagEvent)

--- a/app/repositories/Sequences.scala
+++ b/app/repositories/Sequences.scala
@@ -31,7 +31,7 @@ class DynamoSequence(sequenceTable: Table, sequenceName: String) {
     Dynamo.sequenceTable.getItem("sequenceName", sequenceName).getLong("value")
   }
 
-  def setCurrentId(v: Long) {
+  def setCurrentId(v: Long): Unit = {
     Dynamo.sequenceTable.putItem(new Item().withString("sequenceName", sequenceName).withLong("value", v))
   }
 }

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -79,21 +79,21 @@ object SQS {
 
 class KinesisStreamProducer(streamName: String, requireCompressionByte: Boolean = false) extends Logging {
 
-  def publishUpdate(key: String, data: String) {
+  def publishUpdate(key: String, data: String): Unit = {
     publishUpdate(key, ByteBuffer.wrap(data.getBytes("UTF-8")))
   }
 
-  def publishUpdate(key: String, data: Array[Byte]) {
+  def publishUpdate(key: String, data: Array[Byte]): Unit = {
     publishUpdate(key, ByteBuffer.wrap(data))
   }
 
-  def publishUpdate(key: String, struct: ThriftStruct) {
+  def publishUpdate(key: String, struct: ThriftStruct): Unit = {
     logger.info(s"Kinesis Producer publishUpdate for streamName: $streamName")
     val thriftKinesisEvent: Array[Byte] = ThriftSerializer.serializeToBytes(struct, requireCompressionByte)
     publishUpdate(key, ByteBuffer.wrap(thriftKinesisEvent))
   }
 
-  def publishUpdate(key: String, dataBuffer: ByteBuffer) {
+  def publishUpdate(key: String, dataBuffer: ByteBuffer): Unit = {
     AWS.Kinesis.putRecord(streamName, dataBuffer, key)
   }
 }

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -37,8 +37,8 @@ class KinesisConsumer(streamName: String, appName: String, processor: KinesisStr
     .config(kinesisClientLibConfiguration)
     .build()
 
-  def start() { Future{ worker.run() } }
-  def stop() { worker.shutdown() }
+  def start(): Unit = { Future{ worker.run() } }
+  def stop(): Unit = { worker.shutdown() }
 }
 
 class KinesisProcessorConsumerFactory(appName: String, processor: KinesisStreamRecordProcessor) extends IRecordProcessorFactory {

--- a/app/services/SQSQueue.scala
+++ b/app/services/SQSQueue.scala
@@ -22,7 +22,7 @@ class SQSQueue(val queueName: String) {
     response.getMessages.asScala.toList
   }
 
-  def deleteMessage(message: Message) {
+  def deleteMessage(message: Message): Unit = {
     SQS.SQSClient.deleteMessage(
       new DeleteMessageRequest(queueUrl, message.getReceiptHandle)
     )


### PR DESCRIPTION
This change was automated with ScalaFix - in my `~/.sbt/1.0/plugins.sbt` file, I added this line:

```
addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
```

Then at the sbt console ran:

```
scalafixEnable
scalafixAll ProcedureSyntax
```

...steps copied from https://github.com/guardian/content-api/pull/2893 & https://github.com/guardian/content-api/pull/2894 .

## See also

* https://github.com/guardian/content-api/pull/2894
* https://github.com/guardian/mobile-apps-api/pull/2726
