### PR TITLE
Support commercial IAB taxonomy tags

### DIFF
--- a/app/model/CommercialInformation.scala
+++ b/app/model/CommercialInformation.scala
@@ -4,9 +4,8 @@ import play.api.libs.json._
 import ai.x.play.json.Jsonx
 import ai.x.play.json.Encoders.encoder
 import com.gu.tagmanagement.{CommercialInformation => ThriftCommercialInformation, IABTaxonomyInformation => ThriftIABTaxonomyInformation}
-import repositories.Sequences.tagId
 
-case class IabTaxonomyInformation(tagId: String, taxonomyCode: String, modelId: Option[String]) {
+case class IABTaxonomyInformation(tagId: String, taxonomyCode: String, modelId: Option[String]) {
   def asThrift = ThriftIABTaxonomyInformation(
     tagId = tagId,
     taxonomyCode = taxonomyCode,
@@ -20,37 +19,36 @@ case class IabTaxonomyInformation(tagId: String, taxonomyCode: String, modelId: 
   }
 }
 
-object IabTaxonomyInformation {
-  implicit val format: OFormat[IabTaxonomyInformation] = Jsonx.formatCaseClass[IabTaxonomyInformation]
+object IABTaxonomyInformation {
+  implicit val iabTaxonomyFormat: OFormat[IABTaxonomyInformation] = Jsonx.formatCaseClass[IABTaxonomyInformation]
 
-  def apply(thriftIABTaxonomyInformation: ThriftIABTaxonomyInformation): IabTaxonomyInformation =
-    IabTaxonomyInformation(
-      tagId=thriftIABTaxonomyInformation.tagId, 
+  def apply(thriftIABTaxonomyInformation: ThriftIABTaxonomyInformation): IABTaxonomyInformation =
+    IABTaxonomyInformation(
+      tagId = thriftIABTaxonomyInformation.tagId,
       taxonomyCode = thriftIABTaxonomyInformation.taxonomyCode, 
       modelId = thriftIABTaxonomyInformation.modelId
-      )
+    )
 }
 
-case class CommercialInformation(commercialType: String, iabTaxonomyInformation: Option[IabTaxonomyInformation]) {
-
+case class CommercialInformation(commercialType: String, iabTaxonomyInformation: Option[IABTaxonomyInformation]) {
   def asThrift = ThriftCommercialInformation(
       commercialType = commercialType,
-      // iabTaxonomyInformation = iabTaxonomyInformation.map(t=>t.asThrift)
-
+      iabTaxonomyInformation = iabTaxonomyInformation.map(_.asThrift)
   )
 
   def asExportedXml = {
     <commercialType>{this.commercialType}</commercialType>
+    <iabTaxonomy>{this.iabTaxonomyInformation}</iabTaxonomy>
   }
 }
 
 object CommercialInformation {
 
-  implicit val trackingFormat: OFormat[CommercialInformation] = Jsonx.formatCaseClass[CommercialInformation]
+  implicit val commercialFormat: OFormat[CommercialInformation] = Jsonx.formatCaseClass[CommercialInformation]
 
   def apply(thriftCommercialInformation: ThriftCommercialInformation): CommercialInformation =
     CommercialInformation(
       commercialType = thriftCommercialInformation.commercialType,
-      iabTaxonomyInformation = thriftCommercialInformation.iabTaxonomyInformation
+      iabTaxonomyInformation = thriftCommercialInformation.iabTaxonomyInformation.map(IABTaxonomyInformation(_))
     )
 }

--- a/app/model/CommercialInformation.scala
+++ b/app/model/CommercialInformation.scala
@@ -1,0 +1,56 @@
+package model
+
+import play.api.libs.json._
+import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders.encoder
+import com.gu.tagmanagement.{CommercialInformation => ThriftCommercialInformation, IABTaxonomyInformation => ThriftIABTaxonomyInformation}
+import repositories.Sequences.tagId
+
+case class IabTaxonomyInformation(tagId: String, taxonomyCode: String, modelId: Option[String]) {
+  def asThrift = ThriftIABTaxonomyInformation(
+    tagId = tagId,
+    taxonomyCode = taxonomyCode,
+    modelId = modelId
+  )
+
+  def asExportedXml = {
+    <tagId>{this.tagId}</tagId>
+    <taxonomyCode>{this.taxonomyCode}</taxonomyCode>
+    <modelId>{this.modelId}</modelId>
+  }
+}
+
+object IabTaxonomyInformation {
+  implicit val format: OFormat[IabTaxonomyInformation] = Jsonx.formatCaseClass[IabTaxonomyInformation]
+
+  def apply(thriftIABTaxonomyInformation: ThriftIABTaxonomyInformation): IabTaxonomyInformation =
+    IabTaxonomyInformation(
+      tagId=thriftIABTaxonomyInformation.tagId, 
+      taxonomyCode = thriftIABTaxonomyInformation.taxonomyCode, 
+      modelId = thriftIABTaxonomyInformation.modelId
+      )
+}
+
+case class CommercialInformation(commercialType: String, iabTaxonomyInformation: Option[IabTaxonomyInformation]) {
+
+  def asThrift = ThriftCommercialInformation(
+      commercialType = commercialType,
+      // iabTaxonomyInformation = iabTaxonomyInformation.map(t=>t.asThrift)
+
+  )
+
+  def asExportedXml = {
+    <commercialType>{this.commercialType}</commercialType>
+  }
+}
+
+object CommercialInformation {
+
+  implicit val trackingFormat: OFormat[CommercialInformation] = Jsonx.formatCaseClass[CommercialInformation]
+
+  def apply(thriftCommercialInformation: ThriftCommercialInformation): CommercialInformation =
+    CommercialInformation(
+      commercialType = thriftCommercialInformation.commercialType,
+      iabTaxonomyInformation = thriftCommercialInformation.iabTaxonomyInformation
+    )
+}

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -13,6 +13,7 @@ import services.DynamoJsonConversions
 import scala.util.control.NonFatal
 import scala.xml.Node
 
+//LOOK
 case class Tag(
                 id: Long,
                 path: String,
@@ -45,12 +46,13 @@ case class Tag(
                 adBlockingLevel: Option[BlockingLevel],
                 contributionBlockingLevel: Option[BlockingLevel],
                 keywordType: Option[KeywordType],
+                commercialInformation: Option[CommercialInformation],
                 var updatedAt: Long = 0L
 ) {
 
   def toItem: EnhancedDocument = DynamoJsonConversions.jsonToDocument(Json.toJson(this))
 
-  def asThrift = ThriftTag(
+  def asThrift = ThriftTag( //update - translation from what is local to what is transported making sure it forms the right format
     id                = id,
     path              = path,
     pageId            = pageId,
@@ -150,9 +152,9 @@ object Tag extends Logging {
     )
   }
 
-  def fromJson(json: JsValue) = json.as[Tag]
+  def fromJson(json: JsValue) = json.as[Tag] //JS encoder
 
-  def apply(thriftTag: ThriftTag): Tag =
+  def apply(thriftTag: ThriftTag): Tag = //opposite from above
     Tag(
       id                = thriftTag.id,
       path              = thriftTag.path,
@@ -184,7 +186,8 @@ object Tag extends Logging {
       expired = thriftTag.expired,
       adBlockingLevel =  thriftTag.adBlockingLevel.map(tLevel => BlockingLevel.withName(tLevel.name)),
       contributionBlockingLevel =  thriftTag.contributionBlockingLevel.map(tLevel => BlockingLevel.withName(tLevel.name)),
-      keywordType = thriftTag.keywordType.map(tLevel => KeywordType.withName(tLevel.name))
+      keywordType = thriftTag.keywordType.map(tLevel => KeywordType.withName(tLevel.name)),
+      commercialInformation = thriftTag.commercialInformation.map(CommercialInformation(_))
     )
 }
 
@@ -222,6 +225,7 @@ case class DenormalisedTag (
   adBlockingLevel: Option[BlockingLevel],
   contributionBlockingLevel: Option[BlockingLevel],
   keywordType: Option[KeywordType] = None,
+  commercialInformation: Option[CommercialInformation] = None
   ) {
 
   def normalise(): (Tag, Option[Sponsorship]) = {
@@ -257,12 +261,13 @@ case class DenormalisedTag (
       expired = expired,
       adBlockingLevel = adBlockingLevel,
       contributionBlockingLevel = contributionBlockingLevel,
-      keywordType = keywordType
+      keywordType = keywordType,
+      commercialInformation = commercialInformation
     )
     (tag, sponsorship)
   }
 }
-
+//translate for a thrift tag to a tag in
 object DenormalisedTag{
 
   implicit val tagFormat: OFormat[DenormalisedTag] = Jsonx.formatCaseClassUseDefaults[DenormalisedTag]

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -94,6 +94,7 @@ case class Tag(
       case KeywordType.PLACE => ThriftKeywordType.Place
       case KeywordType.OTHER => ThriftKeywordType.Other
     },
+    commercialInformation = commercialInformation.map(_.asThrift)
   )
 
   // in this limited format for inCopy to consume
@@ -303,6 +304,7 @@ object DenormalisedTag{
     expired = t.expired,
     adBlockingLevel = t.adBlockingLevel,
     contributionBlockingLevel = t.contributionBlockingLevel,
-    keywordType = t.keywordType
+    keywordType = t.keywordType,
+    commercialInformation = t.commercialInformation
   )
 }

--- a/app/model/Tag.scala
+++ b/app/model/Tag.scala
@@ -46,7 +46,7 @@ case class Tag(
                 adBlockingLevel: Option[BlockingLevel],
                 contributionBlockingLevel: Option[BlockingLevel],
                 keywordType: Option[KeywordType],
-                commercialInformation: Option[CommercialInformation],
+                commercialInformation: Option[CommercialInformation] = None,
                 var updatedAt: Long = 0L
 ) {
 

--- a/app/model/command/CreateTagCommand.scala
+++ b/app/model/command/CreateTagCommand.scala
@@ -85,7 +85,8 @@ case class CreateTagCommand(
                       createMicrosite: Boolean = false,
                       adBlockingLevel: Option[BlockingLevel] = None,
                       contributionBlockingLevel: Option[BlockingLevel] = None,
-                           keywordType: Option[KeywordType] = None,
+                      keywordType: Option[KeywordType] = None,
+                      commercialInformation: Option[CommercialInformation] = None
                            ) extends Command with Logging {
 
   type T = Tag
@@ -135,6 +136,7 @@ case class CreateTagCommand(
     val tagSubType: Option[String] =  `type` match {
       case "Tracking" => trackingInformation.map(_.trackingType)
       case "Campaign" => campaignInformation.map(_.campaignType)
+      case "Commercial" => commercialInformation.map(_.commercialType)
       case _ => None
     }
 
@@ -183,6 +185,7 @@ case class CreateTagCommand(
       adBlockingLevel = adBlockingLevel,
       contributionBlockingLevel = contributionBlockingLevel,
       keywordType = keywordType,
+      commercialInformation = commercialInformation
     )
 
     val result = TagRepository.upsertTag(tag)

--- a/app/model/command/logic/TagPathCalculator.scala
+++ b/app/model/command/logic/TagPathCalculator.scala
@@ -21,6 +21,7 @@ object TagPathCalculator {
       case ("tracking", trackingType) => s"tracking/${trackingType.getOrElse("")}/$slug"
       case ("campaign", campaignType) => s"campaign/${campaignType.getOrElse("")}/$slug"
       case ("paidcontent", Some("hostedcontent")) => s"advertiser-content/$slug"
+      case ("commercial", commercialType) => s"commercial/${commercialType.getOrElse("")}/$slug"
       case (_, _) => sectionPathPrefix + slug
     }
   }

--- a/app/services/Config.scala
+++ b/app/services/Config.scala
@@ -182,6 +182,7 @@ class DevConfig extends Config {
   override def corsablePostDomains: Seq[String] = Seq(
     targetingDomain
   )
+  override def pathManagerUrl: String = "https://pathmanager.local.dev-gutools.co.uk/"
 }
 
 class CodeConfig extends Config {

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val dependencies = Seq(
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.google.guava" % "guava" % "18.0",
   "com.gu" %% "content-api-client-default" % "27.0.0",
-  "com.gu" %% "tags-thrift-schema" % "2.8.6",
+  "com.gu" %% "tags-thrift-schema" % "2.8.8-PREVIEW.dsadd-commercial-iab-taxonomy-tags.2026-09-03T1505.e1788e09",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.12",

--- a/public/components/TagEdit/TagEdit.react.js
+++ b/public/components/TagEdit/TagEdit.react.js
@@ -14,7 +14,7 @@ import NewspaperBookInfoEdit from './formComponents/newspaperbook/NewspaperBookI
 import PaidContentInfoEdit from './formComponents/paidcontent/PaidContentInfoEdit.react';
 import TrackingInfoEdit from './formComponents/tracking/TrackingInformation.react.js';
 import CampaignInfoEdit from './formComponents/campaigns/CampaignInformation.react.js';
-
+import CommercialInfoEdit from './formComponents/commercial/CommercialInformation.react.js';
 
 import * as tagTypes from '../../constants/tagTypes';
 
@@ -117,6 +117,10 @@ export default class TagEdit extends React.Component {
       return <CampaignInfoEdit tag={this.props.tag} updateTag={this.props.updateTag} tagEditable={this.props.tagEditable} />;
     }
 
+    renderCommercialFields() {
+        return <CommercialInfoEdit tag={this.props.tag} updateTag={this.props.updateTag} tagEditable={this.props.tagEditable} />;
+    }
+
     renderTagTypeSpecificFields() {
 
       if (!this.props.tag.type) {
@@ -153,6 +157,10 @@ export default class TagEdit extends React.Component {
 
       if (this.props.tag.type === tagTypes.campaign.name) {
         return this.renderCampaignFields();
+      }
+
+      if (this.props.tag.type === tagTypes.commercial.name) {
+          return this.renderCommercialFields();
       }
 
       return false;

--- a/public/components/TagEdit/formComponents/commercial/CommercialInformation.react.js
+++ b/public/components/TagEdit/formComponents/commercial/CommercialInformation.react.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {commercialTagTypes} from '../../../../constants/commercialTagTypes';
+
+export default class CommercialInformation extends React.Component {
+
+    constructor(props) {
+        super(props);
+    }
+
+    updateCommercialType(e) {
+        this.props.updateTag(Object.assign({}, this.props.tag, {
+            commercialInformation: Object.assign({}, this.props.tag.commercialInformation, {
+                commercialType: e.target.value
+            })
+        }));
+    }
+
+    render () {
+
+        const selectCommercialType = this.props.tag.commercialInformation ? this.props.tag.commercialInformation.commercialType : undefined;
+
+        return (
+            <div className="tag-edit__input-group">
+                <label className="tag-edit__input-group__header">Commercial Information</label>
+                <div className="tag-edit__field">
+                    <label className="tag-edit__label">Commercial Type</label>
+                    <select value={selectCommercialType || ""} onChange={this.updateCommercialType.bind(this)} disabled={!this.props.tagEditable}>
+                        {!selectCommercialType ? <option value={false}></option> : false}
+                        {commercialTagTypes.sort((a, b) => {return a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1;}).map(function(t) {
+                            return (
+                                <option value={t.value} key={t.value} >{t.name}</option>
+                            );
+                        })}
+                    </select>
+                </div>
+            </div>
+        );
+    }
+}

--- a/public/constants/commercialTagTypes.js
+++ b/public/constants/commercialTagTypes.js
@@ -1,0 +1,3 @@
+export const commercialTagTypes = [
+    {name: 'IAB Content Taxonomy', value: 'iabContentTaxonomy'},
+];

--- a/public/constants/tagTypes.js
+++ b/public/constants/tagTypes.js
@@ -66,3 +66,9 @@ export const campaign = {
     displayName: 'Campaign',
     pathPrefix: 'campaign'
 };
+
+export const commercial = {
+  name: 'Commercial',
+  displayName: 'Commercial',
+  pathPrefix: 'commercial'
+};

--- a/test/utils/TagTestUtils.scala
+++ b/test/utils/TagTestUtils.scala
@@ -40,6 +40,7 @@ object TagTestUtils {
       contributionBlockingLevel = tContributionBlockingLevel,
       updatedAt = tUpdatedAt,
       keywordType = None,
+      commercialInformation = None
     )
   }
 


### PR DESCRIPTION
## What does this change?

This adds support for commercial tags to carry IAB taxonomy information, including:

- Commercial type
- IAB taxonomy tag ID
- Taxonomy code
- Optional model ID


The information is now accepted when creating or updating a tag, stored with the tag, and included when the tag is converted to Thrift for publishing to the tag update stream. Commercial tags also get a consistent commercial/{type}/{slug} path.

The branch also updates the tags Thrift schema dependency and keeps the new field optional so existing tags continue to work.

When creating a commercial tag, the path is generated as commercial/{commercialType}/{slug}. If `preCalculatedPath` is supplied, that value is used instead. The resulting path is registered with Path Manager and stored on the tag.

Why

CEMS needs to associate commercial tags with their IAB taxonomy data. Adding this to the tag model means the information can travel with the tag through Tag Manager, be stored alongside it, and be shared with downstream consumers through the existing tag update stream.

## How to test

Run this branch locally or on CODE. Create or edit an existing "Commercial" tag. 

- Create give a name for an IAB taxonomy tag

You should also be able to preview the new fields here: https://tagmanager.local.dev-gutools.co.uk/api/tag/[TAG-ID-HERE]


## Have we considered potential risks?

Low risk.

## Related PRs

- [tags-thrift-schema](https://github.com/guardian/tags-thrift-schema/pull/53) 
- [tagmanager](https://github.com/guardian/tagmanager/pull/666) <- you are here
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3400)   
- [content-api-models](https://github.com/guardian/content-api-models/pull/333)
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/) 