### PR TITLE
Upgrade to Panda v7 - support key rotation

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,11 +1,8 @@
-import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
-import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
-import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
+import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, S3BucketLoader}
 import controllers.AssetsComponents
 import model.jobs.JobRunner
 import modules.clustersync.ClusterSynchronisation
 import modules.sponsorshiplifecycle.SponsorshipLifecycleJobs
-import permissions.Permissions
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -32,12 +29,10 @@ class AppComponents(context: Context, config: Config)
   new JobRunner(context.lifecycle)
   new SponsorshipLifecycleJobs(context.lifecycle)
 
-  val panDomainSettings = new PanDomainAuthSettingsRefresher(
+  val panDomainSettings = PanDomainAuthSettingsRefresher(
     domain = config.pandaDomain,
     system = config.pandaSystemIdentifier,
-    bucketName = config.pandaBucketName,
-    settingsFileKey= config.pandaSettingsFileKey,
-    s3Client = AWS.S3Client,
+    S3BucketLoader.forAwsSdkV1(AWS.S3Client, "pan-domain-auth-settings")
   )
 
   lazy val router: Router = new Routes(

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ scalacOptions ++= Seq(
 
 lazy val awsVersion = "1.12.403"
 
+val pandaVersion = "7.0.0"
 lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
@@ -26,7 +27,7 @@ lazy val dependencies = Seq(
   "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "amazon-kinesis-client" % "1.14.10",
-  "com.gu" %% "pan-domain-auth-play_2-8" % "4.0.0",
+  "com.gu" %% "pan-domain-auth-play_2-8" % pandaVersion,
   "com.gu" %% "editorial-permissions-client" % "2.15",
   ws, // for panda
   "ai.x" %% "play-json-extensions" % "0.42.0",
@@ -37,7 +38,7 @@ lazy val dependencies = Seq(
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",
-  "com.gu"  %% "panda-hmac-play_2-8" % "4.0.0",
+  "com.gu"  %% "panda-hmac-play_2-8" % pandaVersion,
   "com.gu" %% "content-api-client-aws" % "0.7.4",
   "com.beachape" %% "enumeratum" % "1.5.13",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,


### PR DESCRIPTION
This upgrades Panda from v5 to v7, allowing us to use key rotation as introduced with guardian/pan-domain-authentication#150.

* Panda v6 updates:
  * https://github.com/guardian/pan-domain-authentication/pull/151 introduced the new `S3BucketLoader` abstraction, which simplifies constructing a `PanDomainAuthSettingsRefresher` and means that Panda is no longer _tied_ to AWS SDK v1 - an alternative AWS SDK v2 implementation of `S3BucketLoader` could be introduced.

This PR sits on top of:

* https://github.com/guardian/tagmanager/pull/534 - because [Panda v7](https://github.com/guardian/pan-domain-authentication/releases/tag/v7.0.0) requires Java 11.

### Testing

This has been successfully [deployed](https://riffraff.gutools.co.uk/deployment/view/a8a1b778-cf19-407c-bc64-d77bcc5a6022) to CODE, and I've checked that I'm able to re-authenticate with either the updated https://tagmanager.code.dev-gutools.co.uk/ or the unmodified https://composer.code.dev-gutools.co.uk/ - and they both accept each other's cookies:

https://github.com/user-attachments/assets/89bcf7b5-11e0-4213-b7a7-f58334216c78

