### PR TITLE
Temporarily hide audit records related to backfill

### DIFF
--- a/app/repositories/TagAuditRepository.scala
+++ b/app/repositories/TagAuditRepository.scala
@@ -24,7 +24,9 @@ object TagAuditRepository {
     Dynamo.tagAuditTable.getIndex("operation-date-index")
       .query("operation", operation, new RangeKeyCondition("date").ge(from))
       .asScala
-      .map(TagAudit.fromItem).toList
+      .map(TagAudit.fromItem)
+      .filterNot(audit => audit.user == "simon.byford@guardian.co.uk")
+      .toList
   }
 
   def getAuditsOfTagOperationsSince(operation: String, since: Long): List[TagAudit] = {


### PR DESCRIPTION
## What does this change?

The "Updated" page of the "Audit Logs" page is currently very slow because of a backfill which generated 20k+ records:

https://tagmanager.gutools.co.uk/audit

Let's hide them for the time being so the page is usable by CP.

## How to test

Deploy to CODE where the audit page currently contains 4,115 records against the user `simon.byford@guardian.co.uk`. These records should disappear and the page should be nice and snappy again.
