### PR TITLE
Fix for missing sbt by using new guardian/setup-scala action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,8 @@ jobs:
           cache: npm
           cache-dependency-path: 'package-lock.json'
 
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'corretto'
-          cache: 'sbt'
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
 
       - name: Install NPM dependencies
         run: npm ci


### PR DESCRIPTION
Using the new GitHub Action [`guardian/setup-scala`](https://github.com/guardian/setup-scala/) to cope with `sbt` being removed from the latest Ubuntu images we use for CI. This composite action combines [`setup-java`](https://github.com/actions/setup-java) and [`setup-sbt`](https://github.com/sbt/setup-sbt) with good defaults for the Guardian.

#### Version of Java used by CI now specified by `.tool-versions` file

Note that `guardian/setup-scala` requires that projects specify their Java version with an [`asdf`](https://asdf-vm.com/)-formatted `.tool-versions` file - we didn't have to _add_ one with this PR, as it was already present

Based on https://github.com/guardian/etag-caching/pull/60