### PR TITLE
Bump kinesis (again) 

### DIFF
--- a/app/modules/clustersync/SectionSyncUpdateProcessor.scala
+++ b/app/modules/clustersync/SectionSyncUpdateProcessor.scala
@@ -1,6 +1,6 @@
 package modules.clustersync
 
-import com.amazonaws.services.kinesis.model.Record
+import software.amazon.kinesis.retrieval.KinesisClientRecord
 import com.gu.tagmanagement.{EventType, SectionEvent}
 import model.Section
 import play.api.Logging
@@ -25,7 +25,7 @@ object SectionEventDeserialiser {
    * the latest thrift serialisation library that we use here is nat handling that additional byte
    * so we decided to explicitly strip it while reading the feed back from Kinesis
    * */
-  def deserialise(record: Record): Try[SectionEvent] = {
+  def deserialise(record: KinesisClientRecord): Try[SectionEvent] = {
     val tProto = kinesisRecordAsThriftCompactProtocol(record, stripCompressionByte = true)
     Try(SectionEvent.decode(tProto))
   }
@@ -34,7 +34,7 @@ object SectionEventDeserialiser {
 
 object SectionSyncUpdateProcessor extends KinesisStreamRecordProcessor with Logging {
 
-  override def process(record: Record): Unit = {
+  override def process(record: KinesisClientRecord): Unit = {
     SectionEventDeserialiser.deserialise(record) match {
       case Success(sectionEvent) => updateSectionLookupCache(sectionEvent)
       case Failure(exp) =>

--- a/app/modules/clustersync/TagSyncUpdateProcessor.scala
+++ b/app/modules/clustersync/TagSyncUpdateProcessor.scala
@@ -1,6 +1,6 @@
 package modules.clustersync
 
-import com.amazonaws.services.kinesis.model.Record
+import software.amazon.kinesis.retrieval.KinesisClientRecord
 import com.gu.tagmanagement.{EventType, TagEvent}
 import model.Tag
 import play.api.Logging
@@ -25,7 +25,7 @@ object TagEventDeserialiser {
    * the latest thrift serialisation library that we use here is nat handling that additional byte
    * so we decided to explicitly strip it while reading the feed back from Kinesis
    * */
-  def deserialise(record: Record): Try[TagEvent] = {
+  def deserialise(record: KinesisClientRecord): Try[TagEvent] = {
     val tProto = kinesisRecordAsThriftCompactProtocol(record, stripCompressionByte = true)
     Try(TagEvent.decode(tProto))
   }
@@ -34,7 +34,7 @@ object TagEventDeserialiser {
 
 object TagSyncUpdateProcessor extends KinesisStreamRecordProcessor with Logging {
 
-  override def process(record: Record): Unit = {
+  override def process(record: KinesisClientRecord): Unit = {
     logger.info(s"Kinesis consumer receives record \n $record")
     TagEventDeserialiser.deserialise(record) match {
       case Success(tagEvent) => updateTagsLookupCache(tagEvent)

--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -4,17 +4,21 @@ import java.nio.ByteBuffer
 
 // AWS SDK 1 - kept for DynamoDB, Kinesis, CloudWatch (to be migrated in future PRs)
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.dynamodbv2.document.DynamoDB
-import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
 import com.amazonaws.util.EC2MetadataUtils
 
 // AWS SDK 2 - migrated services
 import software.amazon.awssdk.auth.credentials.{ProfileCredentialsProvider => SdkV2ProfileCredentialsProvider}
+import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.regions.{Region => SdkV2Region}
 import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.ec2.model.{DescribeTagsRequest, Filter}
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.kinesis.KinesisClient
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
+import software.amazon.awssdk.services.kinesis.model.PutRecordRequest
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sts.StsClient
@@ -39,14 +43,21 @@ object AWS {
     .region(regionV2)
     .build()
 
-  // SDK 1 clients
-  lazy val CloudWatch = AmazonCloudWatchAsyncClientBuilder
-    .standard()
-    .withRegion(region.getName)
+  lazy val Kinesis = KinesisClient.builder()
+    .region(regionV2)
     .build()
-  lazy val Kinesis = AmazonKinesisClientBuilder
-    .standard()
-    .withRegion(region.getName)
+
+  // Async clients for Kinesis Consumer Library
+  lazy val kinesisAsyncClient: KinesisAsyncClient = KinesisAsyncClient.builder()
+    .region(regionV2)
+    .build()
+
+  lazy val dynamoDbAsyncClient: DynamoDbAsyncClient = DynamoDbAsyncClient.builder()
+    .region(regionV2)
+    .build()
+
+  lazy val cloudWatchAsyncClient: CloudWatchAsyncClient = CloudWatchAsyncClient.builder()
+    .region(regionV2)
     .build()
 
   // SDK 2 S3 client
@@ -138,7 +149,13 @@ class KinesisStreamProducer(streamName: String, requireCompressionByte: Boolean 
   }
 
   def publishUpdate(key: String, dataBuffer: ByteBuffer): Unit = {
-    AWS.Kinesis.putRecord(streamName, dataBuffer, key)
+    AWS.Kinesis.putRecord(
+      PutRecordRequest.builder()
+        .streamName(streamName)
+        .data(SdkBytes.fromByteBuffer(dataBuffer))
+        .partitionKey(key)
+        .build()
+    )
   }
 }
 

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -1,13 +1,14 @@
 package services
 
 import java.nio.ByteBuffer
+import java.util.UUID
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, ShutdownReason, Worker}
-import com.amazonaws.services.kinesis.clientlibrary.types.{InitializationInput, ProcessRecordsInput, ShutdownInput}
-import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
-import com.amazonaws.services.kinesis.model.Record
+import software.amazon.kinesis.common.ConfigsBuilder
+import software.amazon.kinesis.coordinator.Scheduler
+import software.amazon.kinesis.lifecycle.events._
+import software.amazon.kinesis.processor.{ShardRecordProcessor, ShardRecordProcessorFactory}
+import software.amazon.kinesis.retrieval.KinesisClientRecord
+import software.amazon.kinesis.retrieval.polling.PollingConfig
 import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream
 import org.apache.thrift.protocol.{TCompactProtocol, TProtocol}
 import org.apache.thrift.transport.TIOStreamTransport
@@ -16,70 +17,88 @@ import play.api.Logging
 import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.language.implicitConversions
 
 class KinesisConsumer(streamName: String, appName: String, processor: KinesisStreamRecordProcessor) extends Logging {
 
   logger.info(s"Creating Kinesis Consumer for (streamName: $streamName, appName: $appName)")
 
-  val kinesisClientLibConfiguration =
-    new KinesisClientLibConfiguration(appName, streamName,
-      new DefaultAWSCredentialsProviderChain,
-      s"$appName-worker")
+  private val configsBuilder = new ConfigsBuilder(
+    streamName,
+    appName,
+    AWS.kinesisAsyncClient,
+    AWS.dynamoDbAsyncClient,
+    AWS.cloudWatchAsyncClient,
+    s"$appName-worker-${UUID.randomUUID()}",
+    new KinesisProcessorConsumerFactory(appName, processor)
+  )
 
-  kinesisClientLibConfiguration
-    .withRegionName(AWS.region.getName)
-    .withMetricsLevel(MetricsLevel.NONE)
-    .withInitialPositionInStream(InitialPositionInStream.LATEST)
+  private val retrievalConfig = configsBuilder.retrievalConfig()
+    .retrievalSpecificConfig(new PollingConfig(streamName, AWS.kinesisAsyncClient))
 
-  val worker = new Worker.Builder()
-    .recordProcessorFactory(new KinesisProcessorConsumerFactory(appName, processor))
-    .config(kinesisClientLibConfiguration)
-    .build()
+  private val scheduler = new Scheduler(
+    configsBuilder.checkpointConfig(),
+    configsBuilder.coordinatorConfig(),
+    configsBuilder.leaseManagementConfig(),
+    configsBuilder.lifecycleConfig(),
+    configsBuilder.metricsConfig(),
+    configsBuilder.processorConfig(),
+    retrievalConfig
+  )
 
-  def start(): Unit = { Future{ worker.run() } }
-  def stop(): Unit = { worker.shutdown() }
-}
-
-class KinesisProcessorConsumerFactory(appName: String, processor: KinesisStreamRecordProcessor) extends IRecordProcessorFactory {
-  override def createProcessor(): IRecordProcessor = new KinesisProcessorConsumer(appName, processor)
-}
-
-class KinesisProcessorConsumer(appName: String, processor: KinesisStreamRecordProcessor) extends IRecordProcessor with Logging {
-
-
-  override def shutdown(shutdownInput: ShutdownInput): Unit = {
-    shutdownInput.getShutdownReason match {
-      case ShutdownReason.TERMINATE => {
-        logger.info(s"terminating $appName consumer")
-        //shutdownInput.getCheckpointer.checkpoint
-      }
-      case _ => logger.info(s"shutting down $appName consumer reason = ${shutdownInput.getShutdownReason}")
-    }
+  def start(): Unit = { Future { scheduler.run() } }
+  def stop(): Unit = {
+    Future { scheduler.shutdown() }
   }
+}
+
+class KinesisProcessorConsumerFactory(appName: String, processor: KinesisStreamRecordProcessor) extends ShardRecordProcessorFactory {
+  override def shardRecordProcessor(): ShardRecordProcessor = new KinesisProcessorConsumer(appName, processor)
+}
+
+class KinesisProcessorConsumer(appName: String, processor: KinesisStreamRecordProcessor) extends ShardRecordProcessor with Logging {
 
   override def initialize(initializationInput: InitializationInput): Unit = {
-    logger.info(s"$appName consumer started for shard ${initializationInput.getShardId}")
+    logger.info(s"$appName consumer started for shard ${initializationInput.shardId()}")
   }
 
   override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
-
-    processRecordsInput.getRecords.asScala foreach { record =>
+    processRecordsInput.records().asScala.foreach { record =>
       processor.process(record)
     }
+  }
 
+  override def leaseLost(leaseLostInput: LeaseLostInput): Unit = {
+    logger.info(s"$appName consumer lease lost")
+  }
+
+  override def shardEnded(shardEndedInput: ShardEndedInput): Unit = {
+    logger.info(s"$appName consumer shard ended")
+    try {
+      shardEndedInput.checkpointer().checkpoint()
+    } catch {
+      case e: Exception => logger.error(s"Error checkpointing at shard end", e)
+    }
+  }
+
+  override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit = {
+    logger.info(s"$appName consumer shutdown requested")
+    try {
+      shutdownRequestedInput.checkpointer().checkpoint()
+    } catch {
+      case e: Exception => logger.error(s"Error checkpointing at shutdown", e)
+    }
   }
 }
 
 trait KinesisStreamRecordProcessor {
-  def process(record: Record): Unit
+  def process(record: KinesisClientRecord): Unit
 }
 
 object KinesisRecordPayloadConversions {
 
-  def kinesisRecordAsThriftCompactProtocol(rec: Record, stripCompressionByte: Boolean = false): TProtocol = {
+  def kinesisRecordAsThriftCompactProtocol(rec: KinesisClientRecord, stripCompressionByte: Boolean = false): TProtocol = {
 
-    val data: ByteBuffer = rec.getData
+    val data: ByteBuffer = rec.data()
     val bytes = if (stripCompressionByte) ByteBuffer.wrap(data.array().tail) else data
 
     val bbis = new ByteBufferBackedInputStream(bytes)

--- a/app/services/KinesisConsumer.scala
+++ b/app/services/KinesisConsumer.scala
@@ -99,7 +99,11 @@ object KinesisRecordPayloadConversions {
   def kinesisRecordAsThriftCompactProtocol(rec: KinesisClientRecord, stripCompressionByte: Boolean = false): TProtocol = {
 
     val data: ByteBuffer = rec.data()
-    val bytes = if (stripCompressionByte) ByteBuffer.wrap(data.array().tail) else data
+    val bytes = if (stripCompressionByte) {
+      val remaining = new Array[Byte](data.remaining())
+      data.duplicate().get(remaining)
+      ByteBuffer.wrap(remaining.tail)
+    } else data
 
     val bbis = new ByteBufferBackedInputStream(bytes)
     val transport = new TIOStreamTransport(bbis)

--- a/build.sbt
+++ b/build.sbt
@@ -24,13 +24,14 @@ val pandaVersion = "16.0.1"
 lazy val dependencies = Seq(
   // AWS SDK 1 - DynamoDB and Kinesis (to be updated separately)
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdk1Version,
-  "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdk1Version,
-  "com.amazonaws" % "amazon-kinesis-client" % "1.15.3",
-  // AWS SDK 2
+  // AWS SDK 2.x
   "software.amazon.awssdk" % "ec2" % awsSdk2Version,
   "software.amazon.awssdk" % "s3" % awsSdk2Version,
   "software.amazon.awssdk" % "sqs" % awsSdk2Version,
   "software.amazon.awssdk" % "sts" % awsSdk2Version,
+  "software.amazon.awssdk" % "kinesis" % awsSdk2Version,
+  "software.amazon.awssdk" % "cloudwatch" % awsSdk2Version,
+  "software.amazon.kinesis" % "amazon-kinesis-client" % "3.4.1",
   "com.gu" %% "pan-domain-auth-play_3-0" % pandaVersion,
   "com.gu" %% "editorial-permissions-client" % "2.15",
   ws, // for panda

--- a/test/modules/clustersync/SectionEventDeserialiserTest.scala
+++ b/test/modules/clustersync/SectionEventDeserialiserTest.scala
@@ -1,6 +1,6 @@
 package modules.clustersync
 
-import com.amazonaws.services.kinesis.model.Record
+import software.amazon.kinesis.retrieval.KinesisClientRecord
 import com.gu.tagmanagement.{EventType, SectionEvent}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -17,7 +17,9 @@ class SectionEventDeserialiserTest extends AnyFlatSpec with Matchers {
 
     val thriftKinesisEvent: Array[Byte] = ThriftSerializer.serializeToBytes(sectionUpdateEvent, true)
 
-    val testRecordWithCompression = new Record().withData(ByteBuffer.wrap(thriftKinesisEvent))
+    val testRecordWithCompression = KinesisClientRecord.builder()
+      .data(ByteBuffer.wrap(thriftKinesisEvent))
+      .build()
 
     SectionEventDeserialiser.deserialise(testRecordWithCompression) shouldBe Success(sectionUpdateEvent)
 

--- a/test/modules/clustersync/TagEventDeserialiserTest.scala
+++ b/test/modules/clustersync/TagEventDeserialiserTest.scala
@@ -1,6 +1,6 @@
 package modules.clustersync
 
-import com.amazonaws.services.kinesis.model.Record
+import software.amazon.kinesis.retrieval.KinesisClientRecord
 import com.gu.tagmanagement.{EventType, TagEvent}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -17,7 +17,9 @@ class TagEventDeserialiserTest extends AnyFlatSpec with Matchers  {
 
     val thriftKinesisEvent: Array[Byte] = ThriftSerializer.serializeToBytes(tagUpdateEvent, true)
 
-    val testRecordWithCompression = new Record().withData(ByteBuffer.wrap(thriftKinesisEvent))
+    val testRecordWithCompression = KinesisClientRecord.builder()
+      .data(ByteBuffer.wrap(thriftKinesisEvent))
+      .build()
 
     TagEventDeserialiser.deserialise(testRecordWithCompression) shouldBe Success(tagUpdateEvent)
 

--- a/test/modules/clustersync/TagEventDeserialiserTest.scala
+++ b/test/modules/clustersync/TagEventDeserialiserTest.scala
@@ -9,20 +9,37 @@ import services.ThriftSerializer
 import java.nio.ByteBuffer
 import scala.util.Success
 
-class TagEventDeserialiserTest extends AnyFlatSpec with Matchers  {
+class TagEventDeserialiserTest extends AnyFlatSpec with Matchers {
 
-  it should  "serialise byte stream from Kinesis record" in {
+  private val tagUpdateEvent = TagEvent(EventType.Update, 1L, None)
+  private val thriftKinesisEvent: Array[Byte] = ThriftSerializer.serializeToBytes(tagUpdateEvent, includeCompressionFlag = true)
 
-    val tagUpdateEvent = TagEvent(EventType.Update, 1L, None)
+  private def recordWithBuffer(buf: ByteBuffer): KinesisClientRecord =
+    KinesisClientRecord.builder().data(buf).build()
 
-    val thriftKinesisEvent: Array[Byte] = ThriftSerializer.serializeToBytes(tagUpdateEvent, true)
-
+  it should "serialise byte stream from Kinesis record" in {
     val testRecordWithCompression = KinesisClientRecord.builder()
       .data(ByteBuffer.wrap(thriftKinesisEvent))
       .build()
 
     TagEventDeserialiser.deserialise(testRecordWithCompression) shouldBe Success(tagUpdateEvent)
+  }
 
+  it should "deserialise a sliced ByteBuffer (non-zero arrayOffset, as produced by KCL v2 buffer pooling in production)" in {
+    // Simulate KCL v2 handing back a slice of a larger pooled buffer.
+    // .slice() produces a buffer with arrayOffset > 0; .array() on this returns
+    // the full backing array from index 0, which is the bug this test guards against.
+    val padded = Array[Byte](0x00.toByte) ++ thriftKinesisEvent
+    val slicedBuffer = ByteBuffer.wrap(padded, 1, thriftKinesisEvent.length).slice()
+    TagEventDeserialiser.deserialise(recordWithBuffer(slicedBuffer)) shouldBe Success(tagUpdateEvent)
+  }
+
+  it should "deserialise a ByteBuffer with a non-zero position (as produced by KCL v2 concurrent shard reads in production)" in {
+    // Simulate KCL v2 advancing the position into a larger buffer before handing it to the processor.
+    val padded = Array[Byte](0x00.toByte) ++ thriftKinesisEvent
+    val positionedBuffer = ByteBuffer.wrap(padded)
+    positionedBuffer.position(1)
+    TagEventDeserialiser.deserialise(recordWithBuffer(positionedBuffer)) shouldBe Success(tagUpdateEvent)
   }
 
 }

--- a/test/modules/clustersync/TagSyncUpdateProcessorTest.scala
+++ b/test/modules/clustersync/TagSyncUpdateProcessorTest.scala
@@ -1,6 +1,6 @@
 package modules.clustersync
 
-import com.amazonaws.services.kinesis.model.Record
+import software.amazon.kinesis.retrieval.KinesisClientRecord
 import com.gu.tagmanagement.{EventType, TagEvent}
 import model.BlockingLevel
 import org.scalatest.flatspec.AnyFlatSpec
@@ -37,13 +37,13 @@ class TagSyncUpdateProcessorTest extends AnyFlatSpec with Matchers {
     })
   }
 
-  private def createKinesisTagUpdateEventRecord(tag: model.Tag) = {
+  private def createKinesisTagUpdateEventRecord(tag: model.Tag): KinesisClientRecord = {
     val thriftTag = tag.asThrift
     val tagUpdateEvent = TagEvent(EventType.Update, 1L, Some(thriftTag))
     val thriftKinesisEvent: Array[Byte] = ThriftSerializer.serializeToBytes(tagUpdateEvent, true)
-    new Record()
-      .withData(ByteBuffer.wrap(thriftKinesisEvent))
-
+    KinesisClientRecord.builder()
+      .data(ByteBuffer.wrap(thriftKinesisEvent))
+      .build()
   }
 
 }


### PR DESCRIPTION
Reverts guardian/tagmanager#627 and should fix the issue seen in prod. The second commit in this PR contains the fix. 

Although I'd tested the original PR in code and it seemed to be working as intended, in prod relevant stream updates weren't coming through. We can confirm this by looking at the logs:
- a tag (local elections 2026) created prior to the original PR getting released provides [these logs](https://logs.gutools.co.uk/s/editorial-tools/app/r/s/noBAr)
- a tag (april fools day) created after shows [these](https://logs.gutools.co.uk/s/editorial-tools/app/r/s/mHeVS).

The salient difference is that the `TagEvent received` message never appears in the latter, and on double checking, weren't coming through when the branch was up on code either ([searching](https://logs.gutools.co.uk/app/r/s/8YnPO) for it in the past couple of weeks only brings up records from today). 

## What's changed

To be transparent, I used Copilot to help investigate this, and it pointed to an issue in the ByteBuffer handling inside KinesisRecordPayloadConversions.

When consuming Kinesis records via the updated KCL client, KinesisClientRecord.data() can return ByteBuffer instances with a non-zero arrayOffset or position, due to KCL's internal pooled/sliced buffer allocation. The previous implementation didn't account for this - it passed the buffer directly without respecting its current position, which meant Thrift could be decoding from the wrong byte index, causing deserialization failures.

The fix updates kinesisRecordAsThriftCompactProtocol to correctly extract the relevant bytes from the ByteBuffer by respecting its position and arrayOffset, so the correct slice of the backing array is always read regardless of how the buffer was constructed.

Additional tests have been added to TagEventDeserialiserTest covering the three ByteBuffer states KCL v2 can produce: clean, sliced (arrayOffset > 0), and positioned (position > 0).

## Testing

Deployed to CODE, I created a new tag (gl-test-kinesis) and in quick succession updated it a few times. These updates came through correctly, and we can see the `TagEvent received` messages in the [logs](https://logs.gutools.co.uk/app/r/s/OqVXn). Considering the level of usage of the code environment vs prod, it feels like there's a limit to how well this can be tested, but those logs give me reassurance that the kinesis stream logic is now correct. 