### PR TITLE
implement filtering by "deprecated" field

### DIFF
--- a/app/controllers/HyperMediaApi.scala
+++ b/app/controllers/HyperMediaApi.scala
@@ -57,7 +57,8 @@ class HyperMediaApi(
         internalName = req.getQueryString("internalName"),
         externalName = req.getQueryString("externalName"),
         referenceToken = req.getQueryString("externalReferenceToken"),
-        subType = req.getQueryString("subType")
+        subType = req.getQueryString("subType"),
+        deprecated = req.getQueryString("deprecated")
       )
 
       val limit = req.getQueryString("limit").getOrElse("25").toInt

--- a/app/controllers/TagManagementApi.scala
+++ b/app/controllers/TagManagementApi.scala
@@ -74,7 +74,8 @@ class TagManagementApi(
       searchField = req.getQueryString("searchField"),
       types = req.getQueryString("types").map(_.split(",").toList.map(_.trim())),
       referenceType = req.getQueryString("referenceType"),
-      hasFields = req.getQueryString("hasFields").map(_.split(",").toList.map(_.trim()))
+      hasFields = req.getQueryString("hasFields").map(_.split(",").toList.map(_.trim())),
+      deprecated = req.getQueryString("deprecated"),
     )
 
     val orderBy = req.getQueryString("orderBy").getOrElse("internalName")

--- a/app/repositories/TagRepository.scala
+++ b/app/repositories/TagRepository.scala
@@ -51,7 +51,8 @@ case class TagSearchCriteria(
   referenceToken: Option[String] = None,
   searchField: Option[String] = None,
   subType: Option[String] = None,
-  hasFields: Option[List[String]] = None
+  hasFields: Option[List[String]] = None,
+  deprecated: Option[String] = None,
 ) extends Logging {
 
   type TagFilter = (List[Tag]) => List[Tag]
@@ -65,7 +66,8 @@ case class TagSearchCriteria(
     referenceType.map(v => referenceTypeFilter(v.toLowerCase) _) ++
     referenceToken.map(v => referenceTokenFilter(v.toLowerCase) _) ++
     subType.map(v => subTypeFilter(v.toLowerCase) _) ++
-    hasFields.map(v => hasFieldsFilter(v.map(_.toLowerCase)) _)
+    hasFields.map(v => hasFieldsFilter(v.map(_.toLowerCase)) _) ++
+    deprecated.map(v => deprecatedFilter(v.toLowerCase) _)
 
   def execute(tags: List[Tag]): List[Tag] = {
     filters.foldLeft(tags){ case(ts, filter) => filter(ts) }
@@ -160,6 +162,11 @@ case class TagSearchCriteria(
     ).getOrElse(false)
   }
 
+  private def deprecatedFilter(value: String)(tags: List[Tag]) = normalize(value) match {
+    case "true" => tags.filter { t => t.deprecated }
+    case "false" => tags.filter { t => !t.deprecated }
+    case _ => tags
+  }
 
   def asFilters = {
     Seq() ++


### PR DESCRIPTION
## What does this change?

Adds a query param for the "deprecate" property added in https://github.com/guardian/tagmanager/pull/631 to the "/hyper/tags" and "/api/tags" endpoints.

## How has this change been tested?


running locally, after marking the "Obs: 100 Great British Woods and Forests (nbs)" tag (https://tagmanager.local.dev-gutools.co.uk/hyper/tags/43543) as deprecated, compared the results of the following queries:

- https://tagmanager.local.dev-gutools.co.uk/hyper/tags?query=obs&limit=250&type=newspaper%20book%20section&deprecated=true
- https://tagmanager.local.dev-gutools.co.uk/hyper/tags?query=obs&limit=250&type=newspaper%20book%20section&deprecated=false
- https://tagmanager.local.dev-gutools.co.uk/hyper/tags?query=obs&limit=250&type=newspaper%20book%20section

As expected, the "deprecated" param filtered the tag results by the value of the field and the query without the param returned the union of the "true" and "false" queries.

## How can we measure success?

Will facilitate API queries by the new field- eg Workflow excluded deprecated book section tags.

When adding the UI to TagManager, we can also have the option to filter the tag search results to include deprecated tags or not

## Have we considered potential risks?

Should not have a downstream impact until applications use the new param
