### PR TITLE
Stop filtering my audit records

### DIFF
--- a/app/repositories/TagAuditRepository.scala
+++ b/app/repositories/TagAuditRepository.scala
@@ -44,7 +44,6 @@ object TagAuditRepository {
     val response = Dynamo.client.query(request)
     response.items().asScala
       .map(item => TagAudit.fromItem(EnhancedDocument.fromAttributeValueMap(item)))
-      .filterNot(audit => audit.user == "simon.byford@guardian.co.uk")
       .toList
   }
 


### PR DESCRIPTION
## What does this change?

Reverts https://github.com/guardian/tagmanager/pull/596 now it is no longer needed.

I've tested this on CODE and everything looks fine:

<img width="1043" height="360" alt="Screenshot 2026-05-18 at 11 12 10" src="https://github.com/user-attachments/assets/b1e53261-bf1a-4ac0-91dc-c0b52bd09d1b" />
