### PR TITLE
Add GitHub CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/fronts-and-curation


### PR DESCRIPTION
The @guardian/fronts-and-curation team are listed as the owners for this repo in the [Trello for Journalism stream ownership](https://trello.com/b/rc4e63Wu/journalism-stream-triage-ownership-work-in-progress):

<img width="284" alt="image" src="https://github.com/user-attachments/assets/f33147b2-19b0-4b72-b914-5bb89bea9ab3" />

[Tag Manager](https://tagmanager.gutools.co.uk/) is a tool for curation, so it makes sense that Fronts & Curation team takes ownership! 

