### PR TITLE
Adds request for tracking pixel to React router onUpdate callback

### DIFF
--- a/public/router.js
+++ b/public/router.js
@@ -41,8 +41,19 @@ function clearErrorBar() {
     store.dispatch(clearError());
 }
 
+function onRouterUpdate() {
+  const domainMatch = /^.*\.(?<environment>local|code)\.dev-gutools\.co\.uk$|^.*\.gutools\.co\.uk$/
+      .exec(location.hostname);
+  if (domainMatch) {
+    const stage = (domainMatch.groups?.environment || "PROD");
+    const telemetryUrl = stage === "PROD" ? "user-telemetry.gutools.co.uk" : `user-telemetry.${stage}.dev-gutools.co.uk`
+    const image = new Image();
+    image.src = `https://${telemetryUrl}/guardian-tool-accessed?app=tag-manager&stage=${stage.toUpperCase()}&path=${window.location.pathname}`;
+  }
+}
+
 export const router = (
-  <Router history={browserHistory}>
+  <Router history={browserHistory} onUpdate={onRouterUpdate}>
     <Route path="/" component={ReactApp}>
       <Route name="tag" path="/tag/create" component={TagCreate} onEnter={requirePermission.bind(this, 'tag_edit')}/>
       <Route name="tagCreate" path="/tag/:tagId" component={TagDisplay} onLeave={clearErrorBar.bind(this)} />


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
As part of the tools audit, we have identified tag manager as useful tool to track the usage of: [#1143](https://github.com/guardian/workflow/issues/1143).

This PR uses the tracking pixel to send events to the backend so we can monitor the use of the tools:

https://github.com/guardian/editorial-tools-user-telemetry-service?tab=readme-ov-file#tracking-pixel

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable locally or using [CODE](https://tagmanager.code.dev-gutools.co.uk/). Results should either appear in your local telemetry service or in [ES if sent to CODE](https://logs.gutools.co.uk/s/editorial-tools/app/r/s/3wYyv). 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We know how regularly Tag Manager is being used. 

