### PR TITLE
Add keyword type backfill

### DIFF
--- a/app/model/command/UpdateKeywordTypesCommand.scala
+++ b/app/model/command/UpdateKeywordTypesCommand.scala
@@ -5,7 +5,7 @@ import model.jobs.steps.UpdateKeywordTypeForAllTags
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class UpdateKeywordTypesCommand(keywordTypeMappings: Map[Long, String]) extends Command {
+case class UpdateKeywordTypesCommand(keywordTypeMappings: Map[String, String]) extends Command {
   override type T = Unit
 
   override def process()(implicit username: Option[String], ec: ExecutionContext): Future[Option[T]] = Future {

--- a/app/model/command/UpdateKeywordTypesCommand.scala
+++ b/app/model/command/UpdateKeywordTypesCommand.scala
@@ -1,0 +1,23 @@
+package model.command
+
+import model.jobs.JobHelper
+import model.jobs.steps.UpdateKeywordTypeForAllTags
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class UpdateKeywordTypesCommand(keywordTypeMappings: Map[Long, String]) extends Command {
+  override type T = Unit
+
+  override def process()(implicit username: Option[String], ec: ExecutionContext): Future[Option[T]] = Future {
+    JobHelper.beginUpdateKeywordTypes(keywordTypeMappings)
+    Some(())
+  }
+}
+
+object UpdateKeywordTypesCommand {
+  def fromCsv(csvContent: String): UpdateKeywordTypesCommand = {
+    val step = UpdateKeywordTypeForAllTags.fromCsv(csvContent)
+    UpdateKeywordTypesCommand(step.keywordTypeMappings)
+  }
+}
+

--- a/app/model/jobs/JobHelper.scala
+++ b/app/model/jobs/JobHelper.scala
@@ -121,5 +121,16 @@ object JobHelper {
       )
   }
 
+  def beginUpdateKeywordTypes(keywordTypeMappings: Map[Long, String])(implicit username: Option[String], ec: ExecutionContext) = {
+    JobRepository.addJob(
+      Job(
+        id = Sequences.jobId.getNextId,
+        title = s"Updating keyword types for ${keywordTypeMappings.size} tags",
+        createdBy = username,
+        steps = List(UpdateKeywordTypeForAllTags(keywordTypeMappings, username))
+      )
+    )
+  }
+
   private def removeTagSteps(tag: Tag)(implicit username: Option[String]) = List(RemoveTagPath(tag), RemoveTagFromCapi(tag), RemoveTag(tag, username))
 }

--- a/app/model/jobs/JobHelper.scala
+++ b/app/model/jobs/JobHelper.scala
@@ -121,7 +121,7 @@ object JobHelper {
       )
   }
 
-  def beginUpdateKeywordTypes(keywordTypeMappings: Map[Long, String])(implicit username: Option[String], ec: ExecutionContext) = {
+  def beginUpdateKeywordTypes(keywordTypeMappings: Map[String, String])(implicit username: Option[String], ec: ExecutionContext) = {
     JobRepository.addJob(
       Job(
         id = Sequences.jobId.getNextId,

--- a/app/model/jobs/Step.scala
+++ b/app/model/jobs/Step.scala
@@ -124,21 +124,6 @@ object Step extends Logging {
 
   private val retryLimit = 10000
 
-  // Implicit format for Map[Long, String] used in UpdateKeywordTypeForAllTags
-  implicit val mapLongStringFormat: Format[Map[Long, String]] = new Format[Map[Long, String]] {
-    override def writes(m: Map[Long, String]): JsValue =
-      JsObject(m.map { case (k, v) => k.toString -> JsString(v) })
-
-    override def reads(json: JsValue): JsResult[Map[Long, String]] = json match {
-      case JsObject(fields) =>
-        try {
-          JsSuccess(fields.map { case (k, v) => k.toLong -> v.as[String] }.toMap)
-        } catch {
-          case _: NumberFormatException => JsError("Invalid map key - expected Long")
-        }
-      case _ => JsError("Expected JsObject for Map[Long, String]")
-    }
-  }
 
   // Keep all the serialization stuff in here just so it's in one place
   val addTagToContentFormat      = Jsonx.formatCaseClassUseDefaults[ModifyContentTags]

--- a/app/model/jobs/Step.scala
+++ b/app/model/jobs/Step.scala
@@ -124,6 +124,22 @@ object Step extends Logging {
 
   private val retryLimit = 10000
 
+  // Implicit format for Map[Long, String] used in UpdateKeywordTypeForAllTags
+  implicit val mapLongStringFormat: Format[Map[Long, String]] = new Format[Map[Long, String]] {
+    override def writes(m: Map[Long, String]): JsValue =
+      JsObject(m.map { case (k, v) => k.toString -> JsString(v) })
+
+    override def reads(json: JsValue): JsResult[Map[Long, String]] = json match {
+      case JsObject(fields) =>
+        try {
+          JsSuccess(fields.map { case (k, v) => k.toLong -> v.as[String] }.toMap)
+        } catch {
+          case _: NumberFormatException => JsError("Invalid map key - expected Long")
+        }
+      case _ => JsError("Expected JsObject for Map[Long, String]")
+    }
+  }
+
   // Keep all the serialization stuff in here just so it's in one place
   val addTagToContentFormat      = Jsonx.formatCaseClassUseDefaults[ModifyContentTags]
   val mergeTagForContentFormat   = Jsonx.formatCaseClassUseDefaults[MergeTagForContent]
@@ -134,6 +150,7 @@ object Step extends Logging {
   val removeTagFromCapiFormat    = Jsonx.formatCaseClassUseDefaults[RemoveTagFromCapi]
   val removeTagFromContentFormat = Jsonx.formatCaseClassUseDefaults[RemoveTagFromContent]
   val removeTagPathFormat        = Jsonx.formatCaseClassUseDefaults[RemoveTagPath]
+  val updateKeywordTypeFormat    = Jsonx.formatCaseClassUseDefaults[UpdateKeywordTypeForAllTags]
 
   val stepWrites = new Writes[Step] {
     override def writes(step: Step): JsValue = {
@@ -147,6 +164,7 @@ object Step extends Logging {
         case s: RemoveTagFromCapi    => removeTagFromCapiFormat.writes(s)
         case s: RemoveTagFromContent => removeTagFromContentFormat.writes(s)
         case s: RemoveTagPath        => removeTagPathFormat.writes(s)
+        case s: UpdateKeywordTypeForAllTags => updateKeywordTypeFormat.writes(s)
         case other => {
           logger.warn(s"Attempted to serialize unknown step type ${other.getClass}")
           throw new UnsupportedOperationException(s"unable to serialize step of type ${other.getClass}")
@@ -167,6 +185,7 @@ object Step extends Logging {
         case JsString(RemoveTagFromCapi.`type`)    => removeTagFromCapiFormat.reads(json)
         case JsString(RemoveTagFromContent.`type`) => removeTagFromContentFormat.reads(json)
         case JsString(RemoveTagPath.`type`)        => removeTagPathFormat.reads(json)
+        case JsString(UpdateKeywordTypeForAllTags.`type`) => updateKeywordTypeFormat.reads(json)
         case _ => JsError("unexpected step type value")
       }
     }

--- a/app/model/jobs/steps/UpdateKeywordTypeForAllTags.scala
+++ b/app/model/jobs/steps/UpdateKeywordTypeForAllTags.scala
@@ -28,8 +28,11 @@ case class UpdateKeywordTypeForAllTags(
 
     logger.info(s"Starting keyword type update for $totalCount tags")
 
+    // Build a path -> tag lookup map once for efficiency
+    val tagsByPath: Map[String, model.Tag] = TagLookupCache.allTags.get().map(t => t.path -> t).toMap
+
     keywordTypeMappings.foreach { case (tagPath, keywordTypeStr) =>
-      TagLookupCache.allTags.get().find(_.path == tagPath) match {
+      tagsByPath.get(tagPath) match {
         case Some(tag) =>
           val keywordType = try {
             Some(KeywordType.withName(keywordTypeStr))

--- a/app/model/jobs/steps/UpdateKeywordTypeForAllTags.scala
+++ b/app/model/jobs/steps/UpdateKeywordTypeForAllTags.scala
@@ -1,0 +1,110 @@
+package model.jobs.steps
+
+import com.gu.tagmanagement.{EventType, TagEvent}
+import model.{KeywordType, TagAudit}
+import model.jobs.{Step, StepStatus}
+import play.api.Logging
+import repositories.{TagAuditRepository, TagLookupCache, TagRepository}
+import services.KinesisStreams
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+case class UpdateKeywordTypeForAllTags(
+  keywordTypeMappings: Map[Long, String], // tagId -> keywordType string
+  username: Option[String] = None,
+  `type`: String = UpdateKeywordTypeForAllTags.`type`,
+  var stepStatus: String = StepStatus.ready,
+  var stepMessage: String = "Waiting",
+  var attempts: Int = 0,
+  var processedCount: Int = 0,
+  var totalCount: Int = 0
+) extends Step with Logging {
+
+  override def process(implicit ec: ExecutionContext): Unit = {
+    implicit val un: Option[String] = username
+    totalCount = keywordTypeMappings.size
+    processedCount = 0
+
+    logger.info(s"Starting keyword type update for $totalCount tags")
+
+    keywordTypeMappings.foreach { case (tagId, keywordTypeStr) =>
+      TagRepository.getTag(tagId) match {
+        case Some(tag) =>
+          val keywordType = try {
+            Some(KeywordType.withName(keywordTypeStr))
+          } catch {
+            case _: NoSuchElementException =>
+              logger.warn(s"Invalid keyword type '$keywordTypeStr' for tag $tagId, skipping")
+              None
+          }
+
+          keywordType.foreach { kt =>
+            val updatedTag = tag.copy(keywordType = Some(kt))
+            updatedTag.updatedAt = System.currentTimeMillis()
+
+            TagRepository.upsertTag(updatedTag).foreach { saved =>
+              TagLookupCache.insertTag(saved)
+              KinesisStreams.tagUpdateStream.publishUpdate(
+                saved.id.toString,
+                TagEvent(EventType.Update, saved.id, Some(saved.asThrift))
+              )
+              TagAuditRepository.upsertTagAudit(TagAudit.updated(saved))
+              logger.info(s"Updated keyword type for tag ${saved.id} (${saved.internalName}) to ${kt.entryName}")
+            }
+          }
+
+        case None =>
+          logger.warn(s"Tag $tagId not found, skipping")
+      }
+
+      processedCount += 1
+      if (processedCount % 100 == 0) {
+        logger.info(s"Processed $processedCount / $totalCount tags")
+        Thread.sleep(100) // Small delay to avoid overwhelming the system
+      }
+    }
+
+    logger.info(s"Completed keyword type update for $processedCount tags")
+  }
+
+  override def waitDuration: Option[Duration] = None
+
+  override def check(implicit ec: ExecutionContext): Boolean = true
+
+  override def rollback: Unit = {
+    throw new UnsupportedOperationException("Rollback is not supported for keyword type updates.")
+  }
+
+  override val checkingMessage: String = s"Checking keyword type update was successful"
+  override val failureMessage: String = s"Failed to update keyword types for tags."
+  override val checkFailMessage: String = s"Failed to confirm keyword type update was successful."
+}
+
+object UpdateKeywordTypeForAllTags {
+  val `type` = "update-keyword-type-for-all-tags"
+
+  def fromCsv(csvContent: String): UpdateKeywordTypeForAllTags = {
+    val mappings = csvContent
+      .split("\n")
+      .drop(1) // Skip header row
+      .flatMap { line =>
+        val parts = line.trim.split(",").map(_.trim)
+        if (parts.length >= 2) {
+          try {
+            val tagId = parts(0).toLong
+            val keywordType = parts(1)
+            Some(tagId -> keywordType)
+          } catch {
+            case _: NumberFormatException => None
+          }
+        } else {
+          None
+        }
+      }
+      .toMap
+
+    UpdateKeywordTypeForAllTags(keywordTypeMappings = mappings)
+  }
+}
+

--- a/app/model/jobs/steps/UpdateKeywordTypeForAllTags.scala
+++ b/app/model/jobs/steps/UpdateKeywordTypeForAllTags.scala
@@ -93,9 +93,9 @@ object UpdateKeywordTypeForAllTags {
       .drop(1) // Skip header row
       .flatMap { line =>
         val parts = line.trim.split(",").map(_.trim)
-        if (parts.length >= 2) {
-          val tagPath = parts(0)
-          val keywordType = parts(1)
+        if (parts.length >= 4) {
+          val tagPath = parts(0)      // id column
+          val keywordType = parts(3)  // keywordType column
           if (tagPath.nonEmpty && keywordType.nonEmpty) {
             Some(tagPath -> keywordType)
           } else {

--- a/app/views/Application/migration/keywordTypeUploadForm.scala.html
+++ b/app/views/Application/migration/keywordTypeUploadForm.scala.html
@@ -11,7 +11,7 @@
         <p>Upload a CSV file to update the keywordType for multiple tags at once. This will create a background job to process all the updates.</p>
 
         <h2>CSV Format</h2>
-        <p>The CSV file should have two columns: <code>path</code> and <code>keywordType</code></p>
+        <p>The CSV file should have four columns, but only <code>id</code> and <code>keywordType</code> are used.</p>
         <p>Valid keywordType values are:</p>
         <ul>
             <li>PERSON</li>
@@ -24,10 +24,13 @@
 
         <h3>Example CSV:</h3>
         <pre>
-path,keywordType
-film/inside-out,WORK_OF_ART_OR_PRODUCT
-music/taylor-swift,PERSON
-business/mcdonalds,ORGANISATION
+id,webTitle,internalName,keywordType
+education/ravensbournecollege,Ravensbourne,Ravensbourne College,PLACE
+sport/nhl,NHL,NHL,ORGANISATION
+sport/nick-kyrgios,Nick Kyrgios,Nick Kyrgios,PERSON
+sport/olympic-torch,Olympic torch,Olympic torch,OTHER
+stage/a-taste-of-honey,A Taste of Honey,A Taste of Honey,WORK_OF_ART_OR_PRODUCT
+stage/adelaide-fringe-2015,Adelaide fringe 2015,Adelaide fringe 2015,EVENT
         </pre>
 
         <form method="post" enctype="multipart/form-data" action="/migration/keywordTypes">

--- a/app/views/Application/migration/keywordTypeUploadForm.scala.html
+++ b/app/views/Application/migration/keywordTypeUploadForm.scala.html
@@ -11,7 +11,7 @@
         <p>Upload a CSV file to update the keywordType for multiple tags at once. This will create a background job to process all the updates.</p>
 
         <h2>CSV Format</h2>
-        <p>The CSV file should have two columns: <code>tagId</code> and <code>keywordType</code></p>
+        <p>The CSV file should have two columns: <code>path</code> and <code>keywordType</code></p>
         <p>Valid keywordType values are:</p>
         <ul>
             <li>PERSON</li>
@@ -24,10 +24,10 @@
 
         <h3>Example CSV:</h3>
         <pre>
-tagId,keywordType
-12345,PERSON
-67890,ORGANISATION
-11111,PLACE
+path,keywordType
+film/inside-out,WORK_OF_ART_OR_PRODUCT
+music/taylor-swift,PERSON
+business/mcdonalds,ORGANISATION
         </pre>
 
         <form method="post" enctype="multipart/form-data" action="/migration/keywordTypes">

--- a/app/views/Application/migration/keywordTypeUploadForm.scala.html
+++ b/app/views/Application/migration/keywordTypeUploadForm.scala.html
@@ -1,0 +1,42 @@
+@()
+
+<html>
+
+    <head>
+        <title>TagManager - Update Keyword Types</title>
+    </head>
+
+    <body>
+        <h1>Update Keyword Types for Tags</h1>
+        <p>Upload a CSV file to update the keywordType for multiple tags at once. This will create a background job to process all the updates.</p>
+
+        <h2>CSV Format</h2>
+        <p>The CSV file should have two columns: <code>tagId</code> and <code>keywordType</code></p>
+        <p>Valid keywordType values are:</p>
+        <ul>
+            <li>PERSON</li>
+            <li>ORGANISATION</li>
+            <li>EVENT</li>
+            <li>WORK_OF_ART_OR_PRODUCT</li>
+            <li>PLACE</li>
+            <li>OTHER</li>
+        </ul>
+
+        <h3>Example CSV:</h3>
+        <pre>
+tagId,keywordType
+12345,PERSON
+67890,ORGANISATION
+11111,PLACE
+        </pre>
+
+        <form method="post" enctype="multipart/form-data" action="/migration/keywordTypes">
+            <label>CSV file: <input type="file" name="csvFile" accept=".csv"/></label><br /><br />
+            <input type="submit" value="Upload and Start Job" name="submit"/>
+        </form>
+
+        <p><strong>Note:</strong> After submitting, check the <a href="/status">status page</a> to monitor job progress.</p>
+    </body>
+
+</html>
+

--- a/conf/routes
+++ b/conf/routes
@@ -134,5 +134,7 @@ GET            /migration/moveToSections                               controlle
 GET            /migration/flattenSponsoredMicrosite/:sponsId           controllers.Migration.flattenSponsoredMicrosite(sponsId: Long)
 GET            /migration/addMissingPaidContentTypes                   controllers.Migration.addMissingPaidContentTypes()
 GET            /migration/dudupeActiveSponsorships                     controllers.Migration.dudupeActiveSponsorships()
+GET            /migration/keywordTypes                                 controllers.Migration.showKeywordTypeUploadForm()
+POST           /migration/keywordTypes                                 controllers.Migration.updateKeywordTypes()
 
 


### PR DESCRIPTION
## What does this change?

Adds a mechanism to backfill the new `keywordType` field for existing topic tags.

The data science team have provided us with a csv file containing a list of tag paths (e.g. `film/inside-out`) mapped to their keyword type (e.g. `WORK_OF_ART_OR_PRODUCT`). Here is a sample to illustrate the format:

```
id,webTitle,internalName,keywordType
education/ravensbournecollege,Ravensbourne,Ravensbourne College,PLACE
sport/nhl,NHL,NHL,ORGANISATION
sport/nick-kyrgios,Nick Kyrgios,Nick Kyrgios,PERSON
sport/olympic-torch,Olympic torch,Olympic torch,OTHER
stage/a-taste-of-honey,A Taste of Honey,A Taste of Honey,WORK_OF_ART_OR_PRODUCT
stage/adelaide-fringe-2015,Adelaide fringe 2015,Adelaide fringe 2015,EVENT
```

This PR introduces a new `/migration/keywordTypes` route which provides an interface to upload this csv file and process its contents.

When processing begins, the system iterates through all the mappings and updates each tag's `keywordType` field accordingly. It also publishes updates to the Kinesis stream (to update CAPI) and creates an audit record for each update.

If a given tag cannot be found, or its associated keyword type is malformed, the row is skipped but processing continues.

## How to test

### Happy path

1) Deploy to CODE and visit: https://tagmanager.code.dev-gutools.co.uk/migration/keywordTypes
2) Upload a csv file containing a small handful of mappings in the appropriate format. The above example should work.
3) Once the job is started, visit the job status page to see its progress: https://tagmanager.code.dev-gutools.co.uk/status
4) When complete, find the appropriate tags and ensure:
- their keyword type has been set correctly ([example](https://tagmanager.code.dev-gutools.co.uk/tag/64543))
- an audit record has been created ([example](https://tagmanager.code.dev-gutools.co.uk/tag/64543))
- CAPI is up to date ([example](https://content.code.dev-guardianapis.com/tags?q=nick-kyrgios&api-key=))

Finally, [check the logs](https://logs.gutools.co.uk/s/editorial-tools/app/r/s/DvJl1) to see if there are any errors. 

### Non-existent keyword type

Try with a non-existent keyword type. For example:

```
sport/nick-kyrgios,Nick Kyrgios,Nick Kyrgios,BROKEN
```

This should result in the mapping being skipped and an error logged:

```
Invalid keyword type 'BROKEN' for tag 'sport/nick-kyrgios', skipping
```

The other mappings should be processed normally.

### Non-existent tag

Try with a non-existent tag. For example:

```
politics/blah-blah,Blah Blah,Blah Blah,PERSON
```

This should result in the mapping being skipped and an error logged:

```
Tag with path 'politics/blah-blah' not found, skipping
```

The other mappings should be processed normally.

## Have we considered potential risks?

We might wish to break the csv file into smaller ones to avoid overwhelming the application.

## Images

<img width="878" height="632" alt="Screenshot 2026-01-14 at 15 26 12" src="https://github.com/user-attachments/assets/63dec5c6-6dca-444c-a4a2-c86a4584efdd" />

