### PR TITLE
Use specific credentials provider for S3 so that local profiles are checked

### DIFF
--- a/app/services/AWS.scala
+++ b/app/services/AWS.scala
@@ -51,8 +51,14 @@ object AWS {
     .region(regionV2)
     .build()
 
+  lazy val credentialsProvider = DefaultCredentialsProvider
+    .builder()
+    .profileName("composer")
+    .build()
+
   lazy val s3Client: S3Client = S3Client.builder()
     .region(regionV2)
+    .credentialsProvider(credentialsProvider)
     .build()
 
   private lazy val frontendCredentialsProvider = Config().frontendBucketWriteRole.map { role =>
@@ -67,11 +73,6 @@ object AWS {
   lazy val frontendStaticFilesS3Client = S3Client.builder()
     .credentialsProvider(frontendCredentialsProvider.getOrElse(SdkV2ProfileCredentialsProvider.create("frontend")))
     .region(regionV2)
-    .build()
-
-  lazy val credentialsProvider = DefaultCredentialsProvider
-    .builder()
-    .profileName("composer")
     .build()
 }
 


### PR DESCRIPTION
## What does this change?

This changes the provider chain used for S3.

I believe that running this project locally was broken by https://github.com/guardian/tagmanager/pull/638, and this PR fixes it by using a provider chain that tries the "composer" profile for S3 when running tagmanager locally.