### PR TITLE
Remove unused endpoints

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -65,24 +65,4 @@ class App(
     Future.successful(Ok(result))
   }
 
-  def hello = AuthAction {
-    logger.info("saying hello")
-    Ok(views.html.Application.hello("Hello world"))
-  }
-
-  def testScan = Action { req =>
-
-    val criteria = TagSearchCriteria(
-      q = req.getQueryString("q"),
-      types = req.getQueryString("types").map(_.split(",").toList)
-    )
-
-    val startTime = System.currentTimeMillis
-    val paths = TagRepository.scanSearch(criteria)
-    val time = System.currentTimeMillis - startTime
-
-    paths foreach println
-    Ok(s"scan complete ${paths.size} items in $time ms")
-  }
-
 }

--- a/conf/routes
+++ b/conf/routes
@@ -100,9 +100,6 @@ GET            /tools/newspaperintegration/tags/deleted/:since         controlle
 GET            /tools/newspaperintegration/tags/created/:since         controllers.ReadOnlyApi.createsAsXml(since: Long)
 
 
-GET            /hello                                                  controllers.App.hello
-GET            /testScan                                               controllers.App.testScan
-
 GET            /oauthCallback                                          controllers.Login.oauthCallback
 GET            /logout                                                 controllers.Login.logout
 GET            /reauth                                                 controllers.Login.reauth


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR removes the `/hello` and `/testScan` endpoints, which are unused.

The `testScan` endpoint runs a full DB scan and is not authenticated, so it would be good to remove it.

## How to test

1. Deploy to CODE and check the app is working as usual. 
2. Check that the `/hello` and `/testScan` endpoints are no active functional.