### PR TITLE
Upgrade `sbt` to allow Scala Steward to run

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.10.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
 // need to add jdeb dependency explicitly because https://github.com/sbt/sbt-native-packager/issues/1053
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
 
+/*
+   See https://github.com/guardian/maintaining-scala-projects/issues/13
+ */
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
We need at least sbt 1.9.0 to run Scala Steward, see:

* https://github.com/guardian/maintaining-scala-projects/issues/7

Otherwise the Scala Steward run [fails](https://github.com/guardian/scala-steward-public-repos/actions/runs/11478176242/job/31941818963#step:7:1520):

```
2024-10-23 10:41:09,359 ERROR Steward guardian/tagmanager failed
  org.scalasteward.core.io.process$ProcessFailedException: '"SBT_OPTS=-Xmx2048m -Xss8m -XX:MaxMetaspaceSize=512m" sbt -Dsbt.color=false -Dsbt.log.noformat=true -Dsbt.supershell=false -Dsbt.server.forcestart=true ;+ stewardDependencies;reload plugins;stewardDependencies' exited with code 1.
  [info] [launcher] getting org.scala-sbt sbt 1.7.1  (this may take some time)...
  [info] [launcher] getting Scala 2.12.16 (for sbt)...
  [info] welcome to sbt 1.7.1 (Amazon.com Inc. Java 21.0.5)
  error:
    bad constant pool index: 0 at pos: 48454
       while compiling: <no file>
          during phase: globalPhase=<no phase>, enteringPhase=<some phase>
       library version: version 2.12.16
      compiler version: version 2.12.16
    reconstructed args: -classpath /home/runner/.sbt/boot/scala-2.12.16/lib/scala-library.jar -Yrangepos
  
    last tree to typer: EmptyTree
         tree position: <unknown>
              tree tpe: <notype>
                symbol: null
             call site: <none> in <none>
```
