### PR TITLE
Add video tracking subtype

### DIFF
--- a/public/constants/trackingTagTypes.js
+++ b/public/constants/trackingTagTypes.js
@@ -1,5 +1,6 @@
 export const trackingTagTypes = [
   {name: 'Commissioning Desk', value: 'commissioningdesk'},
   {name: 'Platform Functional', value: 'platformfunctional'},
-  {name: 'Audience', value: 'audience'}
+  {name: 'Audience', value: 'audience'},
+  {name: 'Video', value: 'video'},
 ];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are working on [making content atoms taggable](https://github.com/guardian/content-atom/pull/211) to improve data analysis.

The pull request adds a subtype `video` under `tracking` type for tags that will be intended for video tracking.

## How has this change been tested?

In tagmanager, create a new tag and on the UI we should be able to select the new subtype `video` under the `tracking` type. After creating a tag with video tracking subtype, we could find the tags by the API - e.g. https://tagmanager.code.dev-gutools.co.uk/hyper/tags?query=<tag name>&type=tracking&subType=video&limit=150

## Images

| Before | After |
| --- | --- |
| <img width="455" height="223" alt="Screenshot 2026-05-15 at 15 33 55" src="https://github.com/user-attachments/assets/78666ce2-cc3c-4d01-b0f7-39b04468f241" /> | <img width="456" height="225" alt="Screenshot 2026-05-15 at 15 40 47" src="https://github.com/user-attachments/assets/28ea62d7-cb39-44ed-8466-fadae383a6cd" /> |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214714624861786