### PR TITLE
Upgrade to Scala 2.13

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.24.8.1

--- a/app/controllers/ReadOnlyApi.scala
+++ b/app/controllers/ReadOnlyApi.scala
@@ -22,7 +22,7 @@ class ReadOnlyApi(
   def getTagsAsXml() = Action {
     val tags = TagLookupCache.allTags
 
-    val sections: Map[Long, Section] = SectionRepository.loadAllSections.map(s => s.id -> s)(collection.breakOut)
+    val sections: Map[Long, Section] = SectionRepository.loadAllSections.map(s => s.id -> s).toMap
     val xmlTags = tags.get.sortBy(_.id).map(_.asExportedXml(sections))
 
     Ok(<tags>
@@ -54,7 +54,7 @@ class ReadOnlyApi(
 
   def tagAsXml(id: Long) = Action {
 
-    val sections: Map[Long, Section] = SectionRepository.loadAllSections.map(s => s.id -> s)(collection.breakOut)
+    val sections: Map[Long, Section] = SectionRepository.loadAllSections.map(s => s.id -> s).toMap
 
 
     TagRepository.getTag(id).map { tag =>
@@ -104,7 +104,7 @@ class ReadOnlyApi(
 
     val tags = audits.map(x => TagRepository.getTag(x.tagId)).flatten
     val root = createElem("tags") % createAttribute("dateRange", dateRange)
-    val sections: Map[Long, Section] = SectionRepository.loadAllSections.map(s => s.id -> s)(collection.breakOut)
+    val sections: Map[Long, Section] = SectionRepository.loadAllSections.map(s => s.id -> s).toMap
 
     val ret = tags.foldLeft(root: Node)((x, parent) => addChild(x, parent.asExportedXml(sections)))
     Ok(ret)
@@ -127,7 +127,7 @@ class ReadOnlyApi(
       case (_ , _) => None
     }
 
-    val sections: Map[Long, Section] = SectionRepository.loadAllSections.map(s => s.id -> s)(collection.breakOut)
+    val sections: Map[Long, Section] = SectionRepository.loadAllSections.map(s => s.id -> s).toMap
     val tags = audits.map(x => TagRepository.getTag(x.tagId)).flatten
     val root = createElem("tags") % createAttribute("dateRange", dateRange)
 

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -287,7 +287,7 @@ class TagManagementApi(
 
     val orderedSponsorships: List[Sponsorship] = orderBy match {
       case("sponsor") => sponsorships.sortBy(_.sponsorName)
-      case("from") => sponsorships.sortBy(_.validFrom.map(_.getMillis).getOrElse(0l))
+      case("from") => sponsorships.sortBy(_.validFrom.map(_.getMillis).getOrElse(0L))
       case("to") => sponsorships.sortBy(_.validTo.map(_.getMillis).getOrElse(Long.MaxValue))
       case("status") => sponsorships.sortBy(_.status)
       case(_) => sponsorships.sortBy(_.sponsorName)

--- a/app/model/Audit.scala
+++ b/app/model/Audit.scala
@@ -5,7 +5,7 @@ import org.joda.time.DateTime
 import helpers.JodaDateTimeFormat._
 import play.api.Logging
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 trait Audit extends Logging {
   def user: String

--- a/app/model/Section.scala
+++ b/app/model/Section.scala
@@ -12,6 +12,7 @@ import repositories.SponsorshipRepository
 
 import scala.util.control.NonFatal
 import scala.xml.Node
+import com.madgag.scala.collection.decorators._
 
 case class Section(
                     id: Long,
@@ -35,7 +36,7 @@ case class Section(
     path          = path,
     wordsForUrl   = wordsForUrl,
     pageId        = pageId,
-    editions      = editions.mapValues(_.asThift),
+    editions      = editions.mapV(_.asThift),
     discriminator = discriminator,
     isMicrosite   = isMicrosite,
     activeSponsorships = if (activeSponsorships.isEmpty) None else Some(activeSponsorships.flatMap {sid =>
@@ -78,7 +79,7 @@ object Section extends Logging {
       path          = thriftSection.path,
       wordsForUrl   = thriftSection.wordsForUrl,
       pageId        = thriftSection.pageId,
-      editions      = thriftSection.editions.mapValues(EditionalisedPage(_)).toMap,
+      editions      = thriftSection.editions.mapV(EditionalisedPage(_)),
       discriminator = thriftSection.discriminator,
       isMicrosite   = thriftSection.isMicrosite,
       activeSponsorships = thriftSection.activeSponsorships.map(_.map(_.id).toList).getOrElse(Nil)

--- a/app/model/command/RemoveEditionFromSectionCommand.scala
+++ b/app/model/command/RemoveEditionFromSectionCommand.scala
@@ -23,7 +23,7 @@ case class RemoveEditionFromSectionCommand(sectionId: Long, editionName: String)
 
     val pageId = try { PathManager.removePathForId(editionInfo.pageId) } catch { case p: PathRemoveFailed => PathNotFound}
 
-    val updatedEditions = section.editions.filterKeys(_.toUpperCase != editionName.toUpperCase)
+    val updatedEditions = section.editions.filterKeys(_.toUpperCase != editionName.toUpperCase).toMap
 
     val updatedSection = section.copy(
       editions = updatedEditions,

--- a/app/model/jobs/JobRunner.scala
+++ b/app/model/jobs/JobRunner.scala
@@ -1,6 +1,6 @@
 package model.jobs
 
-import scala.collection.convert.wrapAll._
+import scala.jdk.CollectionConverters._
 import com.google.common.util.concurrent.{AbstractScheduledService, ServiceManager}
 import com.google.common.util.concurrent.AbstractScheduledService.Scheduler
 import play.api.inject.ApplicationLifecycle

--- a/app/modules/clustersync/ClusterSynchronisation.scala
+++ b/app/modules/clustersync/ClusterSynchronisation.scala
@@ -7,7 +7,7 @@ import play.api.Logging
 import repositories.{TagLookupCache, SectionLookupCache}
 import services.{Config, KinesisConsumer}
 
-import scala.collection.convert.wrapAll._
+import scala.jdk.CollectionConverters._
 
 import com.google.common.util.concurrent.{ServiceManager, AbstractScheduledService}
 import com.google.common.util.concurrent.AbstractScheduledService.Scheduler

--- a/app/modules/clustersync/NodeStatusRepository.scala
+++ b/app/modules/clustersync/NodeStatusRepository.scala
@@ -37,7 +37,7 @@ object NodeStatusRepository extends Logging {
 
   private def generateNextNodeId(currentNodes: List[NodeStatus]) = {
     if(currentNodes.isEmpty) {
-      1l
+      1L
     } else {
       currentNodes.map(_.nodeId).max + 1
     }

--- a/app/modules/sponsorshiplifecycle/SponsorshipLifecycleModule.scala
+++ b/app/modules/sponsorshiplifecycle/SponsorshipLifecycleModule.scala
@@ -21,7 +21,7 @@ class SponsorshipLifecycleJobs @Inject() (
   implicit val ec: ExecutionContext
 ) extends Logging {
 
-  import scala.collection.convert.wrapAll._
+  import scala.jdk.CollectionConverters._
 
   logger.info("Starting sponsorship lifecycle jobs")
   lazy val scheduledJobs = List(new SponsorshipLauncher, new SponsorshipExpirer)

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -3,6 +3,7 @@ package permissions
 import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
 import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 import services.Config
+import com.madgag.scala.collection.decorators._
 
 object Permissions {
   val app = "tag-manager"
@@ -28,6 +29,6 @@ object Permissions {
     permissions.hasPermission(permission, email)
   }
   def getPermissionsForUser(email: String): Map[String, Boolean] =
-    permissionDefinitions.mapValues(permission => permissions.hasPermission(permission, email))
+    permissionDefinitions.mapV(permission => permissions.hasPermission(permission, email))
 }
 

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -17,7 +17,7 @@ import com.amazonaws.util.EC2MetadataUtils
 import com.twitter.scrooge.ThriftStruct
 import play.api.Logging
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object AWS {
 

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -3,7 +3,7 @@ package services
 import java.util.Properties
 
 import com.amazonaws.services.s3.model.GetObjectRequest
-import services.Config._
+
 
 import scala.jdk.CollectionConverters._
 
@@ -24,6 +24,7 @@ object Config extends AwsInstanceTags {
 }
 
 sealed trait Config {
+  import services.Config._
 
   private val remoteConfiguration: Map[String, String] = loadConfiguration
 
@@ -43,6 +44,8 @@ sealed trait Config {
   }
 
   object aws {
+
+
     lazy val stack = readTag("Stack") getOrElse "flexible"
     lazy val stage = readTag("Stage") getOrElse "DEV"
     lazy val app = readTag("App") getOrElse "tag-manager"

--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,12 @@ name := "tag-manager"
 
 version := "1.0"
 
-lazy val scalaVer = "2.12.19"
+lazy val scalaVer = "2.13.15"
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 scalacOptions ++= Seq(
+  "-quickfix:any",
   "-release:11",
   "-encoding", "UTF-8",
   "-unchecked",
@@ -45,7 +46,7 @@ lazy val dependencies = Seq(
   "com.typesafe.play" %% "play-json-joda" % "2.8.1",
   "org.apache.commons" % "commons-lang3" % "3.11",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0"
+  "com.madgag" %% "scala-collection-plus" % "0.11"
 )
 
 dependencyOverrides += "org.bouncycastle" % "bcprov-jdk15on" % "1.67"


### PR DESCRIPTION
* https://github.com/guardian/maintaining-scala-projects/issues/2

This PR sits on top of:

* https://github.com/guardian/tagmanager/pull/522
* https://github.com/guardian/tagmanager/pull/523
* https://github.com/guardian/tagmanager/pull/526
* https://github.com/guardian/tagmanager/pull/532
* https://github.com/guardian/tagmanager/pull/538

...with all those updates out of the way, this PR to upgrade to Scala 2.13 is pretty small:

* Use https://github.com/rtyley/scala-collection-plus to get `mapV` to replace `mapValues`
* [`collection.breakOut`](https://www.scala-lang.org/api/2.12.3/scala/collection/index.html#breakOut[From,T,To](implicitb:scala.collection.generic.CanBuildFrom[Nothing,T,To]):scala.collection.generic.CanBuildFrom[From,T,To]) no longer exists - it was just a way of converting a collection to particular type, and we can just say `toMap` here instead.
* `scala.collection.convert.wrapAll._` goes to  `scala.jdk.CollectionConverters._`

Completing this upgrade is also a step in unblocking:

* https://github.com/guardian/pan-domain-authentication/issues/149


## Testing

This has been [deployed](https://riffraff.gutools.co.uk/deployment/view/bf342770-237c-4c67-b691-32d0926ba7a9) to CODE, and looks good:

![image](https://github.com/user-attachments/assets/81bc481f-b592-4aff-8eb1-c22e13e85da3)


