### PR TITLE
Add episodic artwork fields to podcast metadata

### DIFF
--- a/app/model/PodcastMetadata.scala
+++ b/app/model/PodcastMetadata.scala
@@ -1,10 +1,13 @@
 package model
 
 import play.api.libs.json._
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
 import ai.x.play.json.Jsonx
 import ai.x.play.json.Encoders.encoder
 import ai.x.play.json.implicits.optionWithNull
 import com.gu.tagmanagement.{PodcastMetadata => ThriftPodcastMetadata, PodcastCategory => ThriftPodcastCategory}
+import org.joda.time.DateTime
 
 case class PodcastMetadata( linkUrl: String,
                             copyrightText: Option[String] = None,
@@ -19,24 +22,28 @@ case class PodcastMetadata( linkUrl: String,
                             googlePodcastsUrl: Option[String] = None,
                             spotifyUrl: Option[String] = None,
                             acastId: Option[String] = None,
-                            pocketCastsUrl: Option[String] = None
+                            pocketCastsUrl: Option[String] = None,
+                            episodicArtworkEnabled: Option[Boolean] = None,
+                            episodicArtworkEnabledFrom: Option[DateTime] = None
 ) {
 
   def asThrift = ThriftPodcastMetadata(
-    linkUrl =           linkUrl,
-    copyrightText =     copyrightText,
-    authorText =        authorText,
-    iTunesUrl =         iTunesUrl,
-    iTunesBlock =       iTunesBlock,
-    clean =             clean,
-    explicit =          explicit,
-    image =             image.map(_.asThrift),
-    categories =        categories.map((cat) => List(cat.asThrift)),
-    podcastType =       podcastType,
-    googlePodcastsUrl = googlePodcastsUrl,
-    spotifyUrl =        spotifyUrl,
-    acastId =           acastId,
-    pocketCastsUrl =    pocketCastsUrl
+    linkUrl =                    linkUrl,
+    copyrightText =              copyrightText,
+    authorText =                 authorText,
+    iTunesUrl =                  iTunesUrl,
+    iTunesBlock =                iTunesBlock,
+    clean =                      clean,
+    explicit =                   explicit,
+    image =                      image.map(_.asThrift),
+    categories =                 categories.map((cat) => List(cat.asThrift)),
+    podcastType =                podcastType,
+    googlePodcastsUrl =          googlePodcastsUrl,
+    spotifyUrl =                 spotifyUrl,
+    acastId =                    acastId,
+    pocketCastsUrl =             pocketCastsUrl,
+    episodicArtworkEnabled =     episodicArtworkEnabled,
+    episodicArtworkEnabledFrom = episodicArtworkEnabledFrom.map(_.getMillis)
   )
 
   def asExportedXml = {
@@ -54,6 +61,8 @@ case class PodcastMetadata( linkUrl: String,
     <image>{this.image.map(x => x.asExportedXml).getOrElse("")}</image>
     <categories>{this.categories.map(_.asExportedXml).getOrElse("")}</categories>
     <type>{this.podcastType.getOrElse("")}</type>
+    <episodicArtworkEnabled>{this.episodicArtworkEnabled}</episodicArtworkEnabled>
+    <episodicArtworkEnabledFrom>{this.episodicArtworkEnabledFrom.map(_.getMillis).getOrElse("")}</episodicArtworkEnabledFrom>
   }
 }
 
@@ -63,20 +72,22 @@ object PodcastMetadata {
 
   def apply(thriftPodcastMetadata: ThriftPodcastMetadata): PodcastMetadata =
     PodcastMetadata(
-      linkUrl =           thriftPodcastMetadata.linkUrl,
-      copyrightText =     thriftPodcastMetadata.copyrightText,
-      authorText =        thriftPodcastMetadata.authorText,
-      iTunesUrl =         thriftPodcastMetadata.iTunesUrl,
-      iTunesBlock =       thriftPodcastMetadata.iTunesBlock,
-      clean =             thriftPodcastMetadata.clean,
-      explicit =          thriftPodcastMetadata.explicit,
-      image =             thriftPodcastMetadata.image.map(Image(_)),
-      categories =        thriftPodcastMetadata.categories.map(x => PodcastCategory(x.head)),
-      podcastType =       thriftPodcastMetadata.podcastType,
-      googlePodcastsUrl = thriftPodcastMetadata.googlePodcastsUrl,
-      spotifyUrl =        thriftPodcastMetadata.spotifyUrl,
-      acastId =           thriftPodcastMetadata.acastId,
-      pocketCastsUrl =    thriftPodcastMetadata.pocketCastsUrl
+      linkUrl =                    thriftPodcastMetadata.linkUrl,
+      copyrightText =              thriftPodcastMetadata.copyrightText,
+      authorText =                 thriftPodcastMetadata.authorText,
+      iTunesUrl =                  thriftPodcastMetadata.iTunesUrl,
+      iTunesBlock =                thriftPodcastMetadata.iTunesBlock,
+      clean =                      thriftPodcastMetadata.clean,
+      explicit =                   thriftPodcastMetadata.explicit,
+      image =                      thriftPodcastMetadata.image.map(Image(_)),
+      categories =                 thriftPodcastMetadata.categories.map(x => PodcastCategory(x.head)),
+      podcastType =                thriftPodcastMetadata.podcastType,
+      googlePodcastsUrl =          thriftPodcastMetadata.googlePodcastsUrl,
+      spotifyUrl =                 thriftPodcastMetadata.spotifyUrl,
+      acastId =                    thriftPodcastMetadata.acastId,
+      pocketCastsUrl =             thriftPodcastMetadata.pocketCastsUrl,
+      episodicArtworkEnabled =     thriftPodcastMetadata.episodicArtworkEnabled,
+      episodicArtworkEnabledFrom = thriftPodcastMetadata.episodicArtworkEnabledFrom.map(new DateTime(_))
     )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val dependencies = Seq(
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client-default" % "27.0.0",
-  "com.gu" %% "tags-thrift-schema" % "2.8.3",
+  "com.gu" %% "tags-thrift-schema" % "2.8.5-PREVIEW.add-episodic-art-fields-to-podcast-metadata.2025-06-05T0753.0af15c6d",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val dependencies = Seq(
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client-default" % "27.0.0",
-  "com.gu" %% "tags-thrift-schema" % "2.8.5-PREVIEW.add-episodic-art-fields-to-podcast-metadata.2025-06-05T0753.0af15c6d",
+  "com.gu" %% "tags-thrift-schema" % "2.8.5",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -238,11 +238,11 @@ export default class PodcastMetadata extends React.Component {
             onChange={this.updateEpisodicArtworkEnabled.bind(this)}
             checked={this.props.tag.podcastMetadata.episodicArtworkEnabled || false}
             disabled={!this.props.tagEditable} />
-          <label className="tag-edit__label">Enable Episodic Artwork</label>
+          <label className="tag-edit__label">Is episodic artwork enabled?</label>
         </div>
         {this.props.tag.podcastMetadata.episodicArtworkEnabled && (
           <div className="tag-edit__field">
-            <label className="tag-edit__label">Enable Episodic Artwork Start Date</label>
+            <label className="tag-edit__label">Start date for episodic artwork</label>
             <input type="date"
               className="tag-edit__input"
               value={(this.props.tag.podcastMetadata.episodicArtworkEnabledFrom || '').split('T')[0]}

--- a/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
+++ b/public/components/TagEdit/formComponents/series/PodcastMetadata.react.js
@@ -109,6 +109,22 @@ export default class PodcastMetadata extends React.Component {
           }));
   }
 
+    updateEpisodicArtworkEnabled(e) {
+        const isEnabled = e.target.checked;
+
+        this.props.updateTag(R.merge(this.props.tag, {
+            podcastMetadata: isEnabled
+                ? R.merge(this.props.tag.podcastMetadata, { episodicArtworkEnabled: isEnabled })
+                : R.omit(['episodicArtworkEnabledFrom'], R.merge(this.props.tag.podcastMetadata, { episodicArtworkEnabled: isEnabled }))
+        }));
+    }
+
+  updateEpisodicArtworkEnabledFrom(e) {
+      this.props.updateTag(R.merge(this.props.tag, {
+          podcastMetadata: R.merge(this.props.tag.podcastMetadata, { episodicArtworkEnabledFrom: e.target.value })
+      }));
+  }
+
   renderMetadataForm() {
     if (!this.tagHasPodcast()) {
       return false;
@@ -217,6 +233,23 @@ export default class PodcastMetadata extends React.Component {
           label="Podcast Image"
           onChange={this.updateImage.bind(this)}
           tagEditable={this.props.tagEditable}/>
+        <div className="tag-edit__field">
+          <input type="checkbox"
+            onChange={this.updateEpisodicArtworkEnabled.bind(this)}
+            checked={this.props.tag.podcastMetadata.episodicArtworkEnabled || false}
+            disabled={!this.props.tagEditable} />
+          <label className="tag-edit__label">Enable Episodic Artwork</label>
+        </div>
+        {this.props.tag.podcastMetadata.episodicArtworkEnabled && (
+          <div className="tag-edit__field">
+            <label className="tag-edit__label">Enable Episodic Artwork Start Date</label>
+            <input type="date"
+              className="tag-edit__input"
+              value={(this.props.tag.podcastMetadata.episodicArtworkEnabledFrom || '').split('T')[0]}
+              onChange={this.updateEpisodicArtworkEnabledFrom.bind(this)}
+              disabled={!this.props.tagEditable} />
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## What does this change?

Adds two new episodic artwork fields to the podcast metadata.

These fields were introduced here: https://github.com/guardian/tags-thrift-schema/pull/48

Both fields are optional. `episodicArtworkEnabledFrom` can only be set if `episodicArtworkEnabled` is set to true.

## How to test

Run this branch locally or on CODE. Create or edit an existing "Series" tag. Check "Is this series a podcast?" and complete the required fields (Link URL and Podcast Image). Then...

- check "Is episodic artwork enabled?" and save changes. When you refresh the page, is it persisted correctly?
- set "Start date for episodic artwork" to any date. When you refresh the page, is it persisted correctly?
- uncheck "Is episodic artwork enabled?". The date field should disappear. Check it again. The date field should have been reset. 

You should also be able to preview the new fields here: https://tagmanager.local.dev-gutools.co.uk/api/tag/[TAG-ID-HERE]

## How can we measure success?

This brings us closer to being able to control episodic artwork in tooling instead of having to raise PRs like this: https://github.com/guardian/itunes-rss/pull/178

## Have we considered potential risks?

Low risk.

## Images

<img width="443" alt="Screenshot 2025-06-06 at 15 30 19" src="https://github.com/user-attachments/assets/1a881bc6-c17a-4427-b342-e5252b979400" />

## Related PRs

- [tags-thrift-schema](https://github.com/guardian/tags-thrift-schema/pull/48)
- [tagmanager](https://github.com/guardian/tagmanager/pull/558)  <- you are here
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3093) 
- [content-api-models](https://github.com/guardian/content-api-models/pull/261)
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3100) 
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/443)
- [itunes-rss](https://github.com/guardian/itunes-rss/pull/180)

