### PR TITLE
Exclude htmlunit as a dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,15 @@ lazy val dependencies = Seq(
 
 dependencyOverrides += "org.bouncycastle" % "bcprov-jdk15on" % "1.67"
 
+excludeDependencies ++= Seq(
+  ExclusionRule("net.sourceforge.htmlunit", "htmlunit"),
+  ExclusionRule("net.sourceforge.htmlunit", "htmlunit-core-js"),
+  ExclusionRule("net.sourceforge.htmlunit", "htmlunit-cssparser"),
+  ExclusionRule("net.sourceforge.htmlunit", "htmlunit-xpath"),
+  ExclusionRule("net.sourceforge.htmlunit", "neko-htmlunit"),
+  ExclusionRule("org.seleniumhq.selenium", "htmlunit-driver"),
+)
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtWeb, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(


### PR DESCRIPTION

## What does this change?
Exclude htmlunit as a dependency from Tag Manager. It was a transitive dev dependency and was not being used in practice.

This resolves https://app.asana.com/1/1210045093164357/project/1213593438261924/task/1215333775534859

## How has this change been tested?

Deployed tag maanger to code and ensured all tests were running and passing. 

## How can we measure success?
htmlunit is no longer bundled. 
