### PR TITLE
Revert "Pre-Scala 2.13: Upgrade dependencies to versions also available for Scala 2.13"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "tag-manager"
 
 version := "1.0"
 
-lazy val scalaVer = "2.12.19"
+lazy val scalaVer = "2.12.16"
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
@@ -27,20 +27,20 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.14.10",
   "com.gu" %% "pan-domain-auth-play_2-8" % "4.0.0",
-  "com.gu" %% "editorial-permissions-client" % "2.15",
+  "com.gu" %% "editorial-permissions-client" % "2.0",
   ws, // for panda
   "ai.x" %% "play-json-extensions" % "0.42.0",
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.google.guava" % "guava" % "18.0",
-  "com.gu" %% "content-api-client-default" % "31.0.3",
+  "com.gu" %% "content-api-client-default" % "17.24.1",
   "com.gu" %% "tags-thrift-schema" % "2.8.3",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",
   "com.gu"  %% "panda-hmac-play_2-8" % "4.0.0",
-  "com.gu" %% "content-api-client-aws" % "0.7.4",
+  "com.gu" %% "content-api-client-aws" % "0.5",
   "com.beachape" %% "enumeratum" % "1.5.13",
-  "org.scalatest" %% "scalatest" % "3.2.19" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "com.typesafe.play" %% "play-json-joda" % "2.8.1",
   "org.apache.commons" % "commons-lang3" % "3.11",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2",

--- a/test/model/BatchTagOperationTest.scala
+++ b/test/model/BatchTagOperationTest.scala
@@ -1,9 +1,8 @@
 package model
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest._
 
-class BatchTagOperationTest extends AnyFlatSpec with Matchers {
+class BatchTagOperationTest extends FlatSpec with Matchers {
   "AddToBottom operation" should "parse correctly" in {
     BatchTagOperation.AddToBottom.entryName should be ("add-to-bottom")
   }

--- a/test/modules/clustersync/SectionEventDeserialiserTest.scala
+++ b/test/modules/clustersync/SectionEventDeserialiserTest.scala
@@ -1,15 +1,15 @@
 package modules.clustersync
 
+import java.nio.ByteBuffer
+
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.tagmanagement.{EventType, SectionEvent}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.{FlatSpec, Matchers}
 import services.ThriftSerializer
 
-import java.nio.ByteBuffer
 import scala.util.Success
 
-class SectionEventDeserialiserTest extends AnyFlatSpec with Matchers {
+class SectionEventDeserialiserTest extends FlatSpec with Matchers {
 
   it should "serialise byte stream from Kinesis record" in {
 

--- a/test/modules/clustersync/TagEventDeserialiserTest.scala
+++ b/test/modules/clustersync/TagEventDeserialiserTest.scala
@@ -1,15 +1,15 @@
 package modules.clustersync
 
+import java.nio.ByteBuffer
+
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.tagmanagement.{EventType, TagEvent}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.{FlatSpec, FunSuite, Matchers, TryValues}
 import services.ThriftSerializer
 
-import java.nio.ByteBuffer
 import scala.util.Success
 
-class TagEventDeserialiserTest extends AnyFlatSpec with Matchers  {
+class TagEventDeserialiserTest extends  FlatSpec with Matchers  {
 
   it should  "serialise byte stream from Kinesis record" in {
 

--- a/test/modules/clustersync/TagSyncUpdateProcessorTest.scala
+++ b/test/modules/clustersync/TagSyncUpdateProcessorTest.scala
@@ -1,17 +1,16 @@
 package modules.clustersync
 
+import java.nio.ByteBuffer
+
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.tagmanagement.{EventType, TagEvent}
 import model.BlockingLevel
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.{FlatSpec, Matchers}
 import repositories.TagLookupCache
 import services.ThriftSerializer
 import utils.TagTestUtils._
 
-import java.nio.ByteBuffer
-
-class TagSyncUpdateProcessorTest extends AnyFlatSpec with Matchers {
+class TagSyncUpdateProcessorTest extends FlatSpec with Matchers {
 
   behavior of "TagSyncUpdateProcessor.process()"
 

--- a/test/repositories/TagLookupCacheTest.scala
+++ b/test/repositories/TagLookupCacheTest.scala
@@ -1,11 +1,9 @@
 package repositories
 
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import utils.TagTestUtils._
 
-class TagLookupCacheTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
+class TagLookupCacheTest extends FlatSpec with BeforeAndAfterEach with Matchers {
 
   private val cache = TagLookupCache
 


### PR DESCRIPTION
Reverts guardian/tagmanager#522, as unfortunately it [failed to deploy](https://riffraff.gutools.co.uk/deployment/view/67ce92f0-849f-4c4e-abe0-3a4c53ac06ab).