### PR TITLE
Fix exclude tag filter

### DIFF
--- a/public/components/BatchTag/BatchFilters.react.js
+++ b/public/components/BatchTag/BatchFilters.react.js
@@ -107,7 +107,7 @@ export default class BatchFilters extends React.Component {
         'Publication': 'publication/',
       };
 
-      const tagPath = '-' + prefixes[tag.type] ? prefixes[tag.type] + tag.slug : tag.path;
+      const tagPath = '-' + (prefixes[tag.type] ? prefixes[tag.type] + tag.slug : tag.path);
       this.props.updateFilters(Object.assign({}, this.props.filters, {
         'tag': R.uniq(this.getTagArray().concat([tagPath])).join(',')
       }));


### PR DESCRIPTION
## What does this change?

Fixes an operator precedence bug which was causing e.g. JDVance topic tag to be constructed as "undefinedjd-vance" instead of "us-news/jd-vance"

## How to test

Deploy to code. Attempt to exclude jd vance. See that tag appears correctly.
