### PR TITLE
Add Prout to know when PRs are deployed or overdue

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,5 @@
+{
+  "checkpoints": {
+    "PROD": { "url": "https://tagmanager.gutools.co.uk/management/healthcheck", "overdue": "30M" }
+  }
+}

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.gu.tagmanager.BuildInfo
 import play.api.Logging
 import play.api.libs.ws.WSClient
 import play.api.mvc.{BaseController, ControllerComponents}
@@ -16,8 +17,9 @@ class Management(
   extends BaseController
     with Logging {
 
+  def manifest = Action { _ => Ok(BuildInfo.toJson) }
+
   def healthCheck = Action {
     Ok("OK")
   }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val dependencies = Seq(
 
 dependencyOverrides += "org.bouncycastle" % "bcprov-jdk15on" % "1.67"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, JDebPackaging, SystemdPlugin)
+lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(
     playDefaultPort := 8247,
@@ -67,6 +67,13 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, JDebPack
     scalaVersion := scalaVer,
     ThisBuild / scalaVersion := scalaVer,
     libraryDependencies ++= dependencies,
+    buildInfoKeys := Seq(
+      name,
+      BuildInfoKey.sbtbuildinfoConstantEntry("buildTime", System.currentTimeMillis),
+      "gitCommitId" -> Option(System.getenv("GITHUB_SHA")).getOrElse("Unknown")
+    ),
+    buildInfoPackage := "com.gu.tagmanager",
+    buildInfoOptions := Seq(BuildInfoOption.ToJson),
 
     gzip / includeFilter := "*.html" || "*.css" || "*.js",
     pipelineStages := Seq(digest, gzip),

--- a/conf/routes
+++ b/conf/routes
@@ -106,6 +106,7 @@ GET            /reauth                                                 controlle
 
 # Management
 +anyhost
+GET            /management/manifest                                    controllers.Management.manifest()
 GET            /management/healthcheck                                 controllers.Management.healthCheck
 
 # Map static resources from the /public folder to the /assets URL path

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,8 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
+
 // need to add jdeb dependency explicitly because https://github.com/sbt/sbt-native-packager/issues/1053
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
 


### PR DESCRIPTION
Adds [Prout](https://www.theguardian.com/info/developer-blog/2015/feb/03/prout-is-your-pull-request-out), to let us know when our changes don't ship as expected, or when they are ready to check in Production!

This PR uses https://github.com/guardian/permissions/pull/174 as a recent example of adding Prout, other examples include:

* https://github.com/guardian/typerighter/pull/465
* https://github.com/guardian/dotcom-rendering/pull/9692
