### PR TITLE
Scala 2.13 Scalafix: `ExplicitNonNullaryApply` - Auto-application to `()` is deprecated

### DIFF
--- a/app/controllers/Reindex.scala
+++ b/app/controllers/Reindex.scala
@@ -24,7 +24,7 @@ class Reindex(
       if (reindexing) {
         Future.successful(Forbidden)
       } else {
-        ReindexTagsCommand().process.map { result =>
+        ReindexTagsCommand().process().map { result =>
           result.map { count => Ok } getOrElse InternalServerError
         }
       }
@@ -39,7 +39,7 @@ class Reindex(
       if (reindexing) {
         Future.successful(Forbidden)
       } else {
-        ReindexSectionsCommand().process.map { result =>
+        ReindexSectionsCommand().process().map { result =>
           result.map { count => Ok } getOrElse InternalServerError
         }
       }
@@ -54,7 +54,7 @@ class Reindex(
       if (reindexing) {
         Future.successful(Forbidden)
       } else {
-        ReindexPillarsCommand().process.map { result =>
+        ReindexPillarsCommand().process().map { result =>
           result.map { count => Ok } getOrElse InternalServerError
         }
       }

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -149,7 +149,7 @@ class Support(
     req.body.asJson.map { json =>
       val sectionId = (json \ "sectionId").as[Long]
 
-      UnexpireSectionContentCommand(sectionId).process.map{ result =>
+      UnexpireSectionContentCommand(sectionId).process().map{ result =>
         result.map(t => Ok("Unexpiry Completed Successfully")) getOrElse BadRequest("Failed to trigger unexpiry")
 
       } recover {
@@ -166,7 +166,7 @@ class Support(
     req.body.asJson.map { json =>
       val sectionId = (json \ "sectionId").as[Long]
 
-      ExpireSectionContentCommand(sectionId).process.map { result =>
+      ExpireSectionContentCommand(sectionId).process().map { result =>
         result.map(t => Ok("Expiry Completed Successfully")) getOrElse BadRequest("Failed to trigger expiry")
       } recover {
         commandErrorAsResult
@@ -211,7 +211,7 @@ class Support(
 
           val updatedTag = tag.copy(parents = tag.parents.filterNot(_.equals(parentId)))
 
-          Some(UpdateTagCommand(DenormalisedTag(updatedTag)).process.map {result =>
+          Some(UpdateTagCommand(DenormalisedTag(updatedTag)).process().map {result =>
             result getOrElse InternalServerError(s"Could not update tag: ${tag.id}")
             danglingParentsCount += 1
           })

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -43,7 +43,7 @@ class TagManagementApi(
     implicit val username = Option(req.user.email)
 
     req.body.asJson.map { json =>
-      UpdateTagCommand(json.as[DenormalisedTag]).process.map { result =>
+      UpdateTagCommand(json.as[DenormalisedTag]).process().map { result =>
         result.map{t => Ok(Json.toJson(DenormalisedTag(t))) } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -57,7 +57,7 @@ class TagManagementApi(
     (APIAuthAction andThen CreateTagPermissionsCheck() andThen CreateTagSpecificPermissionsCheck()).async { req =>
       implicit val username = Option(req.user.email)
       req.body.asJson.map { json =>
-        json.as[CreateTagCommand].process.map { result =>
+        json.as[CreateTagCommand].process().map { result =>
           result.map { t => Ok(Json.toJson(DenormalisedTag(t))) } getOrElse NotFound
         } recover {
           commandErrorAsResult
@@ -129,7 +129,7 @@ class TagManagementApi(
   def createSection() = (APIAuthAction andThen CreateSectionPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
-      json.as[CreateSectionCommand].process.map { result =>
+      json.as[CreateSectionCommand].process().map { result =>
         result.map{t => Ok(Json.toJson(t)) } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -142,7 +142,7 @@ class TagManagementApi(
   def updateSection(id: Long) = (APIAuthAction andThen UpdateSectionPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
-      UpdateSectionCommand(json.as[Section]).process.map { result =>
+      UpdateSectionCommand(json.as[Section]).process().map { result =>
         result.map{ t => Ok(Json.toJson(t)) } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -157,7 +157,7 @@ class TagManagementApi(
     req.body.asJson.map { json =>
       val editionName = (json \ "editionName").as[String]
 
-      AddEditionToSectionCommand(id, editionName.toUpperCase).process.map { result =>
+      AddEditionToSectionCommand(id, editionName.toUpperCase).process().map { result =>
         result.map{ t => Ok(Json.toJson(t)) } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -169,7 +169,7 @@ class TagManagementApi(
 
   def removeEditionFromSection(id: Long, editionName: String) = (APIAuthAction andThen RemoveEditionFromSectionPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
-    RemoveEditionFromSectionCommand(id, editionName.toUpperCase).process.map {result =>
+    RemoveEditionFromSectionCommand(id, editionName.toUpperCase).process().map {result =>
       result.map{ t => Ok(Json.toJson(t)) } getOrElse NotFound
     } recover {
       commandErrorAsResult
@@ -193,7 +193,7 @@ class TagManagementApi(
   def createPillar() = (APIAuthAction andThen PillarPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
-      json.as[CreatePillarCommand].process.map { result =>
+      json.as[CreatePillarCommand].process().map { result =>
         result.map{t => Ok(Json.toJson(t)) } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -206,7 +206,7 @@ class TagManagementApi(
   def updatePillar(id: Long) = (APIAuthAction andThen PillarPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
-      UpdatePillarCommand(json.as[Pillar]).process.map { result =>
+      UpdatePillarCommand(json.as[Pillar]).process().map { result =>
         result.map { t => Ok(Json.toJson(t)) } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -218,7 +218,7 @@ class TagManagementApi(
 
   def deletePillar(id: Long) = (APIAuthAction andThen PillarPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
-    DeletePillarCommand(id).process.map { result =>
+    DeletePillarCommand(id).process().map { result =>
       result.fold[Result](NotFound)(_ => NoContent)
     } recover {
       commandErrorAsResult
@@ -231,7 +231,7 @@ class TagManagementApi(
 
   def checkPathInUse(tagType: String, slug: String, section: Option[Long], tagSubType: Option[String]) = APIAuthAction.async { req =>
     implicit val username = Option(req.user.email)
-    new PathUsageCheck(tagType, slug, section, tagSubType).process.map{ result =>
+    new PathUsageCheck(tagType, slug, section, tagSubType).process().map{ result =>
       result.map{ t => Ok(Json.toJson(t)) } getOrElse BadRequest
     } recover {
       commandErrorAsResult
@@ -242,7 +242,7 @@ class TagManagementApi(
 
     implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
-      json.as[BatchTagCommand].process.map{ result =>
+      json.as[BatchTagCommand].process().map{ result =>
         result.map{t => NoContent } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -255,7 +255,7 @@ class TagManagementApi(
   def mergeTag = (APIAuthAction andThen MergeTagPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
-      json.as[MergeTagCommand].process.map { result =>
+      json.as[MergeTagCommand].process().map { result =>
         result.map{t => NoContent } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -267,7 +267,7 @@ class TagManagementApi(
 
   def deleteTag(id: Long) = (APIHMACAuthAction andThen DeleteTagPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
-    (DeleteTagCommand(id)).process.map { result =>
+    (DeleteTagCommand(id)).process().map { result =>
       result.map { t => NoContent } getOrElse NotFound
     } recover {
       commandErrorAsResult
@@ -305,7 +305,7 @@ class TagManagementApi(
   def createSponsorship = (APIAuthAction andThen ManageSponsorshipsPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
-      json.as[CreateSponsorshipCommand].process.map { result =>
+      json.as[CreateSponsorshipCommand].process().map { result =>
         result.map{t => Ok(Json.toJson(t)) } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -318,7 +318,7 @@ class TagManagementApi(
   def updateSponsorship(id: Long) = (APIAuthAction andThen ManageSponsorshipsPermissionsCheck()).async { req =>
     implicit val username = Option(req.user.email)
     req.body.asJson.map { json =>
-      json.as[UpdateSponsorshipCommand].process.map { result =>
+      json.as[UpdateSponsorshipCommand].process().map { result =>
         result.map{s => Ok(Json.toJson(DenormalisedSponsorship(s))) } getOrElse NotFound
       } recover {
         commandErrorAsResult
@@ -335,7 +335,7 @@ class TagManagementApi(
     val tagSearch: Option[List[Long]] = tagIds.map(_.split(",").toList.filter(_.length > 0).map(_.toLong))
     val sectionSearch: Option[List[Long]] = sectionIds.map(_.split(",").toList.filter(_.length > 0).map(_.toLong))
     new ClashingSponsorshipsFetch(id, tagSearch, sectionSearch, validFrom.map(new DateTime(_)), validTo.map(new DateTime(_)), editionSearch)
-        .process.map { result =>
+        .process().map { result =>
       result.map{ ss => Ok(Json.toJson(ss.map(DenormalisedSponsorship(_)))) } getOrElse BadRequest
     } recover {
       commandErrorAsResult

--- a/app/model/command/ReindexPillarsCommand.scala
+++ b/app/model/command/ReindexPillarsCommand.scala
@@ -8,7 +8,7 @@ case class ReindexPillarsCommand() extends Command {
   override type T = Unit
 
   override def process()(implicit username: Option[String], ec: ExecutionContext): Future[Option[T]] = Future{
-    JobHelper.beginPillarReindex
+    JobHelper.beginPillarReindex()
     Some(())
   }
 }

--- a/app/model/command/ReindexSectionsCommand.scala
+++ b/app/model/command/ReindexSectionsCommand.scala
@@ -8,7 +8,7 @@ case class ReindexSectionsCommand() extends Command {
   override type T = Unit
 
   override def process()(implicit username: Option[String], ec: ExecutionContext): Future[Option[T]] = Future{
-    JobHelper.beginSectionReindex
+    JobHelper.beginSectionReindex()
     Some(())
   }
 }

--- a/app/model/command/ReindexTagsCommand.scala
+++ b/app/model/command/ReindexTagsCommand.scala
@@ -8,7 +8,7 @@ case class ReindexTagsCommand() extends Command {
   override type T = Unit
 
   override def process()(implicit username: Option[String], ec: ExecutionContext): Future[Option[T]] = Future{
-    JobHelper.beginTagReindex
+    JobHelper.beginTagReindex()
     Some(())
   }
 }

--- a/app/model/command/UpdateTagCommand.scala
+++ b/app/model/command/UpdateTagCommand.scala
@@ -62,7 +62,7 @@ case class UpdateTagCommand(denormalisedTag: DenormalisedTag) extends Command wi
     existingTag foreach {(existing) =>
       if (tag.externalReferences != existing.externalReferences) {
         logger.info("Detected references change, triggering reindex")
-        FlexTagReindexCommand(tag).process
+        FlexTagReindexCommand(tag).process()
       }
     }
 

--- a/app/model/jobs/Job.scala
+++ b/app/model/jobs/Job.scala
@@ -78,7 +78,7 @@ case class Job(
   def rollback = {
     if (rollbackEnabled) {
       val revSteps = steps.reverse
-      revSteps.foreach(step => step.rollbackStep)
+      revSteps.foreach(step => step.rollbackStep())
       jobStatus = JobStatus.rolledback
     }
   }

--- a/app/model/jobs/JobHelper.scala
+++ b/app/model/jobs/JobHelper.scala
@@ -55,7 +55,7 @@ object JobHelper {
         steps = List(ReindexTags())
         )
       )
-    AppAuditRepository.upsertAppAudit(AppAudit.reindexTags)
+    AppAuditRepository.upsertAppAudit(AppAudit.reindexTags())
   }
 
   def beginSectionReindex()(implicit username: Option[String], ec: ExecutionContext) = {
@@ -69,7 +69,7 @@ object JobHelper {
         steps = List(ReindexSections())
         )
       )
-    AppAuditRepository.upsertAppAudit(AppAudit.reindexSections)
+    AppAuditRepository.upsertAppAudit(AppAudit.reindexSections())
   }
 
   def beginPillarReindex()(implicit username: Option[String], ec: ExecutionContext) = {
@@ -83,7 +83,7 @@ object JobHelper {
         steps = List(ReindexPillars())
       )
     )
-    AppAuditRepository.upsertAppAudit(AppAudit.reindexPillars)
+    AppAuditRepository.upsertAppAudit(AppAudit.reindexPillars())
   }
 
   def beginMergeTag(from: Tag, to: Tag)(implicit username: Option[String], ec: ExecutionContext) = {

--- a/app/model/jobs/JobRunner.scala
+++ b/app/model/jobs/JobRunner.scala
@@ -36,7 +36,7 @@ class JobRunner @Inject() (lifecycle: ApplicationLifecycle)(implicit ec: Executi
 
   def tryRun() = {
     try {
-      run
+      run()
     } catch {
       case NonFatal(e) => {
         logger.error(s"An unexpected exception occurred in the job runner: ${e.getStackTrace}")
@@ -64,7 +64,7 @@ class JobRunner @Inject() (lifecycle: ApplicationLifecycle)(implicit ec: Executi
             logger.error(s"Background job failed on ${JobRunner.nodeId}. $e")
           }
         } finally {
-          job.checkIfComplete
+          job.checkIfComplete()
           JobRepository.upsertJobIfOwned(job, JobRunner.nodeId)
           JobRepository.unlock(job, JobRunner.nodeId)
         }
@@ -97,6 +97,6 @@ object JobRunner {
 }
 
 class JobRunnerScheduler(runner: JobRunner) extends AbstractScheduledService {
-  override def runOneIteration(): Unit = runner.tryRun
+  override def runOneIteration(): Unit = runner.tryRun()
   override def scheduler(): Scheduler = Scheduler.newFixedDelaySchedule(1, 10, TimeUnit.SECONDS)
 }

--- a/app/model/jobs/Step.scala
+++ b/app/model/jobs/Step.scala
@@ -26,13 +26,13 @@ trait Step extends Logging {
   // Public methods that wrap the status updates
   def processStep(implicit ec: ExecutionContext) = {
     try {
-      beginProcessing
+      beginProcessing()
       process
-      doneProcessing
+      doneProcessing()
     } catch {
       case NonFatal(e) => {
         logger.error(s"Error thrown during step processing: ${e}")
-        processFailed
+        processFailed()
         throw e // Need to rethrow the exception to inform the job to start a rollback
       }
     }
@@ -41,18 +41,18 @@ trait Step extends Logging {
   def checkStep(implicit ec: ExecutionContext) = {
     attempts += 1
     if (attempts > Step.retryLimit) {
-      checkFailed
+      checkFailed()
       throw TooManyAttempts(s"Too many attempts at checking ${this.`type`}")
     }
 
     try {
       if (check) {
-          checkOk
+          checkOk()
       }
     } catch {
       case NonFatal(e) => {
         logger.error(s"Error thrown during step check: ${e}")
-        checkFailed
+        checkFailed()
         throw e // Need to rethrow the exception to inform the job to start a rollback
       }
     }

--- a/app/modules/clustersync/ClusterSynchronisation.scala
+++ b/app/modules/clustersync/ClusterSynchronisation.scala
@@ -28,7 +28,7 @@ class ClusterSynchronisation @Inject() (lifecycle: ApplicationLifecycle) extends
     AtomicReference[Option[KinesisConsumer]](None)
 
 
-  lifecycle.addStopHook{ () => Future.successful(stop) }
+  lifecycle.addStopHook{ () => Future.successful(stop()) }
   serviceManager.startAsync()
 
   initialise

--- a/app/repositories/ReindexProgressRepository.scala
+++ b/app/repositories/ReindexProgressRepository.scala
@@ -8,51 +8,51 @@ import scala.concurrent.{Future, ExecutionContext}
 object ReindexProgressRepository {
   // Write
   def resetTagReindexProgress(expectedDocs: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.resetTag(expectedDocs).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.resetTag(expectedDocs).toItem())
   }
 
   def resetSectionReindexProgress(expectedDocs: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.resetSection(expectedDocs).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.resetSection(expectedDocs).toItem())
   }
 
   def resetPillarReindexProgress(expectedDocs: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.resetPillar(expectedDocs).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.resetPillar(expectedDocs).toItem())
   }
 
   def updateTagReindexProgress(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.progressTag(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.progressTag(docsSent, docsTotal).toItem())
   }
 
   def updateSectionReindexProgress(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.progressSection(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.progressSection(docsSent, docsTotal).toItem())
   }
   
   def updatePillarReindexProgress(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.progressPillar(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.progressPillar(docsSent, docsTotal).toItem())
   }
 
   def completeTagReindex(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.completeTag(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.completeTag(docsSent, docsTotal).toItem())
   }
 
   def completeSectionReindex(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.completeSection(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.completeSection(docsSent, docsTotal).toItem())
   }
   
   def completePillarReindex(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.completePillar(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.completePillar(docsSent, docsTotal).toItem())
   }
 
   def failTagReindex(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.failTag(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.failTag(docsSent, docsTotal).toItem())
   }
 
   def failSectionReindex(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.failSection(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.failSection(docsSent, docsTotal).toItem())
   }
   
   def failPillarReindex(docsSent: Int, docsTotal: Int) = {
-    Dynamo.reindexProgressTable.putItem(ReindexProgress.failPillar(docsSent, docsTotal).toItem)
+    Dynamo.reindexProgressTable.putItem(ReindexProgress.failPillar(docsSent, docsTotal).toItem())
   }
 
   // Read

--- a/app/services/SQSQueue.scala
+++ b/app/services/SQSQueue.scala
@@ -61,7 +61,7 @@ trait SQSQueueConsumer extends Logging {
           logger.error(s"error processing messages from job queue ${queue.queueName}", e)
         }
       }
-      run
+      run()
     }
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -22,39 +22,39 @@ GET            /spreadsheets                                           controlle
 
 
 # API
-GET            /api/tags                                               controllers.TagManagementApi.searchTags
-POST           /api/tag                                                controllers.TagManagementApi.createTag
+GET            /api/tags                                               controllers.TagManagementApi.searchTags()
+POST           /api/tag                                                controllers.TagManagementApi.createTag()
 
 GET            /api/tag/:id                                            controllers.TagManagementApi.getTag(id: Long)
 PUT            /api/tag/:id                                            controllers.TagManagementApi.updateTag(id: Long)
 DELETE         /api/tag/:id                                            controllers.TagManagementApi.deleteTag(id: Long)
 
-GET            /api/sections                                           controllers.TagManagementApi.listSections
-POST           /api/section                                            controllers.TagManagementApi.createSection
+GET            /api/sections                                           controllers.TagManagementApi.listSections()
+POST           /api/section                                            controllers.TagManagementApi.createSection()
 GET            /api/section/:id                                        controllers.TagManagementApi.getSection(id: Long)
 PUT            /api/section/:id                                        controllers.TagManagementApi.updateSection(id: Long)
 POST           /api/section/:id/edition                                controllers.TagManagementApi.addEditionToSection(id: Long)
 DELETE         /api/section/:id/edition/:editionName                   controllers.TagManagementApi.removeEditionFromSection(id: Long, editionName: String)
 
-GET            /api/pillars                                            controllers.TagManagementApi.listPillars
-POST           /api/pillar                                             controllers.TagManagementApi.createPillar
+GET            /api/pillars                                            controllers.TagManagementApi.listPillars()
+POST           /api/pillar                                             controllers.TagManagementApi.createPillar()
 GET            /api/pillar/:id                                         controllers.TagManagementApi.getPillar(id: Long)
 PUT            /api/pillar/:id                                         controllers.TagManagementApi.updatePillar(id: Long)
 DELETE         /api/pillar/:id                                         controllers.TagManagementApi.deletePillar(id: Long)
 
-GET            /api/sponsorships                                       controllers.TagManagementApi.searchSponsorships
+GET            /api/sponsorships                                       controllers.TagManagementApi.searchSponsorships()
 GET            /api/sponsorship/:id                                    controllers.TagManagementApi.getSponsorship(id: Long)
-POST           /api/sponsorship                                        controllers.TagManagementApi.createSponsorship
+POST           /api/sponsorship                                        controllers.TagManagementApi.createSponsorship()
 PUT            /api/sponsorship/:id                                    controllers.TagManagementApi.updateSponsorship(id: Long)
 GET            /api/clashingSponsorships                               controllers.TagManagementApi.clashingSponsorships(id: Option[Long], tagIds: Option[String], sectionIds: Option[String], validFrom: Option[Long], validTo: Option[Long], editions: Option[String])
 GET            /api/tag/:id/activeSponsorships                         controllers.TagManagementApi.activeSponsorshipsForTag(id: Long)
 GET            /api/section/:id/activeSponsorships                     controllers.TagManagementApi.activeSponsorshipsForSection(id: Long)
 
-GET            /api/referenceTypes                                     controllers.TagManagementApi.listReferenceTypes
+GET            /api/referenceTypes                                     controllers.TagManagementApi.listReferenceTypes()
 
 GET            /api/checkPathInUse                                     controllers.TagManagementApi.checkPathInUse(tagType: String, slug: String, section: Option[Long], tagSubType: Option[String])
-POST           /api/batchTag                                           controllers.TagManagementApi.batchTag
-POST           /api/mergeTag                                           controllers.TagManagementApi.mergeTag
+POST           /api/batchTag                                           controllers.TagManagementApi.batchTag()
+POST           /api/mergeTag                                           controllers.TagManagementApi.mergeTag()
 
 
 GET            /api/audit/tag/:tagId                                   controllers.TagManagementApi.getAuditForTag(tagId: Long)
@@ -67,30 +67,30 @@ GET            /api/jobs                                               controlle
 DELETE         /api/jobs/:id                                           controllers.TagManagementApi.deleteJob(id: Long)
 PUT            /api/jobs/rollback/:id                                  controllers.TagManagementApi.rollbackJob(id: Long)
 
-POST           /api/spreadsheet                                        controllers.TagManagementApi.spreadsheet
+POST           /api/spreadsheet                                        controllers.TagManagementApi.spreadsheet()
 
-POST           /reindex/tags                                           controllers.Reindex.reindexTags
-GET            /reindex/tags                                           controllers.Reindex.getTagReindexProgress
-POST           /reindex/sections                                       controllers.Reindex.reindexSections
-GET            /reindex/sections                                       controllers.Reindex.getSectionReindexProgress
-POST           /reindex/pillars                                        controllers.Reindex.reindexPillars
-GET            /reindex/pillars                                        controllers.Reindex.getPillarReindexProgress
+POST           /reindex/tags                                           controllers.Reindex.reindexTags()
+GET            /reindex/tags                                           controllers.Reindex.getTagReindexProgress()
+POST           /reindex/sections                                       controllers.Reindex.reindexSections()
+GET            /reindex/sections                                       controllers.Reindex.getSectionReindexProgress()
+POST           /reindex/pillars                                        controllers.Reindex.reindexPillars()
+GET            /reindex/pillars                                        controllers.Reindex.getPillarReindexProgress()
 
 
 # Hypmedia API
-GET            /hyper                                                  controllers.HyperMediaApi.hyper
-GET            /hyper/tags                                             controllers.HyperMediaApi.tags
+GET            /hyper                                                  controllers.HyperMediaApi.hyper()
+GET            /hyper/tags                                             controllers.HyperMediaApi.tags()
 GET            /hyper/tags/:id                                         controllers.HyperMediaApi.tag(id: Long)
 GET            /hyper/tags/:id/sponsorships                            controllers.HyperMediaApi.tagSponsorships(id: Long)
 GET            /hyper/sponsorships/:id                                 controllers.HyperMediaApi.sponsorship(id: Long)
 OPTIONS        /*all                                                   controllers.HyperMediaApi.preflight(all: String)
 
 # Tag export for inCopy
-GET            /tags/export/all                                        controllers.ReadOnlyApi.getTagsAsXml
+GET            /tags/export/all                                        controllers.ReadOnlyApi.getTagsAsXml()
 GET            /tags/export/single/:id                                 controllers.ReadOnlyApi.tagAsXml(id: Long)
 GET            /tags/export/merges/:since                              controllers.ReadOnlyApi.mergesAsXml(since: Long)
 
-GET            /sections/export/all                                    controllers.ReadOnlyApi.getSectionsAsXml
+GET            /sections/export/all                                    controllers.ReadOnlyApi.getSectionsAsXml()
 
 
 # More newspaper integration
@@ -100,14 +100,14 @@ GET            /tools/newspaperintegration/tags/deleted/:since         controlle
 GET            /tools/newspaperintegration/tags/created/:since         controllers.ReadOnlyApi.createsAsXml(since: Long)
 
 
-GET            /oauthCallback                                          controllers.Login.oauthCallback
-GET            /logout                                                 controllers.Login.logout
-GET            /reauth                                                 controllers.Login.reauth
+GET            /oauthCallback                                          controllers.Login.oauthCallback()
+GET            /logout                                                 controllers.Login.logout()
+GET            /reauth                                                 controllers.Login.reauth()
 
 # Management
 +anyhost
 GET            /management/manifest                                    controllers.Management.manifest()
-GET            /management/healthcheck                                 controllers.Management.healthCheck
+GET            /management/healthcheck                                 controllers.Management.healthCheck()
 
 # Map static resources from the /public folder to the /assets URL path
 GET            /assets/*file                                           controllers.Assets.versioned(path="/public", file: Asset)
@@ -116,23 +116,23 @@ GET            /assets/*file                                           controlle
 GET            /support/image-metadata                                 controllers.Support.imageMetadata(imageUrl: String)
 POST           /support/uploadLogo/:filename                           controllers.Support.uploadLogo(filename: String)
 GET            /support/previewCapi/*path                              controllers.Support.previewCapiProxy(path: String)
-GET            /support/flexPathMigrationData                          controllers.Support.flexPathMigrationSpecificData
-GET            /support/flexSlugMigrationData                          controllers.Support.flexSlugMigrationSpecificData
+GET            /support/flexPathMigrationData                          controllers.Support.flexPathMigrationSpecificData()
+GET            /support/flexSlugMigrationData                          controllers.Support.flexSlugMigrationSpecificData()
 
-POST           /support/unexpireSectionContent                         controllers.Support.unexpireSectionContent
-POST           /support/expireSectionContent                           controllers.Support.expireSectionContent
+POST           /support/unexpireSectionContent                         controllers.Support.unexpireSectionContent()
+POST           /support/expireSectionContent                           controllers.Support.expireSectionContent()
 
 # TODO DELETE THIS
-POST           /support/unexpireTag                                    controllers.Support.unexpireTag
+POST           /support/unexpireTag                                    controllers.Support.unexpireTag()
 
-GET            /support/fixDanglingParents                             controllers.Support.fixDanglingParents
+GET            /support/fixDanglingParents                             controllers.Support.fixDanglingParents()
 
 # Migration endpoints
-GET            /migration/paidContent                                  controllers.Migration.showPaidContentUploadForm
-POST           /migration/paidContent                                  controllers.Migration.migratePaidContent
-GET            /migration/moveToSections                               controllers.Migration.movePaidcontentSponsorshipUpToSection
+GET            /migration/paidContent                                  controllers.Migration.showPaidContentUploadForm()
+POST           /migration/paidContent                                  controllers.Migration.migratePaidContent()
+GET            /migration/moveToSections                               controllers.Migration.movePaidcontentSponsorshipUpToSection()
 GET            /migration/flattenSponsoredMicrosite/:sponsId           controllers.Migration.flattenSponsoredMicrosite(sponsId: Long)
-GET            /migration/addMissingPaidContentTypes                   controllers.Migration.addMissingPaidContentTypes
-GET            /migration/dudupeActiveSponsorships                     controllers.Migration.dudupeActiveSponsorships
+GET            /migration/addMissingPaidContentTypes                   controllers.Migration.addMissingPaidContentTypes()
+GET            /migration/dudupeActiveSponsorships                     controllers.Migration.dudupeActiveSponsorships()
 
 


### PR DESCRIPTION
Scala 2.13 deprecates (with PR https://github.com/scala/scala/pull/8833) the old behaviour of Scala that zero-parameter methods could be called with either one or zero pairs of parenthesis - ie if you have a method `def foo()` you could call it as `foo()` or just `foo`. With Scala 3, you have to match the number of brackets *used in the method declaration* when you call it - so you'd _have_ to use `foo()` or you'd get an error like this:

```
[error] ~/code/presence-indicator/app/actor/OpenSocketActor.scala:79:7: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method sender,
[error] or remove the empty argument list from its definition (Java-defined methods are exempt).
[error] In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
[error]       sender ! Map(serverId -> (LiveActors(connectionPing, subscription)))
[error]       ^
```

Java methods are exempt from this restriction - you can call either `hashCode()` (which, in Java, is how the method _has_ to be defined, with empty brackets) or just `hashCode` (which is how that method would have been declared if it was declared in Scala, in Scala methods with no side-effects should be declared without brackets: https://docs.scala-lang.org/style/method-invocation.html#arity-0).

## Automatically fixing this code issue

There are two possible ways of automating this code fix - in this small project, they both produce the same code changes:

### Fixing if the project is already on Scala 2.13 - use `-quickfix` in `scalac`

You can use the `-quickfix` support added to Scala 2.13.12 with https://github.com/scala/scala/pull/10482:

Add either of these to the `scalacOptions` in `build.sbt`:

* `"-quickfix:any"`  ...to apply *all* available quick fixes
* `"-quickfix:msg=Auto-application"`  ...to apply quick fixes where the message contains "Auto-application"

Then run `compile` on the sbt console - the first compile will still fail, but it will subtly change the error message to say `[rewritten by -quickfix]` - your files have been edited to receive the fix:

```
[error] /Users/Roberto_Tyley/code/presence-indicator/app/actor/OpenSocketActor.scala:79:7: [rewritten by -quickfix] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method sender,
[error] or remove the empty argument list from its definition (Java-defined methods are exempt).
[error] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[error]       sender ! Map(serverId -> (LiveActors(connectionPing, subscription)))
[error]       ^
```

...run `compile` a second time, and compiler will be much happier.

Examples of other PRs using `-quickfix` to fix this code issue:

* https://github.com/guardian/ophan/pull/5719

### Fixing while still on Scala 2.12 - use Scalafix

Fixing this everywhere in a project can be tedious, but thankfully there is a `ExplicitNonNullaryApply` Scalafix rule to fix this in the https://github.com/lightbend-labs/scala-rewrites project.

The Scalafix rule needs to be run while the project is still on Scala 2.12, not Scala 2.13 (otherwise sbt will say: "Error downloading ch.epfl.scala:sbt-scalafix;sbtVersion=1.0;scalaVersion=2.13:0.13.0").

Once the Scalafix plugin is made available to sbt (by adding `addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")` to either `project/plugins.sbt` or `~/.sbt/1.0/plugins.sbt`), you can run these commands on the sbt prompt to automatically generate the changes in this PR:

```
scalafixEnable
scalafixAll dependency:fix.scala213.ExplicitNonNullaryApply@org.scala-lang:scala-rewrites:0.1.5
```

Examples of other PRs using Scalafix to fix this code issue:

* https://github.com/guardian/mobile-apps-api/pull/2728
* https://github.com/guardian/presence-indicator/pull/196

See also:

* https://github.com/scalacenter/scalafix/issues/204
* https://github.com/lightbend-labs/scala-rewrites/pull/14
