### PR TITLE
Increase job runner lock timeout to 30 minutes

### DIFF
--- a/app/model/jobs/JobRunner.scala
+++ b/app/model/jobs/JobRunner.scala
@@ -92,7 +92,7 @@ class JobRunner @Inject() (lifecycle: ApplicationLifecycle)(implicit ec: Executi
 
 object JobRunner {
   val nodeId = InetAddress.getLocalHost().toString() // EC2 machines have a single eth0 so this should work?
-  val lockTimeOutMillis = 1000 * 60 * 5
+  val lockTimeOutMillis = 1000 * 60 * 30
   val cleanUpMillis = 1000 * 60 * 60 * 24
 }
 


### PR DESCRIPTION
## What does this change?

I attempted to run the [keywordType backfill](https://github.com/guardian/tagmanager/pull/593) on production this morning. Knowing it would be a long-running job, I broke the csv file into 6 smaller files, each with a maximum of 5,000 rows. When testing on CODE, I found that each file should take around 15-20 minutes to process. 

When I uploaded the first file, the job began normally, but after exactly 5 minutes, a second instance kicked in and started running the same job in parallel. A third instance kicked in 5 minutes later. When the first instance finally completed the job after ~17 minutes, it immediately picked up the same job again. This kept going until I realised what was happening and redeployed the application in riff-raff which killed all 3 instances. 

In all, the job was run 4 times to completion, and 1 more time partially. This meant nearly 25,000 tag updates occurred instead of the expected 5,000. You can see the full sequence of events in the logs:

https://logs.gutools.co.uk/s/editorial-tools/app/r/s/GzGIy

Looking into what happened, it turns out there is a locking mechanism whereby any job which doesn't complete within 5 minutes is automatically taken over by another instance. This happens regardless of whether the job is actually stuck.

Therefore bumping the job runner lock timeout to 30 minutes should resolve the issue.

This issue didn't occur when testing on CODE because the auto-scaling group only contains 1 instance, while PROD contains 3 instances.

## How to test

Hard to test. You could increase the number of instances in the CODE auto-scaling-group to more than 1.

## Have we considered potential risks?

Jobs which are genuinely stuck will take 30 minutes to be restarted instead of 5 minutes. This seems fine, and in any case we can always revert this change after we have completed the backfill.
