### PR TITLE
Fix csv parsing bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ lazy val dependencies = Seq(
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "com.typesafe.play" %% "play-json-joda" % "2.8.1",
   "org.apache.commons" % "commons-lang3" % "3.11",
+  "org.apache.commons" % "commons-csv" % "1.12.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.2",
   "com.madgag" %% "scala-collection-plus" % "0.11"
 )


### PR DESCRIPTION
## What does this change?

Follows on from https://github.com/guardian/tagmanager/pull/593

There was a bug in the CSV parser which meant that certain rows were not being processed correctly.

For example, this row would be processed fine:

```
books/colin-barrett,Colin Barrett,Colin Barrett,PERSON
```

Whereas:

```
books/colette,Colette,"Colette (French author, d.1954)",PERSON
```

Would fail with the error:

```
Invalid keyword type 'd.1954)"' for tag 'books/colette', skipping
```

This is because the tag name contains a comma, and the quotes surrounding the tag name aren't being respected.

Using a proper CSV parsing library instead of relying on `.split(",")` should fix the issue.

## How to test

Tested on CODE, everything looks good