### PR TITLE
Include `contributorInformation` in Hypermedia API

### DIFF
--- a/app/model/TagEntity.scala
+++ b/app/model/TagEntity.scala
@@ -20,7 +20,8 @@ case class TagEntity(
   path: String,
   subType: Option[String],
   adBlockingLevel: Option[BlockingLevel],
-  contributionBlockingLevel: Option[BlockingLevel]
+  contributionBlockingLevel: Option[BlockingLevel],
+  contributorInformation: Option[ContributorInformation] = None,
 )
 
 object TagEntity {
@@ -54,7 +55,8 @@ object TagEntity {
         tag.path,
         subtype,
         tag.adBlockingLevel,
-        tag.contributionBlockingLevel
+        tag.contributionBlockingLevel,
+        tag.contributorInformation
       )
   }
 
@@ -81,7 +83,8 @@ object TagEntity {
       "section" -> Json.toJson(te.section),
       "parents" -> JsArray(te.parents.map(Json.toJson(_)).toSeq),
       "externalReferences" -> JsArray(te.references.map(Json.toJson(_))),
-      "path" -> JsString(te.path)
+      "path" -> JsString(te.path),
+      "contributorInformation" -> Json.toJson(te.contributorInformation)
     ) ++ te.subType.map("subType" -> JsString(_))
       ++ te.adBlockingLevel.map(level => "adBlockingLevel" -> JsString(level.entryName))
       ++ te.contributionBlockingLevel.map(level => "contributionBlockingLevel" -> JsString(level.entryName))


### PR DESCRIPTION
## What does this change?

Include optional `contributorInformation` in Hypermedia API so that we can pull in contributor images easily in flexible-content, for use in the multi-byline element. 

Currently, flexible-content accesses tag information via the `/hyper` endpoint, and to save additional requests we want to be able to retrieve contributor information and images from there too.

| Contributor Tag (includes `contributorInformation`) | Topic tag (doesn't include `contributorInformation`) |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f72a5d73-05ee-48aa-80c1-c0496a4a4fc2) | ![image](https://github.com/user-attachments/assets/bab55ea3-3a37-4419-b182-873fc3647025) |

This is an optional property of `TagEntity` that will be excluded when not present.

## How to test

Deploy to CODE, and visit https://tagmanager.code.dev-gutools.co.uk/hyper/tags/65197

Does the Contributor information appear?
