### PR TITLE
Pre-Scala 2.13: Fix JavaConversions warnings with `scala-collection-compat`

### DIFF
--- a/app/model/jobs/JobRunner.scala
+++ b/app/model/jobs/JobRunner.scala
@@ -19,11 +19,12 @@ import scala.util.control.NonFatal
 import java.net.InetAddress
 import java.util.concurrent.TimeUnit
 import scala.util.Random
+import scala.jdk.CollectionConverters._
 
 @Singleton
 class JobRunner @Inject() (lifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends Logging {
   // Scheduler boiler plate
-  val serviceManager = new ServiceManager(List(new JobRunnerScheduler(this)))
+  val serviceManager = new ServiceManager(List(new JobRunnerScheduler(this)).asJava)
   lifecycle.addStopHook{ () => Future.successful(stop) }
   serviceManager.startAsync()
 

--- a/app/modules/clustersync/ClusterSynchronisation.scala
+++ b/app/modules/clustersync/ClusterSynchronisation.scala
@@ -15,11 +15,12 @@ import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
+import scala.jdk.CollectionConverters._
 
 @Singleton
 class ClusterSynchronisation @Inject() (lifecycle: ApplicationLifecycle) extends Logging {
 
-  val serviceManager = new ServiceManager(List(new NodeStatusHeartbeater(this)))
+  val serviceManager = new ServiceManager(List(new NodeStatusHeartbeater(this)).asJava)
 
   val reservation: AtomicReference[Option[NodeStatus]] = new AtomicReference[Option[NodeStatus]](None)
   val tagCacheSynchroniser: AtomicReference[Option[KinesisConsumer]] = new AtomicReference[Option[KinesisConsumer]](None)

--- a/app/modules/clustersync/NodeStatusRepository.scala
+++ b/app/modules/clustersync/NodeStatusRepository.scala
@@ -9,7 +9,7 @@ import helpers.JodaDateTimeFormat._
 import play.api.Logging
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 
 case class HeartbeatException(message: String) extends RuntimeException(message)
@@ -114,7 +114,7 @@ object NodeStatusRepository extends Logging {
     }
   }
 
-  def getCurrentState = Dynamo.clusterStatusTable.scan().map(NodeStatus.fromItem).toList
+  def getCurrentState = Dynamo.clusterStatusTable.scan().asScala.map(NodeStatus.fromItem).toList
 
 }
 

--- a/app/modules/sponsorshiplifecycle/SponsorshipLifecycleModule.scala
+++ b/app/modules/sponsorshiplifecycle/SponsorshipLifecycleModule.scala
@@ -12,6 +12,7 @@ import repositories.SponsorshipRepository
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
+import scala.jdk.CollectionConverters._
 
 @Singleton
 class SponsorshipLifecycleJobs @Inject() (
@@ -25,7 +26,7 @@ class SponsorshipLifecycleJobs @Inject() (
   logger.info("Starting sponsorship lifecycle jobs")
   lazy val scheduledJobs = List(new SponsorshipLauncher, new SponsorshipExpirer)
 
-  lazy val serviceManager = new ServiceManager(scheduledJobs)
+  lazy val serviceManager = new ServiceManager(scheduledJobs.asJava)
 
   serviceManager.startAsync()
 

--- a/app/repositories/AppAuditRepository.scala
+++ b/app/repositories/AppAuditRepository.scala
@@ -5,7 +5,7 @@ import model.AppAudit
 import org.joda.time.{Duration, ReadableDuration, DateTime}
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 object AppAuditRepository {
   def upsertAppAudit(appAudit: AppAudit): Unit = {
@@ -17,6 +17,7 @@ object AppAuditRepository {
     val from = new DateTime().minus(timePeriod).getMillis
     Dynamo.appAuditTable.getIndex("operation-date-index")
       .query("operation", operation, new RangeKeyCondition("date").ge(from))
+      .asScala
       .map(AppAudit.fromItem).toList
   }
 }

--- a/app/repositories/ExternalReferencesTypeRepository.scala
+++ b/app/repositories/ExternalReferencesTypeRepository.scala
@@ -5,7 +5,7 @@ import model.ExternalReferenceType
 import play.api.libs.json.JsValue
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 
 object ExternalReferencesTypeRepository {
@@ -23,6 +23,6 @@ object ExternalReferencesTypeRepository {
     }
   }
 
-  def loadAllReferenceTypes = Dynamo.referencesTypeTable.scan().map(ExternalReferenceType.fromItem)
+  def loadAllReferenceTypes = Dynamo.referencesTypeTable.scan().asScala.map(ExternalReferenceType.fromItem)
 
 }

--- a/app/repositories/JobRepository.scala
+++ b/app/repositories/JobRepository.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.JsValue
 import scala.util.control.NonFatal
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 
 object JobRepository {
@@ -99,10 +99,10 @@ object JobRepository {
   }
 
   def loadAllJobs = {
-    Dynamo.jobTable.scan().map(Job.fromItem(_)).toList
+    Dynamo.jobTable.scan().asScala.map(Job.fromItem(_)).toList
   }
 
   def findJobsForTag(tagId: Long): List[Job] = {
-    Dynamo.jobTable.scan(new ScanFilter("tagIds").contains(tagId)).map(Job.fromItem).toList
+    Dynamo.jobTable.scan(new ScanFilter("tagIds").contains(tagId)).asScala.map(Job.fromItem).toList
   }
 }

--- a/app/repositories/PillarAuditRepository.scala
+++ b/app/repositories/PillarAuditRepository.scala
@@ -6,7 +6,7 @@ import helpers.JodaDateTimeFormat._
 import org.joda.time.{DateTime, Duration, ReadableDuration}
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 
 object PillarAuditRepository {
@@ -17,13 +17,14 @@ object PillarAuditRepository {
   }
 
   def getAuditTrailForPillar(pillarId: Long): List[PillarAudit] = {
-    Dynamo.pillarAuditTable.query("pillarId", pillarId).map(PillarAudit.fromItem).toList
+    Dynamo.pillarAuditTable.query("pillarId", pillarId).asScala.map(PillarAudit.fromItem).toList
   }
 
   def getRecentAuditOfPillarOperation(operation: String, timePeriod: ReadableDuration = Duration.standardDays(7)): List[PillarAudit] = {
     val from = new DateTime().minus(timePeriod).getMillis
     Dynamo.pillarAuditTable.getIndex("operation-date-index")
       .query("operation", operation, new RangeKeyCondition("date").ge(from))
+      .asScala
       .map(PillarAudit.fromItem).toList
   }
 }

--- a/app/repositories/PillarRepository.scala
+++ b/app/repositories/PillarRepository.scala
@@ -4,7 +4,7 @@ import model.Pillar
 import play.api.Logging
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 
@@ -33,7 +33,7 @@ object PillarRepository extends Logging {
     }
   }
 
-  def loadAllPillars: Iterable[Pillar] = Dynamo.pillarTable.scan().map(Pillar.fromItem)
+  def loadAllPillars: Iterable[Pillar] = Dynamo.pillarTable.scan().asScala.map(Pillar.fromItem)
 
-  def count = Dynamo.pillarTable.scan().count(_ => true)
+  def count = Dynamo.pillarTable.scan().asScala.count(_ => true)
 }

--- a/app/repositories/SectionAuditRepository.scala
+++ b/app/repositories/SectionAuditRepository.scala
@@ -7,7 +7,7 @@ import org.joda.time.{DateTime, Duration, ReadableDuration}
 import play.api.Logging
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 
 object SectionAuditRepository {
@@ -18,13 +18,14 @@ object SectionAuditRepository {
   }
 
   def getAuditTrailForSection(sectionId: Long): List[SectionAudit] = {
-    Dynamo.sectionAuditTable.query("sectionId", sectionId).map(SectionAudit.fromItem).toList
+    Dynamo.sectionAuditTable.query("sectionId", sectionId).asScala.map(SectionAudit.fromItem).toList
   }
 
   def getRecentAuditOfSectionOperation(operation: String, timePeriod: ReadableDuration = Duration.standardDays(7)): List[SectionAudit] = {
     val from = new DateTime().minus(timePeriod).getMillis
     Dynamo.sectionAuditTable.getIndex("operation-date-index")
       .query("operation", operation, new RangeKeyCondition("date").ge(from))
+      .asScala
       .map(SectionAudit.fromItem).toList
   }
 }

--- a/app/repositories/SectionRepository.scala
+++ b/app/repositories/SectionRepository.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.dynamodbv2.document.Item
 import model.Section
 import play.api.libs.json.JsValue
 import services.Dynamo
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import java.util.concurrent.atomic.AtomicReference
 
 
@@ -22,9 +22,9 @@ object SectionRepository {
     }
   }
 
-  def loadAllSections = Dynamo.sectionTable.scan().map(Section.fromItem)
+  def loadAllSections = Dynamo.sectionTable.scan().asScala.map(Section.fromItem)
 
-  def count = Dynamo.sectionTable.scan().count(_ => true)
+  def count = Dynamo.sectionTable.scan().asScala.count(_ => true)
 
 }
 

--- a/app/repositories/SponsorshipRepository.scala
+++ b/app/repositories/SponsorshipRepository.scala
@@ -6,7 +6,7 @@ import model.Sponsorship
 import org.joda.time.DateTime
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 
 object SponsorshipRepository {
@@ -26,14 +26,14 @@ object SponsorshipRepository {
     }
   }
 
-  def loadAllSponsorships = Dynamo.sponsorshipTable.scan().map(Sponsorship.fromItem)
+  def loadAllSponsorships = Dynamo.sponsorshipTable.scan().asScala.map(Sponsorship.fromItem)
 
   def searchSponsorships(criteria: SponsorshipSearchCriteria) = {
     val filters = criteria.asFilters
     if (filters.isEmpty) {
-      Dynamo.sponsorshipTable.scan().map(Sponsorship.fromItem).toList
+      Dynamo.sponsorshipTable.scan().asScala.map(Sponsorship.fromItem).toList
     } else {
-      Dynamo.sponsorshipTable.scan(filters: _*).map(Sponsorship.fromItem).toList
+      Dynamo.sponsorshipTable.scan(filters: _*).asScala.map(Sponsorship.fromItem).toList
     }
   }
 
@@ -43,25 +43,25 @@ object SponsorshipRepository {
       new ScanFilter("validFrom").lt(now),
       new ScanFilter("validTo").gt(now),
       new ScanFilter("status").ne("active")
-    ).map(Sponsorship.fromItem).toList
+    ).asScala.map(Sponsorship.fromItem).toList
 
     val withoutEnd = Dynamo.sponsorshipTable.scan(
       new ScanFilter("validFrom").lt(now),
       new ScanFilter("validTo").notExist(),
       new ScanFilter("status").ne("active")
-    ).map(Sponsorship.fromItem).toList
+    ).asScala.map(Sponsorship.fromItem).toList
 
     val withoutStartAndNotEnded = Dynamo.sponsorshipTable.scan(
       new ScanFilter("validFrom").notExist(),
       new ScanFilter("validTo").gt(now),
       new ScanFilter("status").ne("active")
-    ).map(Sponsorship.fromItem).toList
+    ).asScala.map(Sponsorship.fromItem).toList
 
     val alwaysActive = Dynamo.sponsorshipTable.scan(
       new ScanFilter("validFrom").notExist(),
       new ScanFilter("validTo").notExist(),
       new ScanFilter("status").ne("active")
-    ).map(Sponsorship.fromItem).toList
+    ).asScala.map(Sponsorship.fromItem).toList
 
     withEnd ::: withoutEnd ::: withoutStartAndNotEnded ::: alwaysActive
   }
@@ -72,7 +72,7 @@ object SponsorshipRepository {
     Dynamo.sponsorshipTable.scan(
       new ScanFilter("validTo").lt(now),
       new ScanFilter("status").eq("active")
-    ).map(Sponsorship.fromItem).toList
+    ).asScala.map(Sponsorship.fromItem).toList
   }
 
 }

--- a/app/repositories/TagRepository.scala
+++ b/app/repositories/TagRepository.scala
@@ -9,7 +9,7 @@ import play.api.Logging
 import play.api.libs.json.JsValue
 import services.Dynamo
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 
 object TagRepository extends Logging {
@@ -31,12 +31,12 @@ object TagRepository extends Logging {
   }
 
   def scanSearch(criteria: TagSearchCriteria) = {
-    Dynamo.tagTable.scan(criteria.asFilters: _*).map { item =>
+    Dynamo.tagTable.scan(criteria.asFilters: _*).asScala.map { item =>
       item.getString("internalName")
     }
   }
 
-  def loadAllTags = Dynamo.tagTable.scan().map(Tag.fromItem)
+  def loadAllTags = Dynamo.tagTable.scan().asScala.map(Tag.fromItem)
 
   def allTagIter = Dynamo.tagTable.scan()
 }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -5,7 +5,7 @@ import java.util.Properties
 import com.amazonaws.services.s3.model.GetObjectRequest
 import services.Config._
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 
 object Config extends AwsInstanceTags {
@@ -46,7 +46,7 @@ sealed trait Config {
     lazy val stack = readTag("Stack") getOrElse "flexible"
     lazy val stage = readTag("Stage") getOrElse "DEV"
     lazy val app = readTag("App") getOrElse "tag-manager"
-    lazy val region = remoteConfiguration.getOrDefault("aws.region", "eu-west-1")
+    lazy val region = remoteConfiguration.getOrElse("aws.region", "eu-west-1")
   }
 
   private def loadConfiguration = {
@@ -68,7 +68,7 @@ sealed trait Config {
     loadPropertiesFromS3(s"${aws.app}/global.properties", props)
     loadPropertiesFromS3(s"${aws.app}/${aws.stage}.properties", props)
 
-    props.toMap
+    props.asScala.toMap
   }
 
   lazy val permissionsStage: String = readTag("Stage") match {

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -13,7 +13,7 @@ import org.apache.thrift.protocol.{TCompactProtocol, TProtocol}
 import org.apache.thrift.transport.TIOStreamTransport
 import play.api.Logging
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.language.implicitConversions
@@ -64,7 +64,7 @@ class KinesisProcessorConsumer(appName: String, processor: KinesisStreamRecordPr
 
   override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
 
-    processRecordsInput.getRecords foreach { record =>
+    processRecordsInput.getRecords.asScala foreach { record =>
       processor.process(record)
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val dependencies = Seq(
   "com.typesafe.play" %% "play-json-joda" % "2.8.1",
   "org.apache.commons" % "commons-lang3" % "3.11",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0"
 )
 
 dependencyOverrides += "org.bouncycastle" % "bcprov-jdk15on" % "1.67"


### PR DESCRIPTION
This codebase was using `scala.collection.JavaConversions._`, which has been deprecated since Scala 2.12. Rather than update to Scala 2.12 syntax, and then later to Scala 2.13 syntax, here we use the [`scala-collection-compat`](https://github.com/scala/scala-collection-compat) library to allow us to use Scala 2.13 syntax immediately.

The scala-collection-compat library comes with a choice of ScalaFix migrations to automate this update:

https://github.com/scala/scala-collection-compat?tab=readme-ov-file#migration-rules

...but they didn't work well for us (introduced a lot of `.iterator` calls on `Iterable`s, for some reason) so we made these changes manually.
