### PR TITLE
Report publication tag usage correctly

### DIFF
--- a/public/components/BatchTag/BatchFilters.react.js
+++ b/public/components/BatchTag/BatchFilters.react.js
@@ -90,14 +90,24 @@ export default class BatchFilters extends React.Component {
     }
 
     addTag(tag) {
-      const tagPath = tag.type === 'ContentType' ? 'type/' + tag.slug : tag.path;
+      const prefixes = {
+        'ContentType': 'type/',
+        'Publication': 'publication/',
+      };
+
+      const tagPath = prefixes[tag.type] ? prefixes[tag.type] + tag.slug : tag.path;
       this.props.updateFilters(Object.assign({}, this.props.filters, {
         'tag': R.uniq(this.getTagArray().concat([tagPath])).join(',')
       }));
     }
 
     addExcludedTag(tag) {
-      const tagPath = tag.type === 'ContentType' ? '-type/' + tag.slug : '-' + tag.path;
+      const prefixes = {
+        'ContentType': 'type/',
+        'Publication': 'publication/',
+      };
+
+      const tagPath = '-' + prefixes[tag.type] ? prefixes[tag.type] + tag.slug : tag.path;
       this.props.updateFilters(Object.assign({}, this.props.filters, {
         'tag': R.uniq(this.getTagArray().concat([tagPath])).join(',')
       }));

--- a/public/util/capiClient.js
+++ b/public/util/capiClient.js
@@ -68,7 +68,12 @@ function buildSearch(searchString) {
 export function getByTag (tag, params) {
     const query = paramsObjectToQuery(params);
 
-    const tagPath = tag.type === 'ContentType' ? 'type/' + tag.slug : tag.path;
+    const prefixes = {
+        'ContentType': 'type/',
+        'Publication': 'publication/',
+    };
+
+    const tagPath = prefixes[tag.type] ? prefixes[tag.type] + tag.slug : tag.path;
 
     return Reqwest({
       url: getCapiUrl() + '&tag=' + tagPath  + '&' + query,


### PR DESCRIPTION
## What does this change?

Publication tag paths do not match their IDs in CAPI e.g. publication/theobserver has a tag path of theobserver/all

The same is true for content type tags, but these are the only two tag types that deviate from the pattern of path=id (in CAPI). See https://github.com/guardian/content-api/blob/4dfe69e4fb1e1eb119ede634a5759250c6c23253/porter/src/main/scala/com.gu.contentapi.porter/integration/tag/TagTransformer.scala#L21

This PR ensures that the CAPI id for publication tags are correctly constructed