### PR TITLE
Add Audience to the list of tracking tags

### DIFF
--- a/public/constants/trackingTagTypes.js
+++ b/public/constants/trackingTagTypes.js
@@ -1,4 +1,5 @@
 export const trackingTagTypes = [
   {name: 'Commissioning Desk', value: 'commissioningdesk'},
-  {name: 'Platform Functional', value: 'platformfunctional'}
+  {name: 'Platform Functional', value: 'platformfunctional'},
+  {name: 'Audience', value: 'audience'}
 ];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We are planning to use tracking tags to track the intended audience of articles, but with the trackingType set to "Audience".
At the moment, tag manager only lets you create tags with trackingType of "Platform Functional" or "Commissioning desk". This PR is to add "Audience" to this list. 

[Issue here](https://github.com/guardian/workflow/issues/1450)
## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
1. Deploy the branch to CODE
2. Create a new  tag of type 'tracking' in tag manager CODE with tracking type as Audience
## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
## Before Change
<img width="419" height="137" alt="image" src="https://github.com/user-attachments/assets/7f3e1dc2-442d-4185-a6b3-1e056c6df45e" />

## After Change

<img width="419" height="137" alt="image" src="https://github.com/user-attachments/assets/2900dab7-b98d-45d2-b6f5-f4a6b6c8f4b8" />

<img width="219" height="531" alt="image" src="https://github.com/user-attachments/assets/4b4290b4-ab36-4a10-909c-cf07aa94cb98" />
