### PR TITLE
Pre-Scala 2.13: Upgrade deps to versions that are also available on Scala 2.13 (redux)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "tag-manager"
 
 version := "1.0"
 
-lazy val scalaVer = "2.12.16"
+lazy val scalaVer = "2.12.19"
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
@@ -27,20 +27,20 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.14.10",
   "com.gu" %% "pan-domain-auth-play_2-8" % "4.0.0",
-  "com.gu" %% "editorial-permissions-client" % "2.0",
+  "com.gu" %% "editorial-permissions-client" % "2.15",
   ws, // for panda
   "ai.x" %% "play-json-extensions" % "0.42.0",
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.google.guava" % "guava" % "18.0",
-  "com.gu" %% "content-api-client-default" % "17.24.1",
+  "com.gu" %% "content-api-client-default" % "27.0.0",
   "com.gu" %% "tags-thrift-schema" % "2.8.3",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",
   "com.gu"  %% "panda-hmac-play_2-8" % "4.0.0",
-  "com.gu" %% "content-api-client-aws" % "0.5",
+  "com.gu" %% "content-api-client-aws" % "0.7.4",
   "com.beachape" %% "enumeratum" % "1.5.13",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "com.typesafe.play" %% "play-json-joda" % "2.8.1",
   "org.apache.commons" % "commons-lang3" % "3.11",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2",

--- a/test/model/BatchTagOperationTest.scala
+++ b/test/model/BatchTagOperationTest.scala
@@ -1,8 +1,9 @@
 package model
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BatchTagOperationTest extends FlatSpec with Matchers {
+class BatchTagOperationTest extends AnyFlatSpec with Matchers {
   "AddToBottom operation" should "parse correctly" in {
     BatchTagOperation.AddToBottom.entryName should be ("add-to-bottom")
   }

--- a/test/modules/clustersync/SectionEventDeserialiserTest.scala
+++ b/test/modules/clustersync/SectionEventDeserialiserTest.scala
@@ -1,15 +1,15 @@
 package modules.clustersync
 
-import java.nio.ByteBuffer
-
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.tagmanagement.{EventType, SectionEvent}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import services.ThriftSerializer
 
+import java.nio.ByteBuffer
 import scala.util.Success
 
-class SectionEventDeserialiserTest extends FlatSpec with Matchers {
+class SectionEventDeserialiserTest extends AnyFlatSpec with Matchers {
 
   it should "serialise byte stream from Kinesis record" in {
 

--- a/test/modules/clustersync/TagEventDeserialiserTest.scala
+++ b/test/modules/clustersync/TagEventDeserialiserTest.scala
@@ -1,15 +1,15 @@
 package modules.clustersync
 
-import java.nio.ByteBuffer
-
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.tagmanagement.{EventType, TagEvent}
-import org.scalatest.{FlatSpec, FunSuite, Matchers, TryValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import services.ThriftSerializer
 
+import java.nio.ByteBuffer
 import scala.util.Success
 
-class TagEventDeserialiserTest extends  FlatSpec with Matchers  {
+class TagEventDeserialiserTest extends AnyFlatSpec with Matchers  {
 
   it should  "serialise byte stream from Kinesis record" in {
 

--- a/test/modules/clustersync/TagSyncUpdateProcessorTest.scala
+++ b/test/modules/clustersync/TagSyncUpdateProcessorTest.scala
@@ -1,16 +1,17 @@
 package modules.clustersync
 
-import java.nio.ByteBuffer
-
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.tagmanagement.{EventType, TagEvent}
 import model.BlockingLevel
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import repositories.TagLookupCache
 import services.ThriftSerializer
 import utils.TagTestUtils._
 
-class TagSyncUpdateProcessorTest extends FlatSpec with Matchers {
+import java.nio.ByteBuffer
+
+class TagSyncUpdateProcessorTest extends AnyFlatSpec with Matchers {
 
   behavior of "TagSyncUpdateProcessor.process()"
 

--- a/test/repositories/TagLookupCacheTest.scala
+++ b/test/repositories/TagLookupCacheTest.scala
@@ -1,9 +1,11 @@
 package repositories
 
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import utils.TagTestUtils._
 
-class TagLookupCacheTest extends FlatSpec with BeforeAndAfterEach with Matchers {
+class TagLookupCacheTest extends AnyFlatSpec with BeforeAndAfterEach with Matchers {
 
   private val cache = TagLookupCache
 


### PR DESCRIPTION
This is a repeat of the work in https://github.com/guardian/tagmanager/pull/522, previously reverted with https://github.com/guardian/tagmanager/pull/531 due to a runtime SLF4J error on startup (literally, running `sbt run` is enough to immediately expose this error, we should have done that!):

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J(W): Ignoring binding found at [jar:file:/usr/share/tag-manager/lib/ch.qos.logback.logback-classic-1.2.11.jar!/org>
SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
Oops, cannot start the server.
java.lang.ClassCastException: org.slf4j.helpers.NOPLoggerFactory cannot be cast to ch.qos.logback.classic.LoggerContext
```

* https://github.com/guardian/maintaining-scala-projects/issues/14

The error occurred because we were including an update to `content-api-client-default` that took it past version [v28.0.0](https://github.com/guardian/content-api-scala-client/releases/tag/v28.0.0), which upgraded `slf4j-api` to v2, which [no longer honours](https://www.slf4j.org/codes.html#ignoredBindings) the old static binder mechanism for finding logging providers. Logback v1.3+ copes with this, and is used by Play [v2.9](https://github.com/guardian/maintaining-scala-projects/issues/1). However, [Play 2.9 requires Scala 2.13](https://www.playframework.com/documentation/3.0.x/Migration29#Scala-2.12-support-discontinued) - and we are not yet on Scala 2.13! - so I'm going to just stick to CAPI client v27.0.0 for this PR.

### Original PR description

As preparation for Scala 2.13, this updates all dependencies so that they are at versions that are available for Scala 2.13 as well as Scala 2.12.

As ScalaTest is updated to ScalaTest v3.2, we had to do some code updates to cope with class/package changes. We did these manually, though later we remembered that maybe we could have used Scalafix, as in this example here:

* https://github.com/guardian/content-api/pull/2893

The steps would have been:

- add sbt-scalafix plugin to user-level sbt plugins file
  - addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
- checked out main branch, still scala 2.12 (and so already compiled successfully)
- launch sbt
- run `scalafixEnable`
- run `scalafixAll dependency:RewriteDeprecatedNames@org.scalatest:autofix:3.1.0.1`
- increment scalatest dependency

## Testing

This has been [successfully deployed](https://riffraff.gutools.co.uk/deployment/view/d4cd0773-4c5b-4a74-a8c6-9cf24aad8248) to https://tagmanager.code.dev-gutools.co.uk/ (which we didn't do with https://github.com/guardian/tagmanager/pull/522!) and the tool looks good:

![image](https://github.com/user-attachments/assets/8ae32801-35e5-4a79-a6b0-46a9de0c9222)

