### PR TITLE
Allow cross-domain requests from Media Atom Maker

### DIFF
--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -124,6 +124,7 @@ sealed trait Config {
   def targetingDomain: String
   def workflowDomain: String
   def campaignCentralDomain: String
+  def mediaAtomMakerDomain: String
   def corsableDomains: Seq[String]
   def corsablePostDomains: Seq[String]
 
@@ -174,11 +175,13 @@ class DevConfig extends Config {
   override def targetingDomain: String = "https://targeting.local.dev-gutools.co.uk"
   override def campaignCentralDomain: String = "https://campaign-central.local.dev-gutools.co.uk"
   override def workflowDomain: String = "https://workflow.local.dev-gutools.co.uk"
+  override def mediaAtomMakerDomain: String = "https://video.local.dev-gutools.co.uk"
   override def corsableDomains: Seq[String] = Seq(
     composerDomain,
     targetingDomain,
     campaignCentralDomain,
-    workflowDomain
+    workflowDomain,
+    mediaAtomMakerDomain
   )
   override def corsablePostDomains: Seq[String] = Seq(
     targetingDomain
@@ -228,6 +231,8 @@ class CodeConfig extends Config {
   override def targetingDomain: String = "https://targeting.code.dev-gutools.co.uk"
   override def campaignCentralDomain: String = "https://campaign-central.code.dev-gutools.co.uk"
   override def workflowDomain: String = "https://workflow.code.dev-gutools.co.uk"
+  override def mediaAtomMakerDomain = "https://video.code.dev-gutools.co.uk"
+
 
   override def corsableDomains: Seq[String] = Seq(
     composerDomain,
@@ -238,7 +243,9 @@ class CodeConfig extends Config {
     campaignCentralDomain,
     "https://campaign-central.local.dev-gutools.co.uk",
     workflowDomain,
-    "https://workflow.local.dev-gutools.co.uk"
+    "https://workflow.local.dev-gutools.co.uk",
+    mediaAtomMakerDomain,
+    "https://video.local.dev-gutools.co.uk",
     )
 
   override def frontendBucketWriteRole: Option[String] = Some("arn:aws:iam::642631414762:role/composerWriteToStaticBucket")
@@ -290,11 +297,13 @@ class ProdConfig extends Config {
   override def targetingDomain: String = "https://targeting.gutools.co.uk"
   override def campaignCentralDomain: String = "https://campaign-central.gutools.co.uk"
   override def workflowDomain: String = "https://workflow.gutools.co.uk"
+  override def mediaAtomMakerDomain = "https://video.gutools.co.uk"
   override def corsableDomains: Seq[String] = Seq(
     composerDomain,
     targetingDomain,
     campaignCentralDomain,
     workflowDomain,
+    mediaAtomMakerDomain,
     "https://composer-secondary.gutools.co.uk"
     )
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We began work on improving the tag search in Media Atom Maker, and as part of the work we are going to change the tool to query Tag Manager directly for tag search instead of using CAPI (guardian/media-atom-maker#1264).  So the MAM's client code will be making cross-domain requests in users' browsers to tag manager's API.

This pull request adds the domain of media atom maker to the list of domains whose requests are allowed in tag manager's API.

## How to test

Deploy it to CODE and test it with Media Atom Maker with the change in guardian/media-atom-maker#1264,
- search for tag in the "Composer keywords" field in Media Atom Maker, and the search result of the tags can be displayed on UI.  On Inspector tool, we should see that the tag search request goes to tagmanager domain and returns with 200 success response.

## How can we measure success?

Media Atom Maker can search for tags using tag manager API directly.

## Have we considered potential risks?

This PR should not be risky as we don't change the application at all.  It just adds one domain of our tool to the configuration to allow cross-domain requests.